### PR TITLE
Commit Message Linting Phase 1

### DIFF
--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -1,0 +1,134 @@
+import { IPRCommit } from "./github-glue";
+
+export interface ILintError {
+    checkFailed: boolean;           // true if check failed
+    message: string;
+}
+
+/*
+ * Simple class to drive lint tests on commit messages.
+ */
+export class LintCommit {
+    private blocked: boolean;
+    private lines: string[];
+    private patch: IPRCommit;
+    private messages: string[] = [];
+
+    public constructor(patch: IPRCommit) {
+        this.blocked = false;
+        this.lines =  patch.message.split("\n");
+        this.patch = patch;
+    }
+
+    /*
+     * Linter method to run checks on the commit message.
+     * @param {IPRCommit} the patch to be checked
+     *
+     * The lintings are in methods called from here.  If
+     * a lint check is too severe to continue, it will throw
+     * an error.
+     */
+    public async lint(): Promise<ILintError | void> {
+
+        // Basic test before all others
+
+        if (await this.commitViable()) {
+            await Promise.all([
+                this.commitMessageLength(),
+                this.lowerCaseAfterPrefix(),
+                this.signedOffBy(),
+                this.moreThanAHyperlink(),
+            ]);
+        }
+
+        if (this.messages.length) {
+            return { checkFailed: this.blocked,
+                     message: `There ${this.messages.length > 1 ?
+                     "are issues" : "is an issue"} in commit ${
+                     this.patch.commit}:\n${this.messages.join("\n")}`,
+                };
+        }
+    }
+
+    private addMessage(message: string): void {
+        this.messages.push(message);
+    }
+
+    private block(message: string): void {
+        this.blocked = true;
+        this.addMessage(message);
+    }
+
+    // Test for a minimum viable commit message.
+    // - the body of the commit message should not be empty
+
+    private async commitViable(): Promise<boolean> {
+        if (this.lines.length < 3) {
+            this.block("Commit checks stopped - the message is too short");
+            return false;
+        }
+
+        return true;
+    }
+
+    // More tests of the commit message structure.
+    // - the first line should not exceed 76 characters
+    // - the first line should be followed by an empty line
+
+    private async commitMessageLength(): Promise<void> {
+        const maxColumns = 76;
+        if (this.lines[0].length > maxColumns) {
+            this.block(`First line of commit message is too long (> ${
+                maxColumns} columns): ${this.lines[0]}`);
+        }
+
+        if (this.lines[1].length) {
+            // tslint:disable-next-line:max-line-length
+            this.block("The first line must be separated from the rest by an empty line");
+        }
+    }
+
+    // Verify if the first line starts with a prefix (e.g. tests:), it continues
+    // in lower-case
+
+    private async lowerCaseAfterPrefix(): Promise<void> {
+        const match = this.lines[0].match(/^([a-z]+)+?:.*?([A-Z])/);
+
+        if (match) {
+            this.block(`Prefixed commit message must be in lower case: ${
+                       this.lines[0]}`);
+        }
+    }
+
+    // Verify the last line is a Signed-off-by: line - DCO check does this
+    // already, but put out a message if it is indented
+
+    private async signedOffBy(): Promise<void> {
+        const line = this.lines[this.lines.length - 1];
+        const match = line.match(/^(\s*)Signed-off-by:\s+(.*)/);
+
+        if (!match) {
+            this.block("Commit not signed off");
+        } else if (match[1].length) {
+            this.block(`Leading whitespace in sign off: ${line}`);
+        }
+    }
+
+    // Verify the body of the commit message does not consist of a hyperlink,
+    // without any other explanation.
+    // Should all lines be checked ie is it an array of links?
+    // Low hanging fruit: check the first line.
+    // Hyperlink validation is NOT part of the test.
+
+    private async moreThanAHyperlink(): Promise<void> {
+        const line = this.lines[2];
+        const match = line.match(/^(\w*)\s*https*:\/\/\S+\s*(\w*)/);
+
+        if (match) {
+            if (!match[1].length && !match[2].length &&
+                this.lines.length === 5) {
+                this.block(`A hyperlink requires some explanation`);
+            }
+        }
+    }
+}

--- a/tests/commit-lint.test.ts
+++ b/tests/commit-lint.test.ts
@@ -1,0 +1,151 @@
+import "jest";
+import { LintCommit } from "../lib/commit-lint";
+
+jest.setTimeout(180000);
+
+test("basic lint tests", async () => {
+    const commit = {
+        author: {
+            email: "ggg@example.com",
+            login: "ggg",
+            name: "e. e. cummings",
+        },
+        commit: "BAD1FEEDBEEF",
+        committer: {
+            email: "ggg@example.com",
+            login: "ggg",
+            name: "e. e. cummings",
+        },
+        message: "Message has no description",
+        parentCount: 1,
+    };
+
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/too short/);
+        }
+    }
+
+    commit.message = "Missing blank line is bad\nhere\nSigned-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/empty line/);
+        }
+    }
+
+    commit.message = "";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/too short/);
+        }
+    }
+
+    commit.message = `1234578901234567890123456789012345678901234567890${
+                ""}123456789012345678901234567890\nmore bad\nSigned-off-by: x`;
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/too long/);
+            expect(lintError.message).toMatch(/empty line/);
+        }
+    }
+
+    commit.message = "tests: This should be lower case\n\nSigned-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/lower/);
+        }
+    }
+
+    commit.message = "doc: success as lower case\n\nSigned-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).toBeUndefined();
+    }
+
+    commit.message = "Fail not signed off\n\nNotSigned-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/not signed/);
+        }
+    }
+
+    commit.message = "Success signed off\n\n foo bar\nSigned-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).toBeUndefined();
+    }
+
+    commit.message = "Fail blanks in sign off\n\n Signed-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/whitespace/);
+        }
+    }
+
+    commit.message = `Fail just a link\n
+http://www.github.com\n\nSigned-off-by: x`;
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/explanation/);
+        }
+    }
+
+    commit.message = `Success more than a link\n
+http://www.github.com\nblah\n\nSigned-off-by: x`;
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).toBeUndefined();
+    }
+
+    commit.message = `Success more than a link\n
+http://www.github.com blah\n\nSigned-off-by: x`;
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).toBeUndefined();
+    }
+
+    commit.message = `Success more than a link\n
+blah http://www.github.com\n\nSigned-off-by: x`;
+    {
+        const linter = new LintCommit(commit);
+        const lintError = await linter.lint();
+        expect(lintError).toBeUndefined();
+    }
+
+});


### PR DESCRIPTION
The commits in a pull request are obtained from GitHub and run
through some basic validation.  The check job will fail if the messages
do not pass the tests.  The intention is to pre-empt problems that the
git maintainers will raise.

Add new file commit-lint.ts.  It contains several commit message
validation checks.  These should grow over tine.

Add new file commit-lint.test.ts which contains unit tests for
the Linting checks.

This is the start of resolving issue #120.