### PR TITLE
Allow IGitHubUser.email to be null

### DIFF
--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -176,7 +176,7 @@ export class GitGitGadget {
         const send = async (mail: string): Promise<string> => {
             const mbox = await parseMBox(mail);
             mbox.cc = [];
-            mbox.to = userInfo.email;
+            mbox.to = userInfo.email!;
             console.log(mbox);
             return await sendMail(mbox, this.smtpOptions);
         };

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -25,7 +25,7 @@ export interface IPRComment {
 }
 
 export interface IGitHubUser {
-    email: string;                  // null if no public email
+    email: string | null;           // null if no public email
     login: string;
     name: string;
     type: string;

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -128,7 +128,7 @@ export class PatchSeries {
                                      headLabel: string, headCommit: string,
                                      options: PatchSeriesOptions,
                                      senderName?: string,
-                                     senderEmail?: string):
+                                     senderEmail?: string | null):
         Promise<PatchSeries> {
         const workDir = notes.workDir;
         if (!workDir) {


### PR DESCRIPTION
The octokit doc says email will be null if there is no public email.
Updating the type to allow it to be null and a couple of pieces of
code to support it.

Null support is needed for testing.

Signed-off-by: Chris. Webster <chris@webstech.net>