### PR TITLE
Handle multiple entries in the same Cc: line again

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -1,3 +1,4 @@
+import addressparser = require("nodemailer/lib/addressparser");
 import { encodeWords } from "nodemailer/lib/mime-funcs";
 import {
     commitExists, git, gitCommandExists, gitConfig, revParse,
@@ -286,7 +287,13 @@ export class PatchSeries {
                             basedOn = match2[2];
                             break;
                         case "cc:":
-                            cc.push(match2[2]);
+                            addressparser(match2[2]).forEach((e) => {
+                                if (e.name) {
+                                    cc.push(`${e.name} <${e.address}>`);
+                                } else {
+                                    cc.push(e.address);
+                                }
+                            });
                             break;
                         default:
                             footer.push(line);

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -423,7 +423,9 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
                 "some description goes here",
                 "",
                 "Cc: Some Contributor <contributor@example.com>",
-                "CC: Capital Letters <shout@out.loud>",
+                "CC: Capital Letters <shout@out.loud>, Hello <hello@wor.ld>"
+                + ", without@any.explicit.name"
+                + "; Semi Cologne <semi@col.on>",
                 "Cc: Git Maintainer <maintainer@gmail.com>",
                 "This is PR template",
                 "Please read our guide to continue",
@@ -436,6 +438,9 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             expect(parsed.cc).toEqual([
                 "Some Contributor <contributor@example.com>",
                 "Capital Letters <shout@out.loud>",
+                "Hello <hello@wor.ld>",
+                "without@any.explicit.name",
+                "Semi Cologne <semi@col.on>",
                 "Git Maintainer <maintainer@gmail.com>",
             ]);
 


### PR DESCRIPTION
This got broken somewhere along the lines, most likely when we started to use `encodeWords()` to quote names when necessary.

This addresses https://github.com/gitgitgadget/gitgitgadget/issues/171

cc @SyntevoAlex 