### PR TITLE
Hotfix: pass along the vouching user for /allow and /disallow

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,9 +88,10 @@ module.exports = (robot) => {
   })
 
   commands(robot, 'allow', async (context, command) => {
+    const gitHubUser = comment.user.login;
     await instantiate()
     try {
-      if (await gitGitGadget.allowUser(command.arguments))
+      if (await gitGitGadget.allowUser(gitHubUser, command.arguments))
         await addComment(context, `User ${command.arguments} is now allowed to use GitGitGadget.`)
       else
         await addComment(context, `User ${command.arguments} already allowed to use GitGitGadget.`)
@@ -100,9 +101,10 @@ module.exports = (robot) => {
   })
 
   commands(robot, 'disallow', async (context, command) => {
+    const gitHubUser = comment.user.login;
     await instantiate()
     try {
-      if (await gitGitGadget.disallowUser(command.arguments))
+      if (await gitGitGadget.disallowUser(gitHubUser, command.arguments))
         await addComment(context, `User ${command.arguments} is no longer allowed to use GitGitGadget.`)
       else
         await addComment(context, `User ${command.arguments} already not allowed to use GitGitGadget.`)


### PR DESCRIPTION
The `allowUser()` and `denyUser()` methods of the `GitGitGadget` class
require *two* parameters, the vouching user and the user to be added
(or removed) from the list of allowed users.

By mistake, the callers in `index.js` only passed the latter, which is
fixed by this commit.

It would probably be a good idea to convert `index.js` to Typescript,
too, to avoid such stupid mistakes.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>