### PR TITLE
Fix Cc: footer handling

### DIFF
--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -271,29 +271,9 @@ export class GitGitGadget {
         // update work repo from base
         await this.updateNotesAndPullRef(pr.baseOwner, pr.number, previousTag);
 
-        // Remove template from description (if template exists)
-        let prBody: string;
-        try {
-            let prTemplate =
-                await git(["show",
-                           "upstream/master:.github/PULL_REQUEST_TEMPLATE.md"],
-                          { workDir: this.workDir });
-            // github uses \r\n so make sure it is set
-            prTemplate = prTemplate.replace(/\r?\n/g, "\r\n");
-            prBody = pr.body.replace(prTemplate, "");
-        } catch {
-            prBody = pr.body;
-        }
-
-        if (!prBody.length) {       // reject empty description
-            throw new Error("A pull request description must be provided");
-        }
-
-        const description = `${pr.title}\n\n${prBody}`;
-
         const series =
             await PatchSeries.getFromNotes(this.notes, pr.pullRequestURL,
-                                           description, pr.baseLabel,
+                                           pr.title, pr.body, pr.baseLabel,
                                            pr.baseCommit, pr.headLabel,
                                            pr.headCommit, options,
                                            userInfo.name, userInfo.email);

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -289,17 +289,14 @@ export class GitGitGadget {
             throw new Error("A pull request description must be provided");
         }
 
-        // if known, add submitter to email chain
-        const ccSubmitter = userInfo.email ? `\nCc: ${
-            userInfo.name} <${userInfo.email}>` : "";
-        const description = `${pr.title}\n\n${prBody}${ccSubmitter}`;
+        const description = `${pr.title}\n\n${prBody}`;
 
         const series =
             await PatchSeries.getFromNotes(this.notes, pr.pullRequestURL,
                                            description, pr.baseLabel,
                                            pr.baseCommit, pr.headLabel,
                                            pr.headCommit, options,
-                                           userInfo.name);
+                                           userInfo.name, userInfo.email);
 
         const coverMid =
             await series.generateAndSend(console, send,

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -121,7 +121,8 @@ export class PatchSeries {
                                      baseLabel: string, baseCommit: string,
                                      headLabel: string, headCommit: string,
                                      options: PatchSeriesOptions,
-                                     senderName?: string):
+                                     senderName?: string,
+                                     senderEmail?: string):
         Promise<PatchSeries> {
         const workDir = notes.workDir;
         if (!workDir) {
@@ -179,6 +180,11 @@ export class PatchSeries {
             cc,
             coverLetter,
         } = PatchSeries.parsePullRequestDescription(pullRequestDescription);
+
+        // if known, add submitter to email chain
+        if (senderEmail) {
+            cc.push(`${senderName} <${senderEmail}>`);
+        }
 
         if (basedOn && !revParse(basedOn, workDir)) {
             throw new Error(`Cannot find base branch ${basedOn}`);

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -186,7 +186,7 @@ export class PatchSeries {
 
         const publishToRemote = undefined;
 
-        const project = await ProjectOptions.get(workDir, headCommit, cc || [],
+        const project = await ProjectOptions.get(workDir, headCommit, cc,
                                                  basedOn, publishToRemote,
                                                  baseCommit);
 
@@ -200,17 +200,16 @@ export class PatchSeries {
     protected static parsePullRequestDescription(description: string): {
         coverLetter: string,
         basedOn?: string,
-        cc?: string[],
+        cc: string[],
     } {
         let basedOn;
-        let cc: string[] | undefined;
+        const cc: string[] = [];
         let coverLetter = description.trim();
 
         // parse the footers of the pullRequestDescription
         const match = description.match(/^([^]+)\n\n([^]+)$/);
         if (match) {
             coverLetter = match[1];
-            cc = [];
             const footer: string[] = [];
             for (const line of match[2].trimRight().split("\n")) {
                 const match2 = line.match(/^([-A-Za-z]+:) (.*)\n?$/);

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -235,13 +235,13 @@ export class PatchSeries {
             throw new Error("A pull request description must be provided");
         }
 
-        const description = `${prTitle}\n\n${prBody}`;
-
         const {
             basedOn,
             cc,
-            coverLetter,
-        } = PatchSeries.parsePullRequestDescription(description);
+            coverLetterBody,
+        } = PatchSeries.parsePullRequestBody(prBody);
+
+        const coverLetter = `${prTitle}\n\n${coverLetterBody}`;
 
         const wrapCoverLetterAtColumn = 76;
         const wrappedLetter = md2text(coverLetter, wrapCoverLetterAtColumn);
@@ -253,19 +253,19 @@ export class PatchSeries {
         };
     }
 
-    protected static parsePullRequestDescription(description: string): {
-        coverLetter: string,
+    protected static parsePullRequestBody(prBody: string): {
+        coverLetterBody: string,
         basedOn?: string,
         cc: string[],
     } {
         let basedOn;
         const cc: string[] = [];
-        let coverLetter = description.trim();
+        let coverLetterBody = prBody.trim();
 
         // parse the footers of the pullRequestDescription
-        const match = description.match(/^([^]+)\n\n([^]+)$/);
+        const match = prBody.match(/^([^]+)\n\n([^]+)$/);
         if (match) {
-            coverLetter = match[1];
+            coverLetterBody = match[1];
             const footer: string[] = [];
             for (const line of match[2].trimRight().split("\n")) {
                 const match2 = line.match(/^([-A-Za-z]+:) (.*)$/);
@@ -290,13 +290,13 @@ export class PatchSeries {
             }
 
             if (footer.length > 0) {
-                coverLetter += `\n\n${footer.join("\n")}`;
+                coverLetterBody += `\n\n${footer.join("\n")}`;
             }
         }
         return {
             basedOn,
             cc,
-            coverLetter,
+            coverLetterBody,
         };
     }
 

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -213,14 +213,19 @@ export class PatchSeries {
         basedOn?: string,
         cc: string[],
     }> {
+        // Replace \r\n with \n to simplify remaining parsing.
+        // Note that md2text() in the end will do the replacement anyway.
+        prBody = prBody.replace(/\r\n/g, "\n");
+
         // Remove template from description (if template exists)
         try {
             let prTemplate =
                 await git(["show",
                            "upstream/master:.github/PULL_REQUEST_TEMPLATE.md"],
                           { workDir });
-            // github uses \r\n so make sure it is set
-            prTemplate = prTemplate.replace(/\r?\n/g, "\r\n");
+            // Depending on the core.autocrlf setting, the template may contain
+            // \r\n line endings.
+            prTemplate = prTemplate.replace(/\r\n/g, "\n");
             prBody = prBody.replace(prTemplate, "");
         } catch {
             // Just ignore it
@@ -263,7 +268,7 @@ export class PatchSeries {
             coverLetter = match[1];
             const footer: string[] = [];
             for (const line of match[2].trimRight().split("\n")) {
-                const match2 = line.match(/^([-A-Za-z]+:) (.*)\n?$/);
+                const match2 = line.match(/^([-A-Za-z]+:) (.*)$/);
                 if (!match2) {
                     footer.push(line);
                 } else {

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -272,15 +272,15 @@ export class PatchSeries {
                 if (!match2) {
                     footer.push(line);
                 } else {
-                    switch (match2[1]) {
-                        case "Based-On":
+                    switch (match2[1].toLowerCase()) {
+                        case "based-on":
                             if (basedOn) {
                                 throw new Error(`Duplicate Based-On footer: ${
                                     basedOn} vs ${match2[2]}`);
                             }
                             basedOn = match2[2];
                             break;
-                        case "Cc:":
+                        case "cc:":
                             cc.push(match2[2]);
                             break;
                         default:

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -179,7 +179,7 @@ export class PatchSeries {
             basedOn,
             cc,
             coverLetter,
-        } = PatchSeries.parsePullRequestDescription(pullRequestDescription);
+        } = PatchSeries.parsePullRequest(pullRequestDescription);
 
         // if known, add submitter to email chain
         if (senderEmail) {
@@ -196,11 +196,31 @@ export class PatchSeries {
                                                  basedOn, publishToRemote,
                                                  baseCommit);
 
-        const wrapCoverLetterAtColumn = 76;
         return new PatchSeries(notes, options, project, metadata,
                                rangeDiff,
-                               md2text(coverLetter, wrapCoverLetterAtColumn),
+                               coverLetter,
                                senderName);
+    }
+
+    protected static parsePullRequest(description: string): {
+        coverLetter: string,
+        basedOn?: string,
+        cc: string[],
+    } {
+        const {
+            basedOn,
+            cc,
+            coverLetter,
+        } = PatchSeries.parsePullRequestDescription(description);
+
+        const wrapCoverLetterAtColumn = 76;
+        const wrappedLetter = md2text(coverLetter, wrapCoverLetterAtColumn);
+
+        return {
+            basedOn,
+            cc,
+            coverLetter: wrappedLetter,
+        };
     }
 
     protected static parsePullRequestDescription(description: string): {

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -212,7 +212,7 @@ Cc: Some Body <somebody@example.com>
         await PatchSeries.getFromNotes(notes, pullRequestURL, description,
                                        "gitgitgadget:next", baseCommit,
                                        "somebody:master", headCommit,
-                                       {}, "GitHub User");
+                                       {}, "GitHub User", undefined);
 
     expect(patches.coverLetter).toEqual(`My first Pull Request!
 
@@ -243,7 +243,7 @@ to have included in git.git [https://github.com/git/git].`);
         await PatchSeries.getFromNotes(notes, pullRequestURL, description,
                                        "gitgitgadget:next", baseCommit,
                                        "somebody:master", headCommit2,
-                                       {}, "GitHub User");
+                                       {}, "GitHub User", undefined);
     mails.splice(0);
     expect(await patches2.generateAndSend(logger, send, undefined,
                                           pullRequestURL))

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -193,23 +193,21 @@ test("generate tag/notes from a Pull Request", async () => {
     const headCommit = await repo.revParse("HEAD");
 
     const pullRequestURL = "https://github.com/gitgitgadget/git/pull/1";
+    const pullRequestTitle = "My first Pull Request!";
     // tslint:disable-next-line:max-line-length
-    const description = `My first Pull Request!
-
-This Pull Request contains some really important changes that I would love to${
+    const pullRequestBody = `This Pull Request contains some really important changes that I would love to${
         ""} have included in [git.git](https://github.com/git/git).
 
 Cc: Some Body <somebody@example.com>
 `;
-    const match2 = description.match(/^([^]+)\n\n([^]+)$/);
-    expect(match2).toBeTruthy();
 
     await git(["config", "user.name", "GitGitGadget"], repo.options);
     await git(["config", "user.email", "gitgitgadget@example.com"],
               repo.options);
 
     const patches =
-        await PatchSeries.getFromNotes(notes, pullRequestURL, description,
+        await PatchSeries.getFromNotes(notes, pullRequestURL, pullRequestTitle,
+                                       pullRequestBody,
                                        "gitgitgadget:next", baseCommit,
                                        "somebody:master", headCommit,
                                        {}, "GitHub User", undefined);
@@ -240,7 +238,8 @@ to have included in git.git [https://github.com/git/git].`);
 
     const headCommit2 = await repo.revParse("HEAD");
     const patches2 =
-        await PatchSeries.getFromNotes(notes, pullRequestURL, description,
+        await PatchSeries.getFromNotes(notes, pullRequestURL, pullRequestTitle,
+                                       pullRequestBody,
                                        "gitgitgadget:next", baseCommit,
                                        "somebody:master", headCommit2,
                                        {}, "GitHub User", undefined);

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -423,6 +423,7 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
                 "some description goes here",
                 "",
                 "Cc: Some Contributor <contributor@example.com>",
+                "CC: Capital Letters <shout@out.loud>",
                 "Cc: Git Maintainer <maintainer@gmail.com>",
                 "This is PR template",
                 "Please read our guide to continue",
@@ -434,6 +435,7 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
 
             expect(parsed.cc).toEqual([
                 "Some Contributor <contributor@example.com>",
+                "Capital Letters <shout@out.loud>",
                 "Git Maintainer <maintainer@gmail.com>",
             ]);
 


### PR DESCRIPTION
This PR fixes two different problems, each of them prevented `Cc:` footers from working for me.

Quick digging shows that I'm not alone here:
1. https://github.com/gitgitgadget/git/pull/445 --- [only one CC is handled](https://public-inbox.org/git/pull.445.v4.git.1575381738.gitgitgadget@gmail.com/) 
2. https://github.com/gitgitgadget/git/pull/441 --- [only one CC is handled](https://public-inbox.org/git/pull.441.git.1572554506.gitgitgadget@gmail.com/)
3. https://github.com/gitgitgadget/git/pull/427 --- [CC is ignored](https://public-inbox.org/git/pull.427.git.1572012816.gitgitgadget@gmail.com/)

