### PR TITLE
Force-fetch the notes initially

### DIFF
--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -37,7 +37,7 @@ export class GitGitGadget {
             "fetch",
             publishTagsAndNotesToRemote,
             "--",
-            `${GitNotes.defaultNotesRef}:${GitNotes.defaultNotesRef}`,
+            `+${GitNotes.defaultNotesRef}:${GitNotes.defaultNotesRef}`,
         ], { workDir });
 
         const notes = new GitNotes(workDir);


### PR DESCRIPTION
When GitGitGadget starts up, it needs to make sure that it uses the
newest  revision of the gitgitgadget notes, as that is where all the
metadata are saved.

When this developer needs to roll back inadvertent changes, that means that
the notes ref cannot fast-forward. Let's be prepared for that
contingency.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>