### PR TITLE
Do not omit From: line for single-patch contributions

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -468,7 +468,7 @@ export class PatchSeries {
             }
 
             header = authorMatch[1] + replaceSender + authorMatch[3];
-            if (i === 0 && senderName) {
+            if (mails.length > 1 && i === 0 && senderName) {
                 // skip Cc:ing and From:ing in the cover letter
                 mails[i] = header + match[2];
                 return;


### PR DESCRIPTION
When sending a patch on behalf of somebody else, the first line of the mail body should be the appropriate `From:` line.

In GitGitGadget, we special-case the cover letter _not_ to include such a line. However, if there is only a single mail without any cover letter, the current code mistakes it for being the cover letter, and consequently omits the `From:` line, misattributing the authorship.

That happened [in this contribution](https://public-inbox.org/git/pull.690.git.git.1578576634678.gitgitgadget@gmail.com/) (which made it into git.git as https://github.com/git/git/commit/49e268e23e313e8c6b009cd8ebbbaae4316cf6cc).

This PR fixes that.