### PR TITLE
Copy submitter to address issue 58

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -560,8 +560,15 @@ export class CIHelper {
                     coverMid}](https://public-inbox.org/git/${coverMid})`);
             } else if (command === "/allow") {
                 const accountName = argument || await getPRAuthor();
+                let extraComment = "";
                 try {
-                    await this.github.getGitHubUserName(accountName);
+                    const userInfo = await this.github.getGitHubUserInfo(
+                        accountName);
+                    if (userInfo.email === null) {
+                        extraComment = `\n\nWARNING: ${
+                            accountName} has no public email address` +
+                            " set on GitHub";
+                    }
                 } catch (reason) {
                     throw new Error(`User ${
                         accountName} is not a valid GitHub username.`);
@@ -569,7 +576,8 @@ export class CIHelper {
 
                 if (await gitGitGadget.allowUser(comment.author, accountName)) {
                     await addComment(`User ${
-                        accountName} is now allowed to use GitGitGadget.`);
+                        accountName} is now allowed to use GitGitGadget.${
+                        extraComment}`);
                 } else {
                     await addComment(`User ${
                         accountName} already allowed to use GitGitGadget.`);

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -537,27 +537,27 @@ export class CIHelper {
                 if (!pr.title || !pr.body) {
                     throw new Error("Ignoring PR with empty title and/or body");
                 }
-                const description = `${pr.title}\n\n${pr.body}`;
 
                 if (!pr.mergeable) {
                     throw new Error("Refusing to submit a patch series "
                         + "that does not merge cleanly.");
                 }
 
-                const fullAuthorName =
-                    await this.github.getGitHubUserName(comment.author);
-                if (!fullAuthorName) {
+                const userInfo =
+                    await this.github.getGitHubUserInfo(comment.author);
+                if (!userInfo.name) {
                     throw new Error(`Could not determine full name of ${
                         comment.author}`);
                 }
+                const extraComment = userInfo.email === null ?
+                    ( `\n\nWARNING: ${comment.author} has no public email` +
+                    " address set on GitHub" ) : "";
 
                 const coverMid =
-                 await gitGitGadget.submit(comment.author, fullAuthorName,
-                                           pullRequestURL, description,
-                                           pr.baseLabel, pr.baseCommit,
-                                           pr.headLabel, pr.headCommit);
+                    await gitGitGadget.submit(pr, userInfo);
                 await addComment(`Submitted as [${
-                    coverMid}](https://public-inbox.org/git/${coverMid})`);
+                    coverMid}](https://public-inbox.org/git/${coverMid})${
+                        extraComment}`);
             } else if (command === "/allow") {
                 const accountName = argument || await getPRAuthor();
                 let extraComment = "";

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -168,7 +168,10 @@ export class GitGitGadget {
     public async submit(pr: IPullRequestInfo, userInfo: IGitHubUser):
         Promise<string | undefined> {
 
-        const description = `${pr.title}\n\n${pr.body}`;
+        // if known, add submitter to email chain
+        const ccSubmitter = userInfo.email ? `\nCc: ${
+            userInfo.name} <${userInfo.email}>` : "";
+        const description = `${pr.title}\n\n${pr.body}${ccSubmitter}`;
 
         if (pr.baseOwner !== "gitgitgadget" || pr.baseRepo !== "git") {
             throw new Error(`Unsupported repository: ${pr.pullRequestURL}`);

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -20,6 +20,14 @@ export interface IPRComment {
     body: string;
     prNumber: number;
 }
+
+export interface IGitHubUser {
+    email: string;                  // null if no public email
+    login: string;
+    name: string;
+    type: string;
+}
+
 export class GitHubGlue {
     public workDir?: string;
     protected readonly client = new octokit();
@@ -258,6 +266,25 @@ export class GitHubGlue {
             author: response.data.user.login,
             body: response.data.body,
             prNumber,
+        };
+    }
+
+    /**
+     * Obtain basic information for a given GitHub user.
+     *
+     * @param login the GitHub login
+     */
+    public async getGitHubUserInfo(login: string): Promise<IGitHubUser> {
+        await this.ensureAuthenticated(); // required to get email
+
+        const response = await this.client.users.getByUsername({
+            username: login,
+        });
+        return {
+            email: response.data.email,
+            login: response.data.login,
+            name: response.data.name,
+            type: response.data.type,
         };
     }
 

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -9,10 +9,13 @@ export interface IPullRequestInfo {
     body: string;
     baseLabel: string;
     baseCommit: string;
+    baseOwner: string;
+    baseRepo: string;
     hasComments: boolean;
     headLabel: string;
     headCommit: string;
     mergeable: boolean;
+    number: number;
 }
 
 export interface IPRComment {
@@ -209,11 +212,14 @@ export class GitHubGlue {
                 author: pr.user.login,
                 baseCommit: pr.base.sha,
                 baseLabel: pr.base.label,
+                baseOwner: pr.base.repo.owner.login,
+                baseRepo: pr.base.repo.name,
                 body: pr.body,
                 hasComments: pr.updated_at !== pr.created_at,
                 headCommit: pr.head.sha,
                 headLabel: pr.head.label,
                 mergeable: true,
+                number: pr.number,
                 pullRequestURL: pr.html_url,
                 title: pr.title,
             });
@@ -238,11 +244,14 @@ export class GitHubGlue {
             author: response.data.user.login,
             baseCommit: response.data.base.sha,
             baseLabel: response.data.base.label,
+            baseOwner: response.data.base.repo.owner.login,
+            baseRepo: response.data.base.repo.name,
             body: response.data.body,
             hasComments: response.data.comments > 0,
             headCommit: response.data.head.sha,
             headLabel: response.data.head.label,
             mergeable: response.data.mergeable,
+            number: response.data.number,
             pullRequestURL: response.data.html_url,
             title: response.data.title,
         };


### PR DESCRIPTION
This change is done in three commits.  It is intended to address issue #58 where the person submitting changes is not the author (this may be a simplification of the problem being addressed).

The first adds a warning comment in the /allow if a user does not have a public email address.  

The second does the same during a /submit.  It also changes the signature for gitgitgadget::submit to only pass the pull request and user info.  Passing the pull request object removes the need for the CIHelper to know what gitgitgadget needs from the pull request.

The third commit simply adds the submitter to the cc list.