### PR TITLE
Harden regex for PR description footer detection

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -293,7 +293,7 @@ export class PatchSeries {
             coverLetterBody = match[1];
             const footer: string[] = [];
             for (const line of match[2].trimRight().split("\n")) {
-                const match2 = line.match(/^([-A-Za-z]+:) (.*)$/);
+                const match2 = line.match(/^([-A-Za-z]+:)\s*(.*)$/);
                 if (!match2) {
                     footer.push(line);
                 } else {

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -426,6 +426,9 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
                 "CC: Capital Letters <shout@out.loud>, Hello <hello@wor.ld>"
                 + ", without@any.explicit.name"
                 + "; Semi Cologne <semi@col.on>",
+                "Cc:No Space <no@outer.space>",
+                "Cc:   Several Space <i@love.spaces>",
+                "Cc:	Even A. Tab <john@tabular.com>",
                 "Cc: Git Maintainer <maintainer@gmail.com>",
                 "This is PR template",
                 "Please read our guide to continue",
@@ -441,6 +444,9 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
                 "Hello <hello@wor.ld>",
                 "without@any.explicit.name",
                 "Semi Cologne <semi@col.on>",
+                "No Space <no@outer.space>",
+                "Several Space <i@love.spaces>",
+                "Even A. Tab <john@tabular.com>",
                 "Git Maintainer <maintainer@gmail.com>",
             ]);
 


### PR DESCRIPTION
A recent Gitgitgadget PR [1] demonstrates that GGG fails to parse
CC: footers if no space is found after the colon.

Replace the literal space " " by the more lenient "\s*" so that CC:s are
parsed correctly if any kind of whitespace, or no whitespace at all, is
detected after the colon.

[1] https://github.com/gitgitgadget/git/pull/523

Helped-by: Johannes Schindelin <Johannes.Schindelin@gmx.de>
Signed-off-by: Philippe Blain <levraiphilippeblain@gmail.com>