### PR TITLE
Upgrade Typescript to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5648,9 +5648,9 @@
       }
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ts-jest": "^24.0.2",
     "ts-node": "^6.2.0",
     "tslint": "^5.11.0",
-    "typescript": "^2.9.2"
+    "typescript": "^3.5.3"
   },
   "dependencies": {
     "@octokit/rest": "^16.25.0",


### PR DESCRIPTION
The latest octokit type definitions apparently are incompatible with the Typescript version we used before. Not sure why the CI build did not catch this...