### PR TITLE
Support alternate config dir for GitGitGadget

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -23,12 +23,15 @@ export class CIHelper {
     public readonly notes: GitNotes;
     protected readonly mail2commit: MailCommitMapping;
     protected readonly github: GitHubGlue;
+    protected readonly gggConfig: string;
     protected commit2mailNotes: GitNotes | undefined;
     protected testing: boolean;
     private gggNotesUpdated: boolean;
     private mail2CommitMapUpdated: boolean;
 
-    public constructor(workDir?: string, skipUpdate?: boolean) {
+    public constructor(workDir?: string, skipUpdate?: boolean,
+                       gggConfig = ".") {
+        this.gggConfig = gggConfig;
         this.workDir = workDir;
         this.notes = new GitNotes(workDir);
         this.gggNotesUpdated = !!skipUpdate;
@@ -524,7 +527,8 @@ export class CIHelper {
         };
 
         try {
-            const gitGitGadget = await GitGitGadget.get(".");
+            const gitGitGadget = await GitGitGadget.get(this.gggConfig,
+                                                        this.workDir);
             if (!gitGitGadget.isUserAllowed(comment.author)) {
                 throw new Error(`User ${
                     comment.author} is not permitted to use GitGitGadget`);


### PR DESCRIPTION
Positioning change for tests which need to provide a separate
config to GitGitGadget.get().  Currently, the current directory
is passed.  This will remain the default but user testing should
not need to update the local repo config.  This change will allow
tests to provide an alternate location of the config which
GitGitGadget uses to obtain SMTP information.

Issue #140 and PR #156 will be able to use this change.  A work in progress at [webstech/ci-helper-test](https://github.com/webstech/gitgitgadget/commit/13c01a817577f1107e4b16d7320c0ee2371315bc) is a sample use of this change.