### PR TITLE
Disallow `@users.noreply.github.com` emails specifically

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -660,6 +660,13 @@ export class CIHelper {
                 merges.push(cm.commit);
             }
 
+            if (cm.author.email.endsWith("@users.noreply.github.com")) {
+                addComment(`Invalid author email in ${cm.commit}: "${
+                    cm.author.email}"`);
+                result = false;
+                return;
+            }
+
             // Update email from git info if not already set
             if (userInfo && !userInfo.email) {
                 if (userInfo.login === cm.author.login) {

--- a/tests/test-lib.ts
+++ b/tests/test-lib.ts
@@ -105,7 +105,7 @@ export class TestRepo {
         };
 
         if (options.committer) {
-            const match = options.committer.match(/^(.*)<(.*)>$/);
+            const match = options.committer.match(/^(.*?)\s*<(.*)>$/);
             if (match) {
                 Object.assign(gitOpts.env, {
                     GIT_COMMITTER_EMAIL: match[2],
@@ -115,7 +115,7 @@ export class TestRepo {
         }
 
         if (options.author) {
-            const match = options.author.match(/^(.*)<(.*)>$/);
+            const match = options.author.match(/^(.*?)\s*<(.*)>$/);
             if (match) {
                 Object.assign(gitOpts.env, {
                     GIT_AUTHOR_EMAIL: match[2],


### PR DESCRIPTION
We already have patch count linting via #178 (which was just merged). Based on https://github.com/webstech/gitgitgadget/commit/611d4aa98f222d762c180de97bbabd9f64bebca6, this PR now also disallows bogus "...@users.noreply.github.com" email addresses.