### PR TITLE
send-mail: use current date

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@ into a few categories (listed by priority, most important tasks first).
 
 ## Tasks that would be really nice to have, too, time permitting
 
-- Imitate `git send-email` (which apparently overrides the `Date:` header and uses the current time instead)
 - The branches merged into `pu` are also pushed individually to
   https:/github.com/gitster/git. We will want to add a comment to the PR every
   time this branch is pushed, and update the Git note corresponding to the

--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -65,12 +65,15 @@ export async function parseMBox(mbox: string): Promise<IParsedMBox> {
         const value = replaceAll(line.substr(colon + 2), "\n ", " ");
         switch (key.toLowerCase()) {
             case "cc": cc = (cc || []).concat(value.split(", ")); break;
-            case "date": date = value; break;
             case "fcc": break;
             case "from": from = value; break;
             case "message-id": messageId = value; break;
             case "subject": subject = value; break;
             case "to": to = value; break;
+            case "date":
+                /* Ignore value and use 'now' to act like 'git send-mail' */
+                date = new Date().toUTCString();
+                break;
             default:
                 headers.push({ key, value });
         }


### PR DESCRIPTION
We are trying to emulate 'git send-mail', and that command ignores the
date that was created by 'git format-patch' in favor of the current
time. This helps users keep their inbox more organized, especially when
they do not thread their messages.

Signed-off-by: Derrick Stolee <dstolee@microsoft.com>