### PR TITLE
Fix GitGitGadget's open PRs -> cover letter Message-ID map

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -660,7 +660,8 @@ export class PatchSeries {
             if (!globalOptions.openPRs) {
                 globalOptions.openPRs = {};
             }
-            globalOptions.openPRs[this.metadata.pullRequestURL] = "";
+            globalOptions.openPRs[this.metadata.pullRequestURL] =
+                coverMid || "";
             await this.notes.set("", globalOptions, true);
         }
 


### PR DESCRIPTION
By mistake, the Message-ID was left empty.