### PR TITLE
welcome: add pointers to git-mentoring, IRC

### DIFF
--- a/res/WELCOME.md
+++ b/res/WELCOME.md
@@ -38,3 +38,18 @@ If you do not want to subscribe to the Git mailing list just to be able to respo
 ```sh
 curl -g --user "<EMailAddress>:<Password>" --url "imaps://imap.gmail.com/INBOX" -T /path/to/raw.txt
 ```
+
+## Need help?
+
+New contributors who want advice are encouraged to join
+[git-mentoring@googlegroups.com](https://groups.google.com/forum/#!forum/git-mentoring),
+where volunteers who regularly contribute to Git are willing to answer newbie
+questions, give advice, or otherwise provide mentoring to interested
+contributors. You must join in order to post or view messages, but anyone can
+join.
+
+You may also be able to find help in real time in the developer IRC channel,
+[`#git-devel`](https://webchat.freenode.net/#git-devel) on Freenode. Remember
+that IRC does not support offline messaging, so if you send someone a private
+message and log out, they cannot respond to you. The scrollback of `#git-devel`
+is [archived](https://colabti.org/irclogger//irclogger_logs/git-devel), though.


### PR DESCRIPTION
Since many contributors head to GitGitGadget for their first
contribution, advertise help channels which are likely to be useful: the
git-mentoring email list and the #git-devel IRC.

Signed-off-by: Emily Shaffer <emilyshaffer@google.com>