### PR TITLE
Work harder to avoid duplicate Cc: header lines

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -264,7 +264,8 @@ export class PatchSeries {
                 return;
             }
 
-            const ccMatch = header.match(/^([^]*\nCc: .*?)(|\n(?![ \t])[^]*)$/);
+            const ccMatch =
+                header.match(/^([^]*\nCc: [^]*?)(|\n(?![ \t])[^]*)$/);
             if (ccMatch) {
                 header = ccMatch[1] + ",\n    " + authorMatch[2] + ccMatch[2];
             } else {


### PR DESCRIPTION
We already have code that tries to reuse existing Cc: header lines
instead of adding a new one.

And we already fixed the situation where our code failed to anticipate the situation when the `Cc:` header is the last one in the header block.

But we still failed to handle the case correctly where the existing Cc:
header was already a multi-line one.

Let's also handle that case.

This hopefully fixes #16 for good.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>