### PR TITLE
Implement some rudimentary access control

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,4 +86,28 @@ module.exports = (robot) => {
       await addComment(context, `An error occurred while submitting:\n\n${reason}`);
     }
   })
+
+  commands(robot, 'allow', async (context, command) => {
+    await instantiate()
+    try {
+      if (await gitGitGadget.allowUser(command.arguments))
+        await addComment(context, `User ${command.arguments} is now allowed to use GitGitGadget.`)
+      else
+        await addComment(context, `User ${command.arguments} already allowed to use GitGitGadget.`)
+    } catch (reason) {
+      await addComment(context, `An error occurred while processing:\n\n${reason}`)
+    }
+  })
+
+  commands(robot, 'disallow', async (context, command) => {
+    await instantiate()
+    try {
+      if (await gitGitGadget.disallowUser(command.arguments))
+        await addComment(context, `User ${command.arguments} is no longer allowed to use GitGitGadget.`)
+      else
+        await addComment(context, `User ${command.arguments} already not allowed to use GitGitGadget.`)
+    } catch (reason) {
+      await addComment(context, `An error occurred while processing:\n\n${reason}`)
+    }
+  })
 }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = (robot) => {
   const instantiate = async () => {
     if (!gitGitGadget) {
       console.log('Getting new GitGitGadget instance');
-      gitGitGadget = await GitGitGadget.get();
+      gitGitGadget = await GitGitGadget.get(__dirname);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,13 @@ module.exports = (robot) => {
 
   robot.log('Yay, the app was loaded!');
 
+  const instantiate = async () => {
+    if (!gitGitGadget) {
+      console.log('Getting new GitGitGadget instance');
+      gitGitGadget = await GitGitGadget.get();
+    }
+  }
+
   const addComment = async (context, comment) => {
     await context.github.issues.createComment(context.issue({ body: comment }))
   }
@@ -16,10 +23,7 @@ module.exports = (robot) => {
       return;
     }
 
-    if (!gitGitGadget) {
-      console.log('Getting new GitGitGadget instance');
-      gitGitGadget = await GitGitGadget.get();
-    }
+    await instantiate();
 
     const comment = context.payload.comment;
     if (!comment || !comment.user || !comment.user.login) {

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -19,7 +19,7 @@ export async function git(args: string[],
     Promise<string> {
     const workDir = options && options.workDir || ".";
     if (options && options.trace) {
-        process.stderr.write(`Called 'git ${args.join(" ")}':
+        process.stderr.write(`Called 'git ${args.join(" ")}' in '${workDir}':
 ${new Error().stack}
 `);
     }
@@ -27,6 +27,12 @@ ${new Error().stack}
     if (result.exitCode) {
         throw new Error(`git ${args.join(" ")} failed: ${result.exitCode},
 ${result.stderr}`);
+    }
+    if (options && options.trace) {
+        process.stderr.write(`Output of 'git ${args.join(" ")}':
+stderr: ${result.stderr}
+stdout: ${result.stdout}
+`);
     }
     return !options || options.trimTrailingNewline === false ?
         result.stdout : trimTrailingNewline(result.stdout);

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -191,6 +191,17 @@ export class GitGitGadget {
         return pullRequestRef;
     }
 
+    protected async fetchAndReReadOptions(): Promise<void> {
+        await git([
+            "fetch",
+            this.publishTagsAndNotesToRemote,
+            "--",
+            `+${GitNotes.defaultNotesRef}:${GitNotes.defaultNotesRef}`,
+        ], { workDir: this.workDir });
+        [this.options, this.allowedUsers] =
+            await GitGitGadget.readOptions(this.notes);
+    }
+
     protected async pushNotesRef(): Promise<void> {
         await git([
             "push",

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -190,4 +190,17 @@ export class GitGitGadget {
 
         return pullRequestRef;
     }
+
+    protected async pushNotesRef(): Promise<void> {
+        await git([
+            "push",
+            this.publishTagsAndNotesToRemote,
+            "--",
+            `${this.notes.notesRef}`,
+        ], { workDir: this.workDir });
+
+        // re-read options
+        [this.options, this.allowedUsers] =
+            await GitGitGadget.readOptions(this.notes);
+    }
 }

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -13,16 +13,17 @@ export interface IGitGitGadgetOptions {
  * The central class of the Probot-based Web App.
  */
 export class GitGitGadget {
-    public static async get(workDir?: string): Promise<GitGitGadget> {
+    public static async get(gitGitGadgetDir: string, workDir?: string):
+        Promise<GitGitGadget> {
         if (!workDir) {
-            workDir = await gitConfig("gitgitgadget.workDir");
+            workDir = await gitConfig("gitgitgadget.workDir", gitGitGadgetDir);
             if (!workDir) {
                 throw new Error(`Could not find GitGitGadget's work tree`);
             }
         }
 
         const publishTagsAndNotesToRemote =
-            await gitConfig("gitgitgadget.publishRemote");
+            await gitConfig("gitgitgadget.publishRemote", gitGitGadgetDir);
         if (!publishTagsAndNotesToRemote) {
             throw new Error(`No remote to which to push configured`);
         }
@@ -42,9 +43,12 @@ export class GitGitGadget {
 
         const notes = new GitNotes(workDir);
 
-        const smtpUser = await gitConfig("gitgitgadget.smtpUser");
-        const smtpHost = await gitConfig("gitgitgadget.smtpHost");
-        const smtpPass = await gitConfig("gitgitgadget.smtpPass");
+        const smtpUser = await gitConfig("gitgitgadget.smtpUser",
+            gitGitGadgetDir);
+        const smtpHost = await gitConfig("gitgitgadget.smtpHost",
+            gitGitGadgetDir);
+        const smtpPass = await gitConfig("gitgitgadget.smtpPass",
+            gitGitGadgetDir);
         if (!smtpUser || !smtpHost || !smtpPass) {
             throw new Error(`No SMTP settings configured`);
         }

--- a/tests/test-lib.ts
+++ b/tests/test-lib.ts
@@ -57,11 +57,12 @@ export async function testCreateRepo(name: string) {
         "commit-tree", "-m", "Test commit",
         "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     ], {
-        workDir: dir,
-        env: {
-            GIT_AUTHOR_DATE: `123457689 +0000`,
-            GIT_COMMITTER_DATE: `123457689 +0000`,
-        }
+            env: {
+                GIT_AUTHOR_DATE: `123457689 +0000`,
+                GIT_COMMITTER_DATE: `123457689 +0000`,
+            },
+            workDir: dir,
+        },
     );
 
     return dir;

--- a/tests/test-lib.ts
+++ b/tests/test-lib.ts
@@ -24,7 +24,8 @@ export async function removeRecursively(path: string): Promise<void> {
 
 let initializedHome: boolean = false;
 
-export async function testCreateRepo(name: string) {
+export async function testCreateRepo(name: string, suffix?: string):
+    Promise<string> {
     let tmp = `${__dirname}/../.test-dir/`;
     if (!await isDirectory(tmp)) {
         await mkdir(tmp);
@@ -34,6 +35,9 @@ export async function testCreateRepo(name: string) {
     const match = name.match(/^(.*[\\/])?(.*?)(\.test)?\.ts$/);
     if (match) {
         name = `trash directory.${match[2]}`;
+    }
+    if (suffix) {
+        name += suffix;
     }
 
     const dir = `${tmp}/${name}`;

--- a/tests/test-lib.ts
+++ b/tests/test-lib.ts
@@ -55,7 +55,7 @@ export async function testCreateRepo(name: string) {
     }
     await git([
         "commit-tree", "-m", "Test commit",
-	"4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+        "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     ], {
         workDir: dir,
         env: {


### PR DESCRIPTION
So far, GitGitGadget only accepts commands by myself (identified via the GitHub user account who added the comment).

With this Pull Request, users who are in the "allowed" list can issue `/allow <user>` and `/disallow <user>` commands (just like `/submit` commands) to modify that "allowed" list.