### PR TITLE
Avoid concurrent `addComment()` stumbling over one another

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -657,16 +657,16 @@ export class CIHelper {
         const commits = await this.github.getPRCommits(pr.baseOwner, pr.number);
 
         const merges: string[] = [];
-        await Promise.all(commits.map(async (cm: IPRCommit) => {
+        for (const cm of commits) {
             if (cm.parentCount > 1) {
                 merges.push(cm.commit);
             }
 
             if (cm.author.email.endsWith("@users.noreply.github.com")) {
-                addComment(`Invalid author email in ${cm.commit}: "${
+                await addComment(`Invalid author email in ${cm.commit}: "${
                                  cm.author.email}"`);
                 result = false;
-                return;
+                continue;
             }
 
             // Update email from git info if not already set
@@ -677,7 +677,7 @@ export class CIHelper {
                     userInfo.email = cm.committer.email;
                 }
             }
-        }));
+        }
 
         if (merges.length) {
             await addComment(`There ${


### PR DESCRIPTION
I messed up, and this fixes that, addressing the concern raised in https://github.com/gitgitgadget/gitgitgadget/pull/186#discussion_r367146027.