### PR TITLE
Switch from public-inbox.org to lore.kernel.org

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -101,7 +101,7 @@ The principal way to interact with GitGitGadget is by opening a Pull Request at
 <https://github.com/gitgitgadget/git>. The patch submission is then triggered by
 a command given in a single comment to that PR. GitGitGadget will follow up with
 a comment describing details of the patch submission, such as the link to the
-cover letter in [Git's mailing list archive](https://public-inbox.org/git).
+cover letter in [Git's mailing list archive](https://lore.kernel.org/git).
 
 Any other interesting information that can be inferred automatically will be
 added in the form of further comments to the same Pull Request.
@@ -113,7 +113,7 @@ automatically.
 ### Background tasks
 
 The repositories <https://github.com/gitster/git> (and
-<https://public-inbox.org/git)>) are monitored via dedicated [Azure
+<https://lore.kernel.org/git)>) are monitored via dedicated [Azure
 Pipelines](https://dev.azure.com/gitgitgadget/git/_build?definitionId=3),
 backed by Typescript code in <https://github.com/gitgitgadget/gitgitgadget>.
 

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -4,10 +4,10 @@ import { commitExists, git } from "./git";
 import { GitNotes } from "./git-notes";
 import { GitGitGadget, IGitGitGadgetOptions } from "./gitgitgadget";
 import { GitHubGlue, IGitHubUser, IPullRequestInfo } from "./github-glue";
+import { MailArchiveGitHelper } from "./mail-archive-helper";
 import { MailCommitMapping } from "./mail-commit-mapping";
 import { IMailMetadata } from "./mail-metadata";
 import { IPatchSeriesMetadata } from "./patch-series-metadata";
-import { PublicInboxGitHelper } from "./public-inbox-helper";
 
 const readFile = util.promisify(fs.readFile);
 
@@ -557,7 +557,7 @@ export class CIHelper {
                 const coverMid =
                     await gitGitGadget.submit(pr, userInfo);
                 await addComment(`Submitted as [${
-                    coverMid}](https://public-inbox.org/git/${coverMid})${
+                    coverMid}](https://lore.kernel.org/git/${coverMid})${
                         extraComment}`);
             } else if (command === "/preview") {
                 if (argument && argument !== "") {
@@ -634,19 +634,19 @@ export class CIHelper {
         }
     }
 
-    public async handleNewMails(publicInboxGitDir: string,
+    public async handleNewMails(mailArchiveGitDir: string,
                                 onlyPRs?: Set<number>): Promise<boolean> {
-        await git(["fetch"], { workDir: publicInboxGitDir });
+        await git(["fetch"], { workDir: mailArchiveGitDir });
         const prFilter = !onlyPRs ? undefined :
             (pullRequestURL: string): boolean => {
                 const match = pullRequestURL.match(/.*\/(\d+)$/);
                 return !match ? false : onlyPRs.has(parseInt(match[1], 10));
             };
         await this.maybeUpdateGGGNotes();
-        const publicInboxGit =
-            await PublicInboxGitHelper.get(this.notes, publicInboxGitDir,
+        const mailArchiveGit =
+            await MailArchiveGitHelper.get(this.notes, mailArchiveGitDir,
                                            this.github);
-        return await publicInboxGit.processMails(prFilter);
+        return await mailArchiveGit.processMails(prFilter);
     }
 
     private async getPRInfo(prNumber: number, pullRequestURL: string):

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -84,7 +84,12 @@ export class PatchSeries {
             const tagMessage = await git(["cat-file", "tag", latestTag]);
             match = tagMessage.match(/^[\s\S]*?\n\n([\s\S]*)/);
             (match ? match[1] : tagMessage).split("\n").map((line) => {
-                match = line.match(/https:\/\/public-inbox\.org\/.*\/([^\/]+)/);
+                // tslint:disable-next-line:max-line-length
+                match = line.match(/https:\/\/lore\.kernel\.org\/.*\/([^\/]+)/);
+                if (!match) {
+                    // tslint:disable-next-line:max-line-length
+                    match = line.match(/https:\/\/public-inbox\.org\/.*\/([^\/]+)/);
+                }
                 if (!match) {
                     // tslint:disable-next-line:max-line-length
                     match = line.match(/https:\/\/www\.mail-archive\.com\/.*\/([^\/]+)/);

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -58,7 +58,7 @@ export class ProjectOptions {
                           { workDir })) {
                 upstreamBranch = "upstream/master";
             }
-            midUrlPrefix = "https://public-inbox.org/git/";
+            midUrlPrefix = "https://lore.kernel.org/git/";
         } else if (await commitExists("a3acbf46947e52ff596", workDir)) {
             // Cygwin
             to = "--to=cygwin-patches@cygwin.com";

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -410,17 +410,17 @@ async function getCIHelper(): Promise<CIHelper> {
 
         await ci.handlePush(repositoryOwner, prNumber);
     } else if (command === "handle-new-mails") {
-        const publicInboxGitDir =
-            await gitConfig("gitgitgadget.publicInboxGitDir");
-        if (!publicInboxGitDir) {
-            process.stderr.write("Need a public-inbox/git worktree");
+        const mailArchiveGitDir =
+            await gitConfig("gitgitgadget.loreGitDir");
+        if (!mailArchiveGitDir) {
+            process.stderr.write("Need a lore.kernel/git worktree");
             process.exit(1);
         }
         const onlyPRs = new Set<number>();
         for (const arg of commander.args.slice(1)) {
             onlyPRs.add(parseInt(arg, 10));
         }
-        await ci.handleNewMails(publicInboxGitDir!,
+        await ci.handleNewMails(mailArchiveGitDir!,
                                 onlyPRs.size ? onlyPRs : undefined);
     } else {
         process.stderr.write(`${command}: unhandled sub-command\n`);

--- a/script/search-commit-on-mail-archive.sh
+++ b/script/search-commit-on-mail-archive.sh
@@ -2,25 +2,25 @@
 
 for c in "$@"
 do
-	m="$(curl -s https://public-inbox.org/git/?q="$(git show --format=%aI\ %s -s $c |
+	m="$(curl -s https://lore.kernel.org/git/?q="$(git show --format=%aI\ %s -s $c |
 		sed -e 's/^\(....\)-\(..\)-\(..\)[^ ]* \(.*\)/d%3A\1\2\3..\1\2\3+s%3A%22\4%22/' -e 'y/ /+/')" |
 		grep -v '\[PATCH 0*/' |
 		sed -n '/Search results/,/^Archives are clon/s/^href="\([^"?][^"]*\)\/">\([^<]*\).*/\1 \2/p')"
 
 	test -n "$m" ||
-	m="$(curl -s https://public-inbox.org/git/?q="$(git show --format=%aI\ %s -s $c |
+	m="$(curl -s https://lore.kernel.org/git/?q="$(git show --format=%aI\ %s -s $c |
 		sed -e 's/^[^ ]* \(.*\)/s%3A%22\1%22/' -e 'y/ /+/')" |
 		grep -v '\[PATCH 0*/' |
 		sed -n '/Search results/,/^Archives are clon/s/^href="\([^"?][^"]*\)\/">\([^<]*\).*/\1 \2/p')"
 
 	test -n "$m" ||
-	m="$(curl -s https://public-inbox.org/git/?q="$(git show --format=%aI\ %s -s $c |
+	m="$(curl -s https://lore.kernel.org/git/?q="$(git show --format=%aI\ %s -s $c |
 		sed -e 's/^\(....\)-\(..\)-\(..\)[^ ]* \(.*\)/d%3A\1\2\3..\1\2\3+\4/' -e 'y/ /+/')" |
 		grep -v '\[PATCH 0*/' |
 		sed -n '/Search results/,/^Archives are clon/s/^href="\([^"?][^"]*\)\/">\([^<]*\).*/\1 \2/p')"
 
 	test -n "$m" ||
-	m="$(curl -s https://public-inbox.org/git/?q="$(git show --format=%aI\ %s -s $c |
+	m="$(curl -s https://lore.kernel.org/git/?q="$(git show --format=%aI\ %s -s $c |
 		sed -e 's/^[^ ]* //' -e 'y/ /+/')" |
 		grep -v '\[PATCH 0*/' |
 		sed -n '/Search results/,/^Archives are clon/s/^href="\([^"?][^"]*\)\/">\([^<]*\).*/\1 \2/p')"
@@ -51,6 +51,6 @@ do
 		printf '\t\t%s) echo %s; continue;;\n' "$c" "${m2%% *}"
 	else
 		echo "Multiple candidates for $c ($(git show -s --format=%an:\ %s $c)):"
-		echo "$m" | sed 's|^|https://public-inbox.org/git/|'
+		echo "$m" | sed 's|^|https://lore.kernel.org/git/|'
 	fi
 done

--- a/script/update-mail-to-commit-notes.sh
+++ b/script/update-mail-to-commit-notes.sh
@@ -20,7 +20,7 @@ GITGIT_DIR="$(dirname "$0")/../.git/git-worktree"
 update_gitgit_dir () {
 	test -d "$GITGIT_DIR" ||
 	git clone https://github.com/gitgitgadget/git "$GITGIT_DIR" ||
-	die "Could not clone public-inbox/git to $GITGIT_DIR"
+	die "Could not clone gitgitgadget/git to $GITGIT_DIR"
 
 	git -C "$GITGIT_DIR" fetch https://github.com/gitgitgadget/git \
 		refs/notes/mail-to-commit:refs/notes/mail-to-commit ||

--- a/tests/send-mail.test.ts
+++ b/tests/send-mail.test.ts
@@ -2,7 +2,7 @@ import "jest";
 import { PublicInboxGitHelper } from "../lib/public-inbox-helper";
 import { parseMBox } from "../lib/send-mail";
 
-const mbox =
+const mbox0 =
     `From 566155e00ab72541ff0ac21eab84d087b0e882a5 Mon Sep 17 00:00:00 2001
 Message-Id: <pull.12345.v17.git.gitgitgadget@example.com>
 From:   =?utf-8?B?w4Z2YXIgQXJuZmrDtnLDsA==?= Bjarmason <avarab@gmail.com>
@@ -43,7 +43,7 @@ base-commit: 0ae4d8d45ce43d7ad56faff2feeacf8ed5293518
 `;
 
 test("parse mbox", async () => {
-    const parsed = await parseMBox(mbox);
+    const parsed = await parseMBox(mbox0);
     expect(parsed.from).toEqual("Ævar Arnfjörð Bjarmason <avarab@gmail.com>");
     expect(parsed.cc).toEqual([
         "Some Body <somebody@example.com>",
@@ -59,7 +59,7 @@ test("parse mbox", async () => {
 });
 
 test("test quoted printable", async () => {
-const mbox =
+    const mbox =
     `From 566155e00ab72541ff0ac21eab84d087b0e882a5 Mon Sep 17 00:00:00 2001
 Message-Id: <pull.12345.v17.git.gitgitgadget@example.com>
 From:   =?utf-8?B?w4Z2YXIgQXJuZmrDtnLDsA==?= Bjarmason <avarab@gmail.com>
@@ -85,8 +85,8 @@ have included in git.git.
 });
 
 test("test base64", async () => {
-const mailBody = "Base 64 Data";
-const mbox =
+    const mailBody = "Base 64 Data";
+    const mbox =
     `From 566155e00ab72541ff0ac21eab84d087b0e882a5 Mon Sep 17 00:00:00 2001
 Message-Id: <pull.12345.v17.git.gitgitgadget@example.com>
 From:   =?utf-8?B?w4Z2YXIgQXJuZmrDtnLDsA==?= Bjarmason <avarab@gmail.com>
@@ -108,7 +108,7 @@ ${Buffer.from(mailBody).toString("base64")}`;
 });
 
 test("test empty body", async () => {
-const mbox =
+    const mbox =
     `From 566155e00ab72541ff0ac21eab84d087b0e882a5 Mon Sep 17 00:00:00 2001
 Message-Id: <pull.12345.v17.git.gitgitgadget@example.com>
 From:   =?utf-8?B?w4Z2YXIgQXJuZmrDtnLDsA==?= Bjarmason <avarab@gmail.com>
@@ -125,6 +125,6 @@ Cc: Some Body <somebody@example.com>,
 `;
 
     const parsed = await parseMBox(mbox);
-    const body = PublicInboxGitHelper.mbox2markdown(parsed);
+    const body = MailArchiveGitHelper.mbox2markdown(parsed);
     expect(body).toMatch(/^$/);
 });

--- a/tests/send-mail.test.ts
+++ b/tests/send-mail.test.ts
@@ -1,5 +1,5 @@
 import "jest";
-import { PublicInboxGitHelper } from "../lib/public-inbox-helper";
+import { MailArchiveGitHelper } from "../lib/mail-archive-helper";
 import { parseMBox } from "../lib/send-mail";
 
 const mbox0 =
@@ -80,7 +80,7 @@ have included in git.git.
 `;
 
     const parsed = await parseMBox(mbox);
-    const body = PublicInboxGitHelper.mbox2markdown(parsed);
+    const body = MailArchiveGitHelper.mbox2markdown(parsed);
     expect(body).toMatch(/1234/);
 });
 
@@ -103,7 +103,7 @@ Cc: Some Body <somebody@example.com>,
 ${Buffer.from(mailBody).toString("base64")}`;
 
     const parsed = await parseMBox(mbox);
-    const body = PublicInboxGitHelper.mbox2markdown(parsed);
+    const body = MailArchiveGitHelper.mbox2markdown(parsed);
     expect(body).toMatch(mailBody);
 });
 


### PR DESCRIPTION
Seems that public-inbox.org might go the same way as gmane.org went, or almost: a new archive has been set up at lore.kernel.org. See https://lore.kernel.org/git/20191120195556.GA25189@dcvr/t/#u (which is identical to https://public-inbox.org/git/20191120195556.GA25189@dcvr/t/#u, and has the message by the public-inbox.org maintainer).

A mirror was already set up at https://dev.azure.com/gitgitgadget/git/_git/lore-git?_a=history, and an Azure Pipeline to keep that mirror up to date: https://dev.azure.com/gitgitgadget/git/_build?definitionId=14&_a=summary.

These patches will (hopefully) take care of the rest.

This addresses https://github.com/gitgitgadget/gitgitgadget/issues/155