### PR TITLE
Do not drop all but the last Cc:ed person

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@ into a few categories (listed by priority, most important tasks first).
 ## These tasks should be the focus immediately after GitGitGadget works
 
 - suppress the `Cc: GitGitGadget` and the first body line `From: GitGitGadget` in the cover letter
-- Junio should be Cc:ed on the entire patch series (but is not)
 - add links to the PR and the branch to-be-merged to the cover letter
 - redo the way links are inserted (the `sed` origins still show)
 - Cc: the GitHub user who issued `/submit` on the cover letter

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -83,6 +83,6 @@ export async function gitConfigForEach(key: string,
 
 export async function gitCommandExists(command: string, workDir?: string):
     Promise<boolean> {
-    const result = await GitProcess.exec([command, "-h"], workDir);
+    const result = await GitProcess.exec([command, "-h"], workDir || ".");
     return result.exitCode === 129;
 }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -70,7 +70,7 @@ export class PatchSeries {
                 }
             });
 
-            if (await gitCommandExists("range-diff", workDir)) {
+            if (await gitCommandExists("range-diff", project.workDir)) {
                 rangeDiff = await git(["range-diff", "--no-color", range]);
             }
         }

--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -9,6 +9,7 @@ export interface IParsedMBox {
     messageId?: string;
     subject: string;
     to: string;
+    raw: string;
 }
 
 export interface ISMTPOptions {
@@ -86,6 +87,7 @@ export async function parseMBox(mbox: string): Promise<IParsedMBox> {
         from,
         headers,
         messageId,
+        raw: mbox,
         subject,
         to,
     };
@@ -106,14 +108,12 @@ export async function sendMail(mail: IParsedMBox,
 
         // setup email data with unicode symbols
         const mailOptions: SendMailOptions = {
-            cc: mail.cc || [],
-            date: mail.date,
-            from: mail.from,
-            headers: mail.headers,
-            messageId: mail.messageId,
-            subject: mail.subject,
-            text: mail.body,
-            to: mail.to,
+            envelope: {
+                cc: mail.cc ? mail.cc.join(", ") : undefined,
+                from: mail.from,
+                to: mail.to,
+            },
+            raw: mail.raw,
         };
 
         transporter.sendMail(mailOptions, (error, info): void => {

--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -63,7 +63,7 @@ export async function parseMBox(mbox: string): Promise<IParsedMBox> {
         const key = line.substr(0, colon);
         const value = replaceAll(line.substr(colon + 2), "\n ", " ");
         switch (key.toLowerCase()) {
-            case "cc": cc = value.split(", "); break;
+            case "cc": cc = (cc || []).concat(value.split(", ")); break;
             case "date": date = value; break;
             case "fcc": break;
             case "from": from = value; break;


### PR DESCRIPTION
Due to an incorrect assumption of mine, the Cc: parsing assumed that all Cc: entries would be on the same line, as comma-separated values. However, `git format-patch` generates multiple Cc: lines, at least in the version used in our WebApp (v2.17.0). Let's be nice and accept multiple Cc: lines and move on.