### PR TITLE
Wrap the cover letters

### DIFF
--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -27,5 +27,5 @@ class MyOptions implements HtmlToTextOptions {
 }
 
 export function md2text(markdown: string, columns?: number): string {
-    return fromString(marked(markdown), new MyOptions(76));
+    return fromString(marked(markdown), new MyOptions(columns));
 }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -4,6 +4,7 @@ import {
 import { GitNotes } from "./git-notes";
 import { GitGitGadget } from "./gitgitgadget";
 import { IMailMetadata } from "./mail-metadata";
+import { md2text } from "./markdown-renderer";
 import { IPatchSeriesMetadata } from "./patch-series-metadata";
 import { PatchSeriesOptions } from "./patch-series-options";
 import { ProjectOptions } from "./project-options";
@@ -153,8 +154,10 @@ export class PatchSeries {
         const project = await ProjectOptions.get(workDir, headCommit, cc || [],
             basedOn, publishToRemote, baseCommit);
 
+        const wrapCoverLetterAtColumn = 76;
         return new PatchSeries(notes, options, project, metadata,
-            rangeDiff, coverLetter, senderName);
+            rangeDiff, md2text(coverLetter, wrapCoverLetterAtColumn),
+            senderName);
     }
 
     protected static parsePullRequestDescription(description: string): {

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -25,8 +25,8 @@ MIME-Version: 1.0
 To: reviewer@example.com
 Cc: Some Body <somebody@example.com>
 
-This Pull Request contains some really important changes that I would love to
-have included in git.git.
+This Pull Request contains some really important changes that I would love
+to have included in git.git [https://github.com/git/git].
 
 Contributor (1):
   B
@@ -195,10 +195,11 @@ test("generate tag/notes from a Pull Request", async () => {
     const headCommit = await revParse("HEAD", workDir);
 
     const pullRequestURL = "https://github.com/gitgitgadget/git/pull/1";
+    // tslint:disable-next-line:max-line-length
     const description = `My first Pull Request!
 
-This Pull Request contains some really important changes that I would love to
-have included in git.git.
+This Pull Request contains some really important changes that I would love to${
+        ""} have included in [git.git](https://github.com/git/git).
 
 Cc: Some Body <somebody@example.com>
 `;
@@ -215,8 +216,8 @@ Cc: Some Body <somebody@example.com>
 
     expect(patches.coverLetter).toEqual(`My first Pull Request!
 
-This Pull Request contains some really important changes that I would love to
-have included in git.git.`);
+This Pull Request contains some really important changes that I would love
+to have included in git.git [https://github.com/git/git].`);
 
     const mails = [];
     const midRegex = new RegExp("<(pull|[0-9a-f]{40})"
@@ -269,8 +270,8 @@ have included in git.git.`);
     expect((await git(["cat-file", "tag", "pr-1/somebody/master-v2"], gitOpts))
         .replace(/^[^]*?\n\n/, "")).toEqual(`My first Pull Request!
 
-This Pull Request contains some really important changes that I would love to
-have included in git.git.
+This Pull Request contains some really important changes that I would love
+to have included in git.git [https://github.com/git/git].
 
 Contributor (1):
   B


### PR DESCRIPTION
It was pointed out that long lines are hard to read, and the convention for Markdown (and hence, for PR descriptions on GitHub) is to have paragraphs in one long line, to be rendered (wrapped) when displayed.

When sending mails to the Git mailing list, it is expected that that rendering already happened. And this PR makes it so (as demonstrated by the updates to the tests).