### PR TITLE
Use base commit of PR to base patch series

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,9 @@ module.exports = (robot) => {
       console.log(`Could not determine PR details:\n${JSON.stringify(pr, null, 4)}`);
       return;
     }
+    if (pr.mergeable !== true) {
+      throw new Error(`Refusing to submit a patch series that does not merge cleanly.`);
+    }
     let gitHubUserName = comment.user.name;
     if (!gitHubUserName) {
       let user = await context.github.users.getById({ id: comment.user.id });

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -151,7 +151,7 @@ export class PatchSeries {
         const publishToRemote = undefined;
 
         const project = await ProjectOptions.get(workDir, headCommit, cc || [],
-            basedOn, publishToRemote);
+            basedOn, publishToRemote, baseCommit);
 
         return new PatchSeries(notes, options, project, metadata,
             rangeDiff, coverLetter, senderName);
@@ -594,8 +594,8 @@ export class PatchSeries {
     }
 
     protected async generateMBox(): Promise<string> {
-        const commitRange = this.project.upstreamBranch + ".."
-            + this.project.branchName;
+        const commitRange =
+            `${this.project.baseCommit}..${this.project.branchName}`;
         if (!this.coverLetter && 1 < parseInt(await git(["rev-list", "--count",
             commitRange], { workDir: this.project.workDir }), 10)) {
             throw new Error("Branch " + this.project.branchName
@@ -608,7 +608,7 @@ export class PatchSeries {
             "--add-header=Content-Type: text/plain; charset=UTF-8",
             "--add-header=Content-Transfer-Encoding: 8bit",
             "--add-header=MIME-Version: 1.0",
-            "--base", this.project.upstreamBranch, this.project.to,
+            "--base", this.project.baseCommit, this.project.to,
         ];
         this.project.cc.map((email) => { args.push("--cc=" + email); });
         if (this.metadata.referencesMessageIds) {

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -33,7 +33,7 @@ export class ProjectOptions {
 
     public static async get(workDir: string, branchName: string,
                             cc: string[], basedOn?: string,
-                            publishToRemote?: string):
+                            publishToRemote?: string, baseCommit?: string):
         Promise<ProjectOptions> {
         let upstreamBranch: string;
         let to: string;
@@ -78,14 +78,15 @@ export class ProjectOptions {
             upstreamBranch = basedOn;
         }
 
-        if (await git(["rev-list", branchName + ".." + upstreamBranch],
-            { workDir })) {
+        if (!baseCommit &&
+            await git(["rev-list", branchName + ".." + upstreamBranch],
+                { workDir })) {
             throw new Error("Branch " + branchName + " is not rebased to " +
                 upstreamBranch);
         }
 
         return new ProjectOptions(branchName, upstreamBranch, basedOn,
-            publishToRemote, to, cc, midUrlPrefix, workDir);
+            publishToRemote, to, cc, midUrlPrefix, workDir, baseCommit);
     }
 
     protected static async determineBaseBranch(workDir: string,
@@ -132,6 +133,7 @@ export class ProjectOptions {
 
     public readonly branchName: string;
     public readonly upstreamBranch: string;
+    public readonly baseCommit: string;
     public readonly basedOn?: string;
     public readonly publishToRemote?: string;
     public readonly workDir: string;
@@ -144,9 +146,12 @@ export class ProjectOptions {
                           basedOn: string | undefined,
                           publishToRemote: string | undefined,
                           to: string, cc: string[], midUrlPrefix: string,
-                          workDir: string) {
+                          workDir: string, baseCommit?: string) {
         this.branchName = branchName;
         this.upstreamBranch = upstreamBranch;
+
+        this.baseCommit = baseCommit || upstreamBranch;
+
         this.basedOn = basedOn;
         this.publishToRemote = publishToRemote;
         this.workDir = workDir;


### PR DESCRIPTION
When writing a new patch series, we may target a branch other than `master`. Doing so, we get a different merge-base and have a different set of commits to send.

This PR attempts to link the `pr.base.sha` to a new `baseCommit` in the project information that replaces `upstreamBranch` in the `git format-patch` calculation.

(Note: I don't even have enough on my machine to build and test the project, so I'm going to see what PR checks exist.)