### PR TITLE
Replace the confusing `--work-dir` option by two options (that actually work)

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -23,15 +23,15 @@ export class CIHelper {
     public readonly notes: GitNotes;
     protected readonly mail2commit: MailCommitMapping;
     protected readonly github: GitHubGlue;
-    protected readonly gggConfig: string;
+    protected readonly gggConfigDir: string;
     protected commit2mailNotes: GitNotes | undefined;
     protected testing: boolean;
     private gggNotesUpdated: boolean;
     private mail2CommitMapUpdated: boolean;
 
     public constructor(workDir?: string, skipUpdate?: boolean,
-                       gggConfig = ".") {
-        this.gggConfig = gggConfig;
+                       gggConfigDir = ".") {
+        this.gggConfigDir = gggConfigDir;
         this.workDir = workDir;
         this.notes = new GitNotes(workDir);
         this.gggNotesUpdated = !!skipUpdate;
@@ -527,7 +527,7 @@ export class CIHelper {
         };
 
         try {
-            const gitGitGadget = await GitGitGadget.get(this.gggConfig,
+            const gitGitGadget = await GitGitGadget.get(this.gggConfigDir,
                                                         this.workDir);
             if (!gitGitGadget.isUserAllowed(comment.author)) {
                 throw new Error(`User ${


### PR DESCRIPTION
`--work-dir` did not actually do anything.

Besides, we need _two_ options, one to override the current working directory as the one to be used as GitGitGadget worktree, and one to override the config setting in that worktree that points to the _git.git_ working directory.

This PR makes it so. It is based on #165.