### PR TITLE
Fix GitGitGadget on Linux and with different Git versions

### DIFF
--- a/lib/git.ts
+++ b/lib/git.ts
@@ -80,3 +80,9 @@ export async function gitConfigForEach(key: string,
         workDir || ".");
     result.stdout.split(/\r?\n/).map(callbackfn);
 }
+
+export async function gitCommandExists(command: string, workDir?: string):
+    Promise<boolean> {
+    const result = await GitProcess.exec([command, "-h"], workDir);
+    return result.exitCode === 129;
+}

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -236,12 +236,13 @@ export class PatchSeries {
                 throw new Error("No From: line found in header:\n\n" + header);
             }
 
+            let replaceSender = thisAuthor;
             if (isGitGitGadget) {
                 const onBehalfOf = i === 0 && senderName ?
                     senderName : authorMatch[2].replace(/ <.*>$/, "");
                 // Special-case GitGitGadget to send from
                 // "<author> via GitGitGadget"
-                thisAuthor = "\""
+                replaceSender = "\""
                     + onBehalfOf
                     + " via GitGitGadget\" "
                     + thisAuthor.replace(/^GitGitGadget /, "");
@@ -249,7 +250,7 @@ export class PatchSeries {
                 return;
             }
 
-            header = authorMatch[1] + thisAuthor + authorMatch[3];
+            header = authorMatch[1] + replaceSender + authorMatch[3];
             if (i === 0 && senderName) {
                 // skip Cc:ing and From:ing in the cover letter
                 mails[i] = header + match[2];

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -221,6 +221,8 @@ export class PatchSeries {
     protected static insertCcAndFromLines(mails: string[], thisAuthor: string,
                                           senderName?: string):
         void {
+        const isGitGitGadget = thisAuthor.match(/^GitGitGadget </);
+
         mails.map((mail, i) => {
             const match = mail.match(/^([^]*?)(\n\n[^]*)$/);
             if (!match) {
@@ -234,7 +236,7 @@ export class PatchSeries {
                 throw new Error("No From: line found in header:\n\n" + header);
             }
 
-            if (thisAuthor.match(/^GitGitGadget </)) {
+            if (isGitGitGadget) {
                 const onBehalfOf = i === 0 && senderName ?
                     senderName : authorMatch[2].replace(/ <.*>$/, "");
                 // Special-case GitGitGadget to send from

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -248,6 +248,12 @@ export class PatchSeries {
             }
 
             header = authorMatch[1] + thisAuthor + authorMatch[3];
+            if (i === 0 && senderName) {
+                // skip Cc:ing and From:ing in the cover letter
+                mails[i] = header + match[2];
+                return;
+            }
+
             const ccMatch = header.match(/^([^]*\nCc: .*?)(\n(?![ \t])[^]*)$/);
             if (ccMatch) {
                 header = ccMatch[1] + ", " + authorMatch[2] + ccMatch[2];

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -578,12 +578,14 @@ export class PatchSeries {
                 + " needs a description");
         }
 
-        const args = ["format-patch", "--thread", "--stdout",
+        const args = [
+            "format-patch", "--thread", "--stdout", "--signature=gitgitgadget",
             "--add-header=Fcc: Sent",
             "--add-header=Content-Type: text/plain; charset=UTF-8",
             "--add-header=Content-Transfer-Encoding: 8bit",
             "--add-header=MIME-Version: 1.0",
-            "--base", this.project.upstreamBranch, this.project.to];
+            "--base", this.project.upstreamBranch, this.project.to,
+        ];
         this.project.cc.map((email) => { args.push("--cc=" + email); });
         if (this.metadata.referencesMessageIds) {
             this.metadata.referencesMessageIds.map((email) => {

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -1,4 +1,6 @@
-import { commitExists, git, gitConfig, revParse } from "./git";
+import {
+    commitExists, git, gitCommandExists, gitConfig, revParse,
+} from "./git";
 import { GitNotes } from "./git-notes";
 import { IMailMetadata } from "./mail-metadata";
 import { IPatchSeriesMetadata } from "./patch-series-metadata";
@@ -68,7 +70,9 @@ export class PatchSeries {
                 }
             });
 
-            rangeDiff = await git(["range-diff", "--no-color", range]);
+            if (await gitCommandExists("range-diff", workDir)) {
+                rangeDiff = await git(["range-diff", "--no-color", range]);
+            }
         }
 
         const notes =
@@ -111,9 +115,11 @@ export class PatchSeries {
             const previousRange =
                 `${metadata.baseCommit}..${metadata.headCommit}`;
             const currentRange = `${baseCommit}..${headCommit}`;
-            rangeDiff = await git([
-                "range-diff", "--no-color", previousRange, currentRange,
-            ], { workDir });
+            if (await gitCommandExists("range-diff", workDir)) {
+                rangeDiff = await git([
+                    "range-diff", "--no-color", previousRange, currentRange,
+                ], { workDir });
+            }
 
             metadata.iteration++;
             metadata.baseCommit = baseCommit;

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -65,8 +65,7 @@ export class ProjectOptions {
             upstreamBranch = "busybox/master";
             midUrlPrefix = "https://www.mail-archive.com/search?"
                 + "l=busybox@busybox.net&q=";
-        } else if (await commitExists("0c16a2d9ca7a82f08f3", workDir) ||
-            await commitExists("0ae4d8d45ce43d7ad56", workDir)) {
+        } else if (await commitExists("7ccd18012de2e6c47e5", workDir)) {
             // We're running in the test suite!
             to = "--to=reviewer@example.com";
             upstreamBranch = "master";

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -119,7 +119,7 @@ gitgitgadget
 Message-Id: <07f68c195159518c5777ca4a7c1d07124e7a9956.<Message-ID>>
 In-Reply-To: <pull.<Message-ID>>
 References: <pull.<Message-ID>>
-From: "Contributor via GitGitGadget" <gitgitgadget@example.com>
+From: "Developer via GitGitGadget" <gitgitgadget@example.com>
 Date: Fri, 13 Feb 2009 23:35:30 +0000
 Subject: [PATCH 3/3] C
 Fcc: Sent

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -13,9 +13,9 @@ import {
 jest.setTimeout(60000);
 
 const expectedMails = [
-    `From 566155e00ab72541ff0ac21eab84d087b0e882a5 Mon Sep 17 00:00:00 2001
+    `From 07f68c195159518c5777ca4a7c1d07124e7a9956 Mon Sep 17 00:00:00 2001
 Message-Id: <pull.<Message-ID>>
-From: GitGitGadget <gitgitgadget@example.com>
+From: "GitHub User via GitGitGadget" <gitgitgadget@example.com>
 Date: <Cover-Letter-Date>
 Subject: [PATCH 0/3] My first Pull Request!
 Fcc: Sent
@@ -34,7 +34,7 @@ Contributor (1):
 Developer (1):
   C
 
-GitGitGadget (1):
+Test Dev (1):
   A
 
  A.t | 1 +
@@ -46,14 +46,14 @@ GitGitGadget (1):
  create mode 100644 C.t
 
 
-base-commit: 0ae4d8d45ce43d7ad56faff2feeacf8ed5293518
+base-commit: c241357a04a6f862ceef20bd148946085f3178b9
 --${" "}
 2.17.0.windows.1
-`, `From 44e454a6c1acb125e95d3ba9f57242445fb6beeb Mon Sep 17 00:00:00 2001
-Message-Id: <44e454a6c1acb125e95d3ba9f57242445fb6beeb.<Message-ID>>
+`, `From cd048a1378e3f7b055cd467ff3a24ed0cf5e7453 Mon Sep 17 00:00:00 2001
+Message-Id: <cd048a1378e3f7b055cd467ff3a24ed0cf5e7453.<Message-ID>>
 In-Reply-To: <pull.<Message-ID>>
 References: <pull.<Message-ID>>
-From: GitGitGadget <gitgitgadget@example.com>
+From: "Test Dev via GitGitGadget" <gitgitgadget@example.com>
 Date: Fri, 13 Feb 2009 23:33:30 +0000
 Subject: [PATCH 1/3] A
 Fcc: Sent
@@ -62,6 +62,9 @@ Content-Transfer-Encoding: 8bit
 MIME-Version: 1.0
 To: reviewer@example.com
 Cc: Some Body <somebody@example.com>
+Cc: Test Dev <dev@example.com>
+
+From: Test Dev <dev@example.com>
 
 ---
  A.t | 1 +
@@ -79,8 +82,8 @@ index 0000000..8c7e5a6
 --${" "}
 2.17.0.windows.1
 
-`, `From 0f7ccd74ef817f36e77c07eb918ebee41f6ab9e7 Mon Sep 17 00:00:00 2001
-Message-Id: <0f7ccd74ef817f36e77c07eb918ebee41f6ab9e7.<Message-ID>>
+`, `From b8acfa2635f9907e472d2b7396b260c6e73b1ed5 Mon Sep 17 00:00:00 2001
+Message-Id: <b8acfa2635f9907e472d2b7396b260c6e73b1ed5.<Message-ID>>
 In-Reply-To: <pull.<Message-ID>>
 References: <pull.<Message-ID>>
 From: "Contributor via GitGitGadget" <gitgitgadget@example.com>
@@ -112,8 +115,8 @@ index 0000000..7371f47
 --${" "}
 2.17.0.windows.1
 
-`, `From 566155e00ab72541ff0ac21eab84d087b0e882a5 Mon Sep 17 00:00:00 2001
-Message-Id: <566155e00ab72541ff0ac21eab84d087b0e882a5.<Message-ID>>
+`, `From 07f68c195159518c5777ca4a7c1d07124e7a9956 Mon Sep 17 00:00:00 2001
+Message-Id: <07f68c195159518c5777ca4a7c1d07124e7a9956.<Message-ID>>
 In-Reply-To: <pull.<Message-ID>>
 References: <pull.<Message-ID>>
 From: "Contributor via GitGitGadget" <gitgitgadget@example.com>
@@ -165,8 +168,8 @@ test("generate tag/notes from a Pull Request", async () => {
 
     const gitOpts: ITestCommitOptions = { workDir };
 
-    await git(["config", "user.name", "GitGitGadget"], gitOpts);
-    await git(["config", "user.email", "gitgitgadget@example.com"], gitOpts);
+    await git(["config", "user.name", "Test Dev"], gitOpts);
+    await git(["config", "user.email", "dev@example.com"], gitOpts);
 
     expect(await testCommit(gitOpts, "initial")).not.toEqual("");
     expect(await git(["checkout", "-b", "test-run"], { workDir }))
@@ -197,10 +200,13 @@ Cc: Some Body <somebody@example.com>
     const match2 = description.match(/^([^]+)\n\n([^]+)$/);
     expect(match2).toBeTruthy();
 
+    await git(["config", "user.name", "GitGitGadget"], gitOpts);
+    await git(["config", "user.email", "gitgitgadget@example.com"], gitOpts);
+
     const patches = await PatchSeries.getFromNotes(notes, pullRequestURL,
         description,
         "gitgitgadget:next", baseCommit,
-        "somebody:master", headCommit);
+        "somebody:master", headCommit, "GitHub User");
 
     expect(patches.coverLetter).toEqual(`My first Pull Request!
 
@@ -228,7 +234,7 @@ have included in git.git.`);
     const patches2 = await PatchSeries.getFromNotes(notes, pullRequestURL,
         description,
         "gitgitgadget:next", baseCommit,
-        "somebody:master", headCommit2);
+        "somebody:master", headCommit2, "GitHub User");
     mails.splice(0);
     expect(await patches2.generateAndSend(logger, send))
         .toEqual("pull.1.v2.git.gitgitgadget@example.com");
@@ -263,9 +269,11 @@ Contributor (1):
 Developer (1):
   C
 
-GitGitGadget (2):
-  A
+GitGitGadget (1):
   D
+
+Test Dev (1):
+  A
 
  A.t | 1 +
  B.t | 1 +
@@ -277,7 +285,7 @@ GitGitGadget (2):
  create mode 100644 C.t
  create mode 100644 D.t
 
-base-commit: 0ae4d8d45ce43d7ad56faff2feeacf8ed5293518
+base-commit: c241357a04a6f862ceef20bd148946085f3178b9
 
 Submitted-As: https://dummy.com/?mid=pull.1.v2.git.gitgitgadget@example.com
 In-Reply-To: https://dummy.com/?mid=pull.1.git.gitgitgadget@example.com`);

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -48,7 +48,7 @@ Test Dev (1):
 
 base-commit: c241357a04a6f862ceef20bd148946085f3178b9
 --${" "}
-2.17.0.windows.1
+gitgitgadget
 `, `From cd048a1378e3f7b055cd467ff3a24ed0cf5e7453 Mon Sep 17 00:00:00 2001
 Message-Id: <cd048a1378e3f7b055cd467ff3a24ed0cf5e7453.<Message-ID>>
 In-Reply-To: <pull.<Message-ID>>
@@ -80,7 +80,7 @@ index 0000000..8c7e5a6
 +A
 \\ No newline at end of file
 --${" "}
-2.17.0.windows.1
+gitgitgadget
 
 `, `From b8acfa2635f9907e472d2b7396b260c6e73b1ed5 Mon Sep 17 00:00:00 2001
 Message-Id: <b8acfa2635f9907e472d2b7396b260c6e73b1ed5.<Message-ID>>
@@ -113,7 +113,7 @@ index 0000000..7371f47
 +B
 \\ No newline at end of file
 --${" "}
-2.17.0.windows.1
+gitgitgadget
 
 `, `From 07f68c195159518c5777ca4a7c1d07124e7a9956 Mon Sep 17 00:00:00 2001
 Message-Id: <07f68c195159518c5777ca4a7c1d07124e7a9956.<Message-ID>>
@@ -146,7 +146,7 @@ index 0000000..96d80cd
 +C
 \\ No newline at end of file
 --${" "}
-2.17.0.windows.1
+gitgitgadget
 `,
 ];
 

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -1,5 +1,5 @@
 import "jest";
-import { git, revParse } from "../lib/git";
+import { git, gitCommandExists, revParse } from "../lib/git";
 import { GitNotes } from "../lib/git-notes";
 import { IGitGitGadgetOptions } from "../lib/gitgitgadget";
 import { PatchSeries } from "../lib/patch-series";
@@ -239,7 +239,9 @@ have included in git.git.`);
     expect(await patches2.generateAndSend(logger, send))
         .toEqual("pull.1.v2.git.gitgitgadget@example.com");
     expect(mails.length).toEqual(5);
-    expect(mails[0]).toMatch(/Range-diff vs v1:\n[^]*\n -: .* 4: /);
+    if (await gitCommandExists("range-diff", workDir)) {
+        expect(mails[0]).toMatch(/Range-diff vs v1:\n[^]*\n -: .* 4: /);
+    }
     expect(await revParse("pr-1/somebody/master-v2", workDir)).toBeDefined();
 
     expect(await notes.get(pullRequestURL)).toEqual({

--- a/tests/project-options.test.ts
+++ b/tests/project-options.test.ts
@@ -15,7 +15,7 @@ test("project options", async () => {
     expect(await isDirectory(`${workDir}/.git`)).toBeTruthy();
 
     const gitOpts: ITestCommitOptions = { workDir };
-    const initialCommit = "0c16a2d9ca7a82f08f3d1219f5f11642ffd329e2";
+    const initialCommit = "e073a465d0c7bf27664959bc93a9f018ac6f6f00";
     expect(await testCommit(gitOpts, "initial")).toEqual(initialCommit);
     expect(await git(["rev-parse", "--symbolic-full-name", "HEAD"],
         { workDir })).toEqual("refs/heads/master");

--- a/tests/test-lib.ts
+++ b/tests/test-lib.ts
@@ -22,6 +22,8 @@ export async function removeRecursively(path: string): Promise<void> {
     }
 }
 
+let initializedHome: boolean = false;
+
 export async function testCreateRepo(name: string) {
     let tmp = `${__dirname}/../.test-dir/`;
     if (!await isDirectory(tmp)) {
@@ -43,6 +45,25 @@ export async function testCreateRepo(name: string) {
     }
 
     await git(["init", dir]);
+
+    if (!initializedHome) {
+        initializedHome = true;
+
+        process.env.HOME = tmp;
+        await git(["config", "--global", "user.name", "Test User"]);
+        await git(["config", "--global", "user.email", "user@example.com"]);
+    }
+    await git([
+        "commit-tree", "-m", "Test commit",
+	"4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+    ], {
+        workDir: dir,
+        env: {
+            GIT_AUTHOR_DATE: `123457689 +0000`,
+            GIT_COMMITTER_DATE: `123457689 +0000`,
+        }
+    );
+
     return dir;
 }
 

--- a/tests/test-lib.ts
+++ b/tests/test-lib.ts
@@ -23,10 +23,11 @@ export async function removeRecursively(path: string): Promise<void> {
 }
 
 export async function testCreateRepo(name: string) {
-    const tmp = await realpath(`${__dirname}/../.test-dir/`);
+    let tmp = `${__dirname}/../.test-dir/`;
     if (!await isDirectory(tmp)) {
         await mkdir(tmp);
     }
+    tmp = await realpath(tmp);
 
     const match = name.match(/^(.*[\\/])?(.*?)(\.test)?\.ts$/);
     if (match) {


### PR DESCRIPTION
This patch series addresses the assumptions in the current `master` branch that apply only to my own Windows setup, but probably not to anybody else's. And certainly not to the VSTS build which I want to use as "release gate", i.e. I want to require that build to pass before merging any Pull Request.