### PR TITLE
Improve block quote formatting

### DIFF
--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -17,6 +17,16 @@ class MyOptions implements HtmlToTextOptions {
                 .replace(/./g, "=");
             return `${heading}\n${underline}\n\n`;
         },
+        blockquote(elem: any, fn: any, options: any): string {
+            const indentOptions = Object.assign({}, options);
+            // decrease word wrap, but only to a minimum of 20 columns/line
+            indentOptions.wordwrap = Math.max(20, options.wordwrap - 2);
+
+            const block: string = fn(elem.children, indentOptions);
+            return block.replace(/^>/mg, ">>") // add to quote
+                .replace(/^(?!>|$)/mg, "> ")   // new quote
+                .replace(/(^|\n)(\n)(?!$)/g, "$1>$2"); // quote empty lines
+        },
     };
 
     public constructor(columns?: number) {

--- a/tests/markdown-renderer.test.ts
+++ b/tests/markdown-renderer.test.ts
@@ -8,7 +8,13 @@ A paragraph with [links](https://gitgitgadget.github.io/), with
 * list
 * of
 * items that might span more than seventy-six characters in a single item ${
-    ""}and therefore needs to be wrapped.`;
+    ""}and therefore needs to be wrapped.
+
+> Starting a block quote.
+>
+>> Previously quoted ipsum loren.
+
+> Back to the base quote.`;
 
 test("Markdown rendering test", () => {
     expect(md2text(md)).toEqual(`Welcome to GitGitGadget
@@ -20,5 +26,11 @@ A paragraph with links [https://gitgitgadget.github.io/], with
  * list
  * of
  * items that might span more than seventy-six characters in a single item
-   and therefore needs to be wrapped.`);
+   and therefore needs to be wrapped.
+
+> Starting a block quote.
+>
+>> Previously quoted ipsum loren.
+
+> Back to the base quote.`);
 });


### PR DESCRIPTION
The fromString function from "html-to-text" does "lazy"
quoting with only a leading > for the quote.  This makes
cover letters that include quoting hard to read.

This change adds a blockquote formatter that will put `> ` at
the start of each line of the quote.  Quoting inside of quotes
will only add a `>`.  Not perfect but better than relying on
mail formatters to handle lazy quoting.

Signed-off-by: Chris. Webster <chris@webstech.net>