### PR TITLE
Stop Cc:ing the Git maintainer

### DIFF
--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -48,7 +48,7 @@ export class ProjectOptions {
         } else if (await commitExists("e83c5163316f89bfbde", workDir)) {
             // Git
             to = "--to=git@vger.kernel.org";
-            cc.push("Junio C Hamano <gitster@pobox.com>");
+            // Do *not* Cc: Junio Hamano by default
             upstreamBranch = "upstream/pu";
             if (await git(["rev-list", branchName + ".." + upstreamBranch],
                           { workDir })) {


### PR DESCRIPTION
In https://lore.kernel.org/git/xmqqv9pn5hgl.fsf@gitster-ct.c.googlers.com/, we got yet another piece of disapproval of GitGitGadget. This PR intends to address the feasible part of the wishes offered in that mail thread.

Let's hope that this stream of complaints ends soon.