### PR TITLE
Add /preview PR comment

### DIFF
--- a/azure-function/index.js
+++ b/azure-function/index.js
@@ -3,7 +3,7 @@
  *
  * As Azure Functions do not support Typescript natively yet, we implement it in
  * pure Javascript and keep it as simple as possible.
- * 
+ *
  * Note: while the Azure Function Runtime v1 supported GitHub webhooks natively,
  * via the "webHookType", we want to use v2, so we have to do the payload
  * validation "by hand".
@@ -116,7 +116,7 @@ module.exports = async (context, req) => {
             }
 
             /* Only trigger the Pipeline for valid commands */
-            if (!comment.body || !comment.body.match(/^\/(submit|allow|disallow|test)\b/)) {
+            if (!comment.body || !comment.body.match(/^\/(submit|preview|allow|disallow|test)\b/)) {
                 context.res = {
                     body: `Not a command: '${comment.body}'`,
                 };

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -540,6 +540,24 @@ export class CIHelper {
                 await addComment(`Submitted as [${
                     coverMid}](https://public-inbox.org/git/${coverMid})${
                         extraComment}`);
+            } else if (command === "/preview") {
+                if (argument && argument !== "") {
+                    throw new Error(`/preview does not accept arguments ('${
+                        argument}')`);
+                }
+
+                const pr = await this.getPRInfo(comment.prNumber,
+                                                pullRequestURL);
+                const userInfo = await this.getUserInfo(comment.author);
+
+                if (!userInfo.email) {
+                    throw new Error(`Could not determine public email of ${
+                        comment.author}`);
+                }
+
+                const coverMid =
+                    await gitGitGadget.preview(pr, userInfo);
+                await addComment(`Preview email sent as ${coverMid}`);
             } else if (command === "/allow") {
                 const accountName = argument || await getPRAuthor();
                 let extraComment = "";

--- a/lib/patch-series-options.ts
+++ b/lib/patch-series-options.ts
@@ -1,6 +1,7 @@
 export class PatchSeriesOptions {
     public redo?: boolean;
     public dryRun?: boolean;
+    public noUpdate?: boolean;
     public rfc?: boolean;
     public patience?: boolean;
 }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -519,7 +519,7 @@ export class PatchSeries {
 
             const endOfLine = mail.indexOf("\n", dateOffset);
             mails[i] = mail.substr(0, dateOffset) +
-                new Date(time - j * 1000).toUTCString()
+                new Date(time - j * 1000).toUTCString().replace(/GMT$/, "+0000")
                 + mail.substr(endOfLine);
             count++;
         }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -675,7 +675,7 @@ export class PatchSeries {
                                                        this.project.basedOn);
         }
 
-        if (this.options.dryRun) {
+        if (this.options.noUpdate) {
             logger.log("Would generate tag " + tagName
                 + " with message:\n\n"
                 + tagMessage.split("\n").map((line: string) => {
@@ -780,16 +780,14 @@ export class PatchSeries {
         }
 
         logger.log("Publishing branch and tag");
-        if (this.project.publishToRemote && !this.options.dryRun) {
-            await this.publishBranch(tagName);
-        }
+        await this.publishBranch(tagName);
 
         if (!this.options.dryRun) {
             const key = this.metadata.pullRequestURL || this.project.branchName;
             await this.notes.set(key, this.metadata, true);
         }
 
-        if (!this.options.dryRun && publishTagsAndNotesToRemote) {
+        if (!this.options.noUpdate && publishTagsAndNotesToRemote) {
             await git(["push", publishTagsAndNotesToRemote, this.notes.notesRef,
                        `refs/tags/${tagName}`],
                       { workDir: this.notes.workDir });
@@ -860,7 +858,7 @@ export class PatchSeries {
     }
 
     protected async publishBranch(tagName: string): Promise<void> {
-        if (!this.project.publishToRemote || this.options.dryRun) {
+        if (!this.project.publishToRemote || this.options.noUpdate) {
             return;
         }
 

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -120,6 +120,7 @@ export class PatchSeries {
                                      pullRequestDescription: string,
                                      baseLabel: string, baseCommit: string,
                                      headLabel: string, headCommit: string,
+                                     options: PatchSeriesOptions,
                                      senderName?: string):
         Promise<PatchSeries> {
         const workDir = notes.workDir;
@@ -182,7 +183,6 @@ export class PatchSeries {
             throw new Error(`Cannot find base branch ${basedOn}`);
         }
 
-        const options = new PatchSeriesOptions();
         const publishToRemote = undefined;
 
         const project = await ProjectOptions.get(workDir, headCommit, cc || [],

--- a/res/WELCOME.md
+++ b/res/WELCOME.md
@@ -21,6 +21,8 @@ Once on the list of permitted usernames, you can contribute the patches to the G
 
 After you submit, GitGitGadget will respond with another comment that contains the link to the cover letter mail in the Git mailing list archive. Please make sure to monitor the discussion in that thread and to address comments and suggestions.
 
+If you want to see what email(s) would be sent for a submit request, add a PR comment `/preview` to have the email(s) sent to you.  You must have a public GitHub email address for this.
+
 If you do not want to subscribe to the Git mailing list just to be able to respond to a mail, you can download the mbox ("raw") file corresponding to the mail you want to reply to from the Git mailing list. If you use GMail, you can upload that raw mbox file via:
 
 ```sh

--- a/script/mail-patch-series.ts
+++ b/script/mail-patch-series.ts
@@ -81,6 +81,7 @@ async function main(argv: string[]) {
             options.redo = true;
         } else if (arg === "--dry-run" || arg === "-n") {
             options.dryRun = true;
+            options.noUpdate = true;
         } else if (arg === "--rfc") {
             options.rfc = true;
             // tslint:disable-next-line:no-conditional-assignment

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -212,7 +212,7 @@ Cc: Some Body <somebody@example.com>
         await PatchSeries.getFromNotes(notes, pullRequestURL, description,
                                        "gitgitgadget:next", baseCommit,
                                        "somebody:master", headCommit,
-                                       "GitHub User");
+                                       {}, "GitHub User");
 
     expect(patches.coverLetter).toEqual(`My first Pull Request!
 
@@ -242,7 +242,7 @@ to have included in git.git [https://github.com/git/git].`);
         await PatchSeries.getFromNotes(notes, pullRequestURL, description,
                                        "gitgitgadget:next", baseCommit,
                                        "somebody:master", headCommit2,
-                                       "GitHub User");
+                                       {}, "GitHub User");
     mails.splice(0);
     expect(await patches2.generateAndSend(logger, send, undefined,
                                           pullRequestURL))


### PR DESCRIPTION
This PR addresses issue #83.  An update to gitgitgadget/gitgitgadget.github.io will be done if/when approved.

The /preview comment will only send the emails to the commentor.

The email subject prefix will be PREVIEW instead of PATCH to
identify the email.

A new flag PatchSeriesOptions::noUpdate replaces some of the function
of the dryRun flag to prevent updates to the repos.