### PR TITLE
Limit the number of commits on a pull request.

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -11,6 +11,7 @@ export interface IPullRequestInfo {
     baseCommit: string;
     baseOwner: string;
     baseRepo: string;
+    commits?: number;
     hasComments: boolean;
     headLabel: string;
     headCommit: string;
@@ -249,6 +250,7 @@ export class GitHubGlue {
             baseOwner: response.data.base.repo.owner.login,
             baseRepo: response.data.base.repo.name,
             body: response.data.body,
+            commits: response.data.commits,
             hasComments: response.data.comments > 0,
             headCommit: response.data.head.sha,
             headLabel: response.data.head.label,


### PR DESCRIPTION
A large number of patches is too much for reviewers.

A comment is added to the PR and the pipeline build fails for
pull request updates.

This implements part of #82.

The limit is arbitrary and easily changed.  Support for overrides could be added but really?

Suggestions for better messaging are welcome.

Tests are included with the PR.