### PR TITLE
Avoid duplicate Cc: lines

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -264,7 +264,7 @@ export class PatchSeries {
                 return;
             }
 
-            const ccMatch = header.match(/^([^]*\nCc: .*?)(\n(?![ \t])[^]*)$/);
+            const ccMatch = header.match(/^([^]*\nCc: .*?)(|\n(?![ \t])[^]*)$/);
             if (ccMatch) {
                 header = ccMatch[1] + ",\n    " + authorMatch[2] + ccMatch[2];
             } else {

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -266,7 +266,7 @@ export class PatchSeries {
 
             const ccMatch = header.match(/^([^]*\nCc: .*?)(\n(?![ \t])[^]*)$/);
             if (ccMatch) {
-                header = ccMatch[1] + ", " + authorMatch[2] + ccMatch[2];
+                header = ccMatch[1] + ",\n    " + authorMatch[2] + ccMatch[2];
             } else {
                 header += "\nCc: " + authorMatch[2];
             }

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -66,8 +66,8 @@ Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 MIME-Version: 1.0
 To: reviewer@example.com
-Cc: Some Body <somebody@example.com>
-Cc: Test Dev <dev@example.com>
+Cc: Some Body <somebody@example.com>,
+    Test Dev <dev@example.com>
 
 From: Test Dev <dev@example.com>
 
@@ -99,8 +99,8 @@ Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 MIME-Version: 1.0
 To: reviewer@example.com
-Cc: Some Body <somebody@example.com>
-Cc: Contributor <contributor@example.com>
+Cc: Some Body <somebody@example.com>,
+    Contributor <contributor@example.com>
 
 From: Contributor <contributor@example.com>
 
@@ -132,8 +132,8 @@ Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 MIME-Version: 1.0
 To: reviewer@example.com
-Cc: Some Body <somebody@example.com>
-Cc: Developer <developer@example.com>
+Cc: Some Body <somebody@example.com>,
+    Developer <developer@example.com>
 
 From: Developer <developer@example.com>
 

--- a/tslint.json
+++ b/tslint.json
@@ -2,10 +2,13 @@
     "extends": "tslint:recommended",
     "rules": {
         "max-line-length": {
-            "options": [80]
+            "options": [
+                80
+            ]
         },
         "no-floating-promises": true,
         "no-unused-expression": true,
-        "no-unused-variable": true
+        "no-unused-variable": true,
+        "no-console": false
     }
 }


### PR DESCRIPTION
It was reported in https://github.com/gitgitgadget/gitgitgadget/issues/16 that GitGitGadget produces mails with duplicate Cc: lines, which could be interpreted by anti-malware software to indicate non-benign emails.

So let's fix this.

/cc @ sunshineco 