### PR TITLE
ci: upgrade to node.js v10.x

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pool:
 steps:
 - task: NodeTool@0
   inputs:
-    versionSpec: '8.x'
+    versionSpec: '10.x'
   displayName: 'Install Node.js'
 
 - script: |


### PR DESCRIPTION
In theory, the (very simple) GitGitGadget code should compile easily
with any node.js version that supports ES6. In practice, only a proper
test suite can give us enough confidence that that is the case.

Luckily, even GitGitGadget's rather sparse test suite covers enough to
give us that confidence, and we should be able to upgrade to node.js
v10.x without issues (because v8.x is expected to not receive any
regular updates anymore come April '19, and not even security updates
come December '19).

This addresses part of https://github.com/gitgitgadget/gitgitgadget/issues/63.