### PR TITLE
Fix the formatting of the "Need help?" section

### DIFF
--- a/res/WELCOME.md
+++ b/res/WELCOME.md
@@ -41,15 +41,6 @@ curl -g --user "<EMailAddress>:<Password>" --url "imaps://imap.gmail.com/INBOX" 
 
 ## Need help?
 
-New contributors who want advice are encouraged to join
-[git-mentoring@googlegroups.com](https://groups.google.com/forum/#!forum/git-mentoring),
-where volunteers who regularly contribute to Git are willing to answer newbie
-questions, give advice, or otherwise provide mentoring to interested
-contributors. You must join in order to post or view messages, but anyone can
-join.
+New contributors who want advice are encouraged to join [git-mentoring@googlegroups.com](https://groups.google.com/forum/#!forum/git-mentoring), where volunteers who regularly contribute to Git are willing to answer newbie questions, give advice, or otherwise provide mentoring to interested contributors. You must join in order to post or view messages, but anyone can join.
 
-You may also be able to find help in real time in the developer IRC channel,
-[`#git-devel`](https://webchat.freenode.net/#git-devel) on Freenode. Remember
-that IRC does not support offline messaging, so if you send someone a private
-message and log out, they cannot respond to you. The scrollback of `#git-devel`
-is [archived](https://colabti.org/irclogger//irclogger_logs/git-devel), though.
+You may also be able to find help in real time in the developer IRC channel, [`#git-devel`](https://webchat.freenode.net/#git-devel) on Freenode. Remember that IRC does not support offline messaging, so if you send someone a private message and log out, they cannot respond to you. The scrollback of `#git-devel` is [archived](https://colabti.org/irclogger//irclogger_logs/git-devel), though.


### PR DESCRIPTION
In Markdown, it is best not to have line breaks inside paragraphs because most Markdown renderers interpret those as forced line breaks. But we did. And this PR fixes that.

Cc: @nasamuffin 