### PR TITLE
tests: enforce `node` environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "nodemon --exec \"npm start\"",
     "lint": "tslint -c tslint.json '{lib,script,tests}/**/*.{ts,tsx}'",
     "start": "node server.js",
-    "test": "tslint --project . && jest",
+    "test": "tslint --project . && jest --env=node",
     "test:watch": "jest --watch --notify --notifyMode=change --coverage"
   },
   "bugs": {


### PR DESCRIPTION
This fixes the following error when running `npm run test` in a checkout
on Ubuntu 18.04 on Windows:

  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>