### PR TITLE
Allow any character for commit message prefix lint

### DIFF
--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -92,7 +92,7 @@ export class LintCommit {
     // in lower-case
 
     private async lowerCaseAfterPrefix(): Promise<void> {
-        const match = this.lines[0].match(/^([a-z]+)+?:\s*?([A-Z])/);
+        const match = this.lines[0].match(/^\S+?:\s*?([A-Z])/);
 
         if (match) {
             this.block(`Prefixed commit message must be in lower case: ${


### PR DESCRIPTION
There are a wide variety of characters used.  Rather than restrict
the characters when there is no documented restriction, allow any
characters.  If there is a problem, it can be handled with a future
change.

This fixes issue #196.