### PR TITLE
Adjust date before sending

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,9 @@
     "cSpell.words": [
         "Cygwin",
         "Git's",
+        "Hamano",
         "ISMTP",
+        "Junio",
         "Probot",
         "Schindelin",
         "VSTS",
@@ -32,6 +34,7 @@
         "gitgitgadget",
         "gitster",
         "gmail",
+        "gmane",
         "googlegroups",
         "latesttag",
         "latesttags",
@@ -40,6 +43,7 @@
         "maint",
         "mbox",
         "onelines",
+        "pobox",
         "promisify",
         "publishtoremote",
         "rebased",
@@ -51,6 +55,7 @@
         "superset",
         "taggerdate",
         "tbdiff",
+        "vger",
         "worktree"
     ],
     "cSpell.language": "en-US",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
         "Junio",
         "Probot",
         "Schindelin",
+        "Truthy",
         "VSTS",
         "amlog",
         "basedon",

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@ into a few categories (listed by priority, most important tasks first).
 
 ## Tasks that would be really nice to have, too, time permitting
 
-- Imitate `git send-email` (which apparently overrides the `Date:` header and uses the current time instead)
 - The branches merged into `pu` are also pushed individually to
   https:/github.com/gitster/git. We will want to add a comment to the PR every
   time this branch is pushed, and update the Git note corresponding to the

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -185,6 +185,7 @@ export class GitGitGadget {
                 return await parseHeadersAndSendMail(mail, this.smtpOptions);
             },
             this.publishTagsAndNotesToRemote, pullRequestURL,
+            new Date(),
         );
         return coverMid;
     }

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -132,6 +132,21 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
                 // tslint:disable-next-line:max-line-length
                 /\n---\n\nHEADER\n This\n is\n a\n fake\n cover letter\n\n README/);
         });
+
+        test("adjust mbox to forced date", () => {
+            expect(mails.length).toEqual(2);
+            const endDate = new Date(987654321000);
+            expect(PatchSeries.adjustDateHeaders(mails, endDate)).toEqual(2);
+            const dates = mails.map((mail: string): string => {
+                const match = mail.match(/\nDate: (.*)\n/);
+                if (!match) {
+                    throw new Error(`No Date: header in ${mail}`);
+                }
+                return match[1];
+            });
+            expect(new Date(dates[0]).getTime()).toEqual(987654320000);
+            expect(new Date(dates[1]).getTime()).toEqual(987654321000);
+        });
     }
 }
 


### PR DESCRIPTION
This PR supersedes #22 (whose patch would not work because of the way we call nodemailer: we pass the raw mbox and only provide a small envelope, and the `Date:` header cannot be specified that way.