### PR TITLE
Add dev specific tests against existing commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "dev-test": "set gggdev=1 && jest --env=node",
     "lint": "tslint -c tslint.json '{lib,script,tests}/**/*.{ts,tsx}'",
     "start": "node server.js",
     "test": "tslint --project . && jest --env=node",


### PR DESCRIPTION
This is in response to https://github.com/gitgitgadget/gitgitgadget/pull/191 to help developers not introduce breaking changes to the process.

Adding 'dev-test' to scripts section of package.json.  This will set
gggdev in the environment prior to running jest.  dev-test only runs
tests, so test should still be run to have tslint run.

Adding a test in commit-lint.test.ts that checks gggdev.  It will run
the last 300 commits through the linter.  This should help determine
if the linting could break common commit messages.

Some projects use test:dev in scripts (vs dev-test).  Completely open to other ways to implement.

There is an expectation that the git repo is located at '../git'.  Probably quite common but are overrides needed?