### PR TITLE
Add footers to the cover letter

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@ into a few categories (listed by priority, most important tasks first).
 ## These tasks should be the focus immediately after GitGitGadget works
 
 - suppress the `Cc: GitGitGadget` and the first body line `From: GitGitGadget` in the cover letter
-- add links to the PR and the branch to-be-merged to the cover letter
 - Cc: the GitHub user who issued `/submit` on the cover letter
 - handle the `/allow <user>` and `/disallow <user>` commands
 - upon Probot-type of launch, verify that the base branch is one of "maint", "master", "next" or "pu"

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@ into a few categories (listed by priority, most important tasks first).
 
 - suppress the `Cc: GitGitGadget` and the first body line `From: GitGitGadget` in the cover letter
 - add links to the PR and the branch to-be-merged to the cover letter
-- redo the way links are inserted (the `sed` origins still show)
 - Cc: the GitHub user who issued `/submit` on the cover letter
 - handle the `/allow <user>` and `/disallow <user>` commands
 - upon Probot-type of launch, verify that the base branch is one of "maint", "master", "next" or "pu"

--- a/lib/fs-util.ts
+++ b/lib/fs-util.ts
@@ -18,3 +18,20 @@ export async function isDirectory(path: string): Promise<boolean> {
     }
     return false;
 }
+
+/**
+ * Determine whether a given path refers to an existing file.
+ *
+ * @param {string} path the path to the file
+ * @returns {boolean} whether the specified path points to an existing file
+ */
+export async function isFile(path: string): Promise<boolean> {
+    try {
+        if ((await stat(path)).isFile()) {
+            return true;
+        }
+    } catch (reason) {
+        /* it's okay */
+    }
+    return false;
+}

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -184,7 +184,7 @@ export class GitGitGadget {
             async (mail: string): Promise<string> => {
                 return await parseHeadersAndSendMail(mail, this.smtpOptions);
             },
-            this.publishTagsAndNotesToRemote,
+            this.publishTagsAndNotesToRemote, pullRequestURL,
         );
         return coverMid;
     }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -353,7 +353,7 @@ export class PatchSeries {
     protected static insertFooters(mail: string, isCoverLetter: boolean,
                                    footers: string[]): string {
         const regex = isCoverLetter ?
-            /^([^]*?\n-- \n)([^]*)$/ :
+            /^([^]*?\n)(-- \n[^]*)$/ :
             /^([^]*?\n---\n(?:\n[A-Za-z:]+ [^]*?\n\n)?)([^]*)$/;
         const match = mail.match(regex);
         if (!match) {
@@ -361,7 +361,8 @@ export class PatchSeries {
                 + "point for\n\n" + mail);
         }
 
-        return `${match[1]}\n${footers.join("\n")}\n\n${match[2]}`;
+        const n = isCoverLetter ? "" : "\n";
+        return `${match[1]}${n}${footers.join("\n")}\n${n}${match[2]}`;
     }
 
     public readonly notes: GitNotes;

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -47,6 +47,11 @@ Test Dev (1):
 
 
 base-commit: c241357a04a6f862ceef20bd148946085f3178b9
+Published-As: https://github.com/gitgitgadget/git/releases/tags/${
+    ""}pr-1/somebody/master-v1
+Fetch-It-Via: git fetch https://github.com/gitgitgadget/git ${
+    ""}pr-1/somebody/master-v1
+Pull-Request: https://github.com/gitgitgadget/git/pull/1
 --${" "}
 gitgitgadget
 `, `From cd048a1378e3f7b055cd467ff3a24ed0cf5e7453 Mon Sep 17 00:00:00 2001
@@ -224,7 +229,8 @@ have included in git.git.`);
 
         return "Message-ID";
     }
-    expect(await patches.generateAndSend(logger, send))
+    expect(await patches.generateAndSend(logger, send, undefined,
+        pullRequestURL))
         .toEqual("pull.1.git.gitgitgadget@example.com");
     expect(mails).toEqual(expectedMails);
 
@@ -236,7 +242,8 @@ have included in git.git.`);
         "gitgitgadget:next", baseCommit,
         "somebody:master", headCommit2, "GitHub User");
     mails.splice(0);
-    expect(await patches2.generateAndSend(logger, send))
+    expect(await patches2.generateAndSend(logger, send, undefined,
+        pullRequestURL))
         .toEqual("pull.1.v2.git.gitgitgadget@example.com");
     expect(mails.length).toEqual(5);
     if (await gitCommandExists("range-diff", workDir)) {

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -114,12 +114,16 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             expect(withLinks).toBe(tagMessage1 + footer);
         });
 
+        const footers = [
+            "HEADER",
+        ].concat([
+            "This", "is", "a", "fake", "cover letter",
+        ].map((element: string): string => ` ${element}`));
+
         const coverLetterWithRangeDiff =
-            PatchSeries.insertRangeDiff(coverLetter, true, "HEADER",
-                "This\nis\na\nfake\ncover letter\n");
+            PatchSeries.insertFooters(coverLetter, true, footers);
         const mailWithRangeDiff =
-            PatchSeries.insertRangeDiff(mails[1], false, "HEADER",
-                "This\nis\na\nfake\ncover letter\n");
+            PatchSeries.insertFooters(mails[1], false, footers);
         test("range-diff is inserted correctly", () => {
             expect(coverLetterWithRangeDiff).toMatch(
                 // tslint:disable-next-line:max-line-length

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -127,7 +127,7 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
         test("range-diff is inserted correctly", () => {
             expect(coverLetterWithRangeDiff).toMatch(
                 // tslint:disable-next-line:max-line-length
-                /\n-- \n\nHEADER\n This\n is\n a\n fake\n cover letter\n\n2\.17/);
+                /\n\nHEADER\n This\n is\n a\n fake\n cover letter\n-- \n2\.17/);
             expect(mailWithRangeDiff).toMatch(
                 // tslint:disable-next-line:max-line-length
                 /\n---\n\nHEADER\n This\n is\n a\n fake\n cover letter\n\n README/);

--- a/tests/test-lib.ts
+++ b/tests/test-lib.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as util from "util";
-import { isDirectory } from "../lib/fs-util";
+import { isDirectory, isFile } from "../lib/fs-util";
 import { git, IGitOptions, revParse } from "../lib/git";
 
 const mkdir = util.promisify(fs.mkdir);
@@ -21,8 +21,6 @@ export async function removeRecursively(path: string): Promise<void> {
         await rmdir(path);
     }
 }
-
-let initializedHome: boolean = false;
 
 export async function testCreateRepo(name: string, suffix?: string):
     Promise<string> {
@@ -50,10 +48,8 @@ export async function testCreateRepo(name: string, suffix?: string):
 
     await git(["init", dir]);
 
-    if (!initializedHome) {
-        initializedHome = true;
-
-        process.env.HOME = tmp;
+    process.env.HOME = tmp;
+    if (!await isFile(`${tmp}/.gitconfig`)) {
         await git(["config", "--global", "user.name", "Test User"]);
         await git(["config", "--global", "user.email", "user@example.com"]);
     }


### PR DESCRIPTION
This developer's contributions have the following footers in the cover letter (see e.g. https://public-inbox.org/git/cover.1526593623.git.johannes.schindelin@gmx.de/):

> Published-As: <link to tag>
> Fetch-It-Via: git fetch <url> <tag>

Let's do the same when the web app submits the patch series.

For good measure, also link to the Pull Request itself (this did not make sense before, when this project was still a command-line tool to be run in a local Git worktree).