### PR TITLE
Add TODOs after sending the first patch series via GitGitGadget

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,8 @@ into a few categories (listed by priority, most important tasks first).
 
 ## These tasks should be the focus immediately after GitGitGadget works
 
+- suppress the `Cc: GitGitGadget` and the first body line `From: GitGitGadget` in the cover letter
+- Junio should be Cc:ed on the entire patch series (but is not)
 - add links to the PR and the branch to-be-merged to the cover letter
 - redo the way links are inserted (the `sed` origins still show)
 - Cc: the GitHub user who issued `/submit` on the cover letter


### PR DESCRIPTION
I just submitted my first patch series via GitGitGadget, and it worked,
mostly:

    https://github.com/gitgitgadget/git/pull/3
    https://public-inbox.org/git/pull.3.git.gitgitgadget@gmail.com/

There were only minor glitches that I noticed immediately (and maybe
major ones I missed). Let's remember to fix them.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>