### PR TITLE
Allow GitGitGadget to Work Without a PR Template

### DIFF
--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -260,14 +260,19 @@ export class GitGitGadget {
         // update work repo from base
         await this.updateNotesAndPullRef(pr.number, previousTag);
 
-        // Remove template from description
-        let prTemplate =
-            await git(["show",
-                       "upstream/master:.github/PULL_REQUEST_TEMPLATE.md"],
-                      { workDir: this.workDir });
-        // github uses \r\n so make sure it is set
-        prTemplate = prTemplate.replace(/([^\r])\n/, "$1\r\n");
-        const prBody = pr.body.replace(prTemplate, "");
+        // Remove template from description (if template exists)
+        let prBody: string;
+        try {
+            let prTemplate =
+                await git(["show",
+                           "upstream/master:.github/PULL_REQUEST_TEMPLATE.md"],
+                          { workDir: this.workDir });
+            // github uses \r\n so make sure it is set
+            prTemplate = prTemplate.replace(/\r?\n/g, "\r\n");
+            prBody = pr.body.replace(prTemplate, "");
+        } catch {
+            prBody = pr.body;
+        }
 
         if (!prBody.length) {       // reject empty description
             throw new Error("A pull request description must be provided");

--- a/tests/test-lib.ts
+++ b/tests/test-lib.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import * as path from "path";
 import * as util from "util";
 import { isDirectory, isFile } from "../lib/fs-util";
 import { git, IGitOptions, revParse } from "../lib/git";
@@ -45,6 +46,11 @@ export class TestRepo {
 
         if (!fileName) {
             fileName = `${message}.t`;
+        }
+
+        const fPath = path.dirname(`${this.workDir}/${fileName}`);
+        if (fPath !== this.workDir) {
+            await mkdir(fPath, { recursive: true });
         }
 
         await writeFile(`${this.workDir}/${fileName}`, contents || message);


### PR DESCRIPTION
To support other projects and testing, `try/catch` to avoid errors if there is no template file.

In `TestRepo.commit()`, create directories if they are present in the `fileName` parameter.