### PR TITLE
Support additional nodemailer options

### DIFF
--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -62,6 +62,8 @@ export class GitGitGadget {
                                          gitGitGadgetDir);
         const smtpPass = await gitConfig("gitgitgadget.smtpPass",
                                          gitGitGadgetDir);
+        const smtpOpts = await gitConfig("gitgitgadget.smtpOpts",
+                                         gitGitGadgetDir);
         if (!smtpUser || !smtpHost || !smtpPass) {
             throw new Error(`No SMTP settings configured`);
         }
@@ -69,7 +71,7 @@ export class GitGitGadget {
         const [options, allowedUsers] = await GitGitGadget.readOptions(notes);
 
         return new GitGitGadget(notes, options, allowedUsers,
-                                smtpUser, smtpHost, smtpPass,
+                                { smtpHost, smtpOpts, smtpPass, smtpUser },
                                 publishTagsAndNotesToRemote);
     }
 
@@ -109,7 +111,7 @@ export class GitGitGadget {
     protected constructor(notes: GitNotes,
                           options: IGitGitGadgetOptions,
                           allowedUsers: Set<string>,
-                          smtpUser: string, smtpHost: string, smtpPass: string,
+                          smtpOptions: ISMTPOptions,
                           publishTagsAndNotesToRemote: string) {
         if (!notes.workDir) {
             throw new Error(`Could not determine Git worktree`);
@@ -119,7 +121,7 @@ export class GitGitGadget {
         this.options = options;
         this.allowedUsers = allowedUsers;
 
-        this.smtpOptions = { smtpHost, smtpPass, smtpUser };
+        this.smtpOptions = smtpOptions;
 
         this.publishTagsAndNotesToRemote = publishTagsAndNotesToRemote;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["es6", "es2017.object"],          /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
For testing, an alternate SMTP server may be used to avoid sending
emails.  Setting "gitgitgadget.smtpOpts" in the git config will
allow other nodemailer options to be specified.

Ethereal.email is an example server which does not actually send the
emails.  It does require other options to be passed to nodemailer.

Sample setting:
    await worktree.git(["config",
        '--add', "gitgitgadget.smtpHost", "smtp.ethereal.email"]);
    await worktree.git(["config",
        '--add', "gitgitgadget.smtpOpts",
        '{ "port": 587, "secure": false,
		"tls": { "rejectUnauthorized": false } }']);