### PR TITLE
CONTRIBUTING: fix links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,16 @@
 # Contributing
 
-[fork]: /fork
-[pr]: /compare
+[fork]: https://github.com/gitgitgadget/gitgitgadget/fork
+[pr]: ../../compare
 [style]: https://palantir.github.io/tslint/
 [code-of-conduct]: CODE_OF_CONDUCT.md
+[TODO]: TODO.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
 Please note that this project is released with a [Contributor Code of Conduct][code-of-conduct]. By participating in this project you agree to abide by its terms.
 
-Now, if you are looking for ideas what you could improve in GitGitGadget, there is an extensive [TODO](TODO) list. If you want to add your idea to that TODO list, that's fine, too!
+Now, if you are looking for ideas what you could improve in GitGitGadget, there is an extensive [TODO][TODO] list. If you want to add your idea to that TODO list, that's fine, too!
 
 Most likely you read this because you want to Get Started hacking on GitGitGadget, right? Probably the best way is to install [VS Code](https://code.visualstudio.com/) (no worries, it is Open Source and works out of the box on Linux, macOS and Windows).
 And if you want to dive into the source code to Get Things Done, here is a little overview what is done where:
@@ -33,7 +34,7 @@ Happy coding!
 1. Make sure the tests pass on your machine: `npm test`, note: these tests also apply the linter, so no need to lint separately
 1. Create a new branch: `git checkout -b my-branch-name`
 1. Make your change, add tests, and make sure the tests still pass
-1. Push to your fork and [submit a pull request][pr]
+1. Push to your fork and [submit a pull request][pr] (click "compare across forks")
 1. Pat your self on the back and wait for your pull request to be reviewed and merged.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:


### PR DESCRIPTION
- The link to the TODO was missing the '.md' extension so it
did not work.
- The links for forking the repo and opening a PR did not work
because GitHub automatically adds '/blob/$branch' to relative links

For PRs I did not find a URL trick to automatically activate the "Compare across forks" function. Should I add a mention of this link? like this:
~~~diff
diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
index 9987e9e..308ad7f 100644
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Happy coding!
 1. Make sure the tests pass on your machine: `npm test`, note: these tests also apply the linter, so no need to lint separately
 1. Create a new branch: `git checkout -b my-branch-name`
 1. Make your change, add tests, and make sure the tests still pass
-1. Push to your fork and [submit a pull request][pr]
+1. Push to your fork and [submit a pull request][pr] (click "compare across forks")
 1. Pat your self on the back and wait for your pull request to be reviewed and merged.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
~~~