### PR TITLE
GitHubGlue.getPRCommits(): do not expect valid login information

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -318,13 +318,13 @@ export class GitHubGlue {
             result.push({
                 author: {
                     email: cm.commit.author.email,
-                    login: cm.author.login,
+                    login: cm.author ? cm.author.login : "unknown login",
                     name: cm.commit.author.name,
                 },
                 commit: cm.sha,
                 committer: {
                     email: cm.commit.committer.email,
-                    login: cm.committer.login,
+                    login: cm.committer ? cm.committer.login : "unknown login",
                     name: cm.commit.committer.name,
                 },
                 message: cm.commit.message,


### PR DESCRIPTION
When users push commits with author or committer information listing an email that GitHub does not know about, the GitHub API apparently simply does not return the `author` or`committer` object when being asked for commits.

This PR teaches GitGitGadget to handle that scenario gracefully.

This fixes https://github.com/gitgitgadget/gitgitgadget/issues/193.