### PR TITLE
Fix "Published-As" footer in the cover letter

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -516,7 +516,8 @@ export class PatchSeries {
             const [owner, repo, prNo] =
                 GitGitGadget.parsePullRequestURL(pullRequestURL);
             const prefix = `https://github.com/${owner}/${repo}`;
-            footers.push(`Published-As: ${prefix}/releases/tags/${tagName}`);
+            const tagName2 = encodeURIComponent(tagName);
+            footers.push(`Published-As: ${prefix}/releases/tags/${tagName2}`);
             footers.push(`Fetch-It-Via: git fetch ${prefix} ${tagName}`);
             footers.push(`Pull-Request: ${prefix}/pull/${prNo}`);
         }

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -48,7 +48,7 @@ Test Dev (1):
 
 base-commit: c241357a04a6f862ceef20bd148946085f3178b9
 Published-As: https://github.com/gitgitgadget/git/releases/tags/${
-    ""}pr-1/somebody/master-v1
+    ""}pr-1%2Fsomebody%2Fmaster-v1
 Fetch-It-Via: git fetch https://github.com/gitgitgadget/git ${
     ""}pr-1/somebody/master-v1
 Pull-Request: https://github.com/gitgitgadget/git/pull/1


### PR DESCRIPTION
It can be seen [here](https://public-inbox.org/git/pull.7.git.gitgitgadget@gmail.com/) that the footer is wrong: it was generated as

> Published-As: https://github.com/gitgitgadget/git/releases/tags/pr-7/dscho/fix-build-options-commit-info-v1

but should be

> Published-As: https://github.com/gitgitgadget/git/releases/tags/pr-7%2Fdscho%2Ffix-build-options-commit-info-v1

because GitHub does not leave slashes in tags' names unencoded.

This PR fixes that.