### PR TITLE
Eslint Prep Work

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -157,7 +157,7 @@ export class CIHelper {
                         "refs/remotes/upstream/pu"],
                        { workDir: this.workDir })).split("\n"),
         );
-        let result: boolean = false;
+        let result = false;
         for (const pullRequestURL of Object.keys(options.openPRs)) {
             const info = await this.getPRMetadata(pullRequestURL);
             if (info === undefined || info.latestTag === undefined ||
@@ -220,8 +220,8 @@ export class CIHelper {
         if (!options.openPRs) {
             return false;
         }
-        let result: boolean = false;
-        let optionsUpdated: boolean = false;
+        let result = false;
+        let optionsUpdated = false;
         for (const pullRequestURL in options.openPRs) {
             if (!options.openPRs.hasOwnProperty(pullRequestURL)) {
                 continue;
@@ -642,7 +642,7 @@ export class CIHelper {
                               addComment: CommentFunction,
                               userInfo?: IGitHubUser):
         Promise<boolean> {
-        let result: boolean = true;
+        let result = true;
         const maxCommits = 30;
         if (pr.commits && pr.commits > maxCommits) {
             await addComment(`The pull request has ${pr.commits

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -524,7 +524,7 @@ export class CIHelper {
         console.log(`Handling command ${command} with argument ${argument} at ${
             pullRequestURL}#issuecomment-${commentID}`);
 
-        const addComment = async (body: string) => {
+        const addComment = async (body: string): Promise<void> => {
             console.log(`Adding comment to ${pullRequestURL}:\n${body}`);
             await this.github.addPRComment(pullRequestURL, body);
         };
@@ -709,12 +709,13 @@ export class CIHelper {
         return result;
     }
 
-    public async handlePush(repositoryOwner: string, prNumber: number) {
+    public async handlePush(repositoryOwner: string, prNumber: number):
+        Promise<void> {
         const pr = await this.github.getPRInfo(repositoryOwner, prNumber);
         const pullRequestURL = `https://github.com/${repositoryOwner
                                 }/git/pull/${prNumber}`;
 
-        const addComment = async (body: string) => {
+        const addComment = async (body: string): Promise<void>  => {
             console.log(`Adding comment to ${pullRequestURL}:\n${body}`);
             await this.github.addPRComment(pullRequestURL, body);
         };

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -136,16 +136,16 @@ export class CIHelper {
     public async updateCommitMappings(): Promise<boolean> {
         if (!this.gggNotesUpdated) {
             await git(["fetch", "https://github.com/gitgitgadget/git",
-                       `+refs/notes/gitgitgadget:refs/notes/gitgitgadget`,
-                       `+refs/heads/maint:refs/remotes/upstream/maint`,
-                       `+refs/heads/pu:refs/remotes/upstream/pu`],
+                       "+refs/notes/gitgitgadget:refs/notes/gitgitgadget",
+                       "+refs/heads/maint:refs/remotes/upstream/maint",
+                       "+refs/heads/pu:refs/remotes/upstream/pu"],
                       { workDir: this.workDir });
             this.gggNotesUpdated = true;
         }
 
         const options = await this.getGitGitGadgetOptions();
         if (!options) {
-            throw new Error(`There were no GitGitGadget options to be found?`);
+            throw new Error("There were no GitGitGadget options to be found?");
         }
         if (!options.openPRs) {
             return false;
@@ -215,7 +215,7 @@ export class CIHelper {
     public async handleOpenPRs(): Promise<boolean> {
         const options = await this.getGitGitGadgetOptions();
         if (!options) {
-            throw new Error(`There were no GitGitGadget options to be found?`);
+            throw new Error("There were no GitGitGadget options to be found?");
         }
         if (!options.openPRs) {
             return false;
@@ -478,7 +478,7 @@ export class CIHelper {
     public async getOriginalCommitsForPR(prMeta: IPatchSeriesMetadata):
         Promise<string[]> {
         if (!this.workDir) {
-            throw new Error(`Need a workDir`);
+            throw new Error("Need a workDir");
         }
         if (!await commitExists(prMeta.headCommit, this.workDir)) {
             if (!prMeta.pullRequestURL) {
@@ -486,7 +486,7 @@ export class CIHelper {
                     JSON.stringify(prMeta, null, 4)}`);
             }
             if (!prMeta.latestTag) {
-                throw new Error(`Cannot fetch commits without tag`);
+                throw new Error("Cannot fetch commits without tag");
             }
             const [owner, repo, nr] =
                 GitGitGadget.parsePullRequestURL(prMeta.pullRequestURL);
@@ -562,8 +562,8 @@ export class CIHelper {
 
                 if (commitOkay) {
                     const extraComment = userInfo.email === null ?
-                        ( `\n\nWARNING: ${comment.author} has no public email` +
-                        " address set on GitHub" ) : "";
+                        `\n\nWARNING: ${comment.author
+                        } has no public email address set on GitHub` : "";
 
                     const coverMid = await gitGitGadget.submit(pr, userInfo);
                     await addComment(`Submitted as [${
@@ -601,9 +601,8 @@ export class CIHelper {
                     const userInfo = await this.github.getGitHubUserInfo(
                         accountName);
                     if (userInfo.email === null) {
-                        extraComment = `\n\nWARNING: ${
-                            accountName} has no public email address` +
-                            " set on GitHub";
+                        extraComment = `\n\nWARNING: ${accountName
+                            } has no public email address set on GitHub`;
                     }
                 } catch (reason) {
                     throw new Error(`User ${

--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -135,7 +135,7 @@ export class LintCommit {
         if (match) {
             if (!match[1].length && !match[2].length &&
                 this.lines.length === 5) {
-                this.block(`A hyperlink requires some explanation`);
+                this.block("A hyperlink requires some explanation");
             }
         }
     }

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -121,7 +121,8 @@ export function git(args: string[], options?: IGitOptions | undefined):
  *    the working directory in which to run `git rev-parse`
  * @returns { string | undefined } the full SHA-1, or undefined
  */
-export async function revParse(argument: string, workDir?: string) {
+export async function revParse(argument: string, workDir?: string):
+    Promise<string | undefined> {
     const result = await GitProcess.exec(["rev-parse", "--verify", "-q",
                                           argument],
                                          workDir || ".");
@@ -137,7 +138,7 @@ export async function revParse(argument: string, workDir?: string) {
  * @returns number the number of commits in the commit range
  */
 export async function revListCount(rangeArgs: string | string[],
-                                   workDir: string = "."):
+                                   workDir = "."):
     Promise<number> {
     const gitArgs: string[] = ["rev-list", "--count"];
     if (typeof(rangeArgs) === "string") {

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -27,7 +27,7 @@ export class GitGitGadget {
         const workDir =
             await gitConfig("gitgitgadget.workDir", gitGitGadgetDir);
         if (!workDir) {
-            throw new Error(`Could not find GitGitGadget's work tree`);
+            throw new Error("Could not find GitGitGadget's work tree");
         }
         return workDir;
     }
@@ -41,7 +41,7 @@ export class GitGitGadget {
         const publishTagsAndNotesToRemote =
             await gitConfig("gitgitgadget.publishRemote", gitGitGadgetDir);
         if (!publishTagsAndNotesToRemote) {
-            throw new Error(`No remote to which to push configured`);
+            throw new Error("No remote to which to push configured");
         }
 
         // Initialize the worktree if necessary
@@ -65,7 +65,7 @@ export class GitGitGadget {
         const smtpOpts = await gitConfig("gitgitgadget.smtpOpts",
                                          gitGitGadgetDir);
         if (!smtpUser || !smtpHost || !smtpPass) {
-            throw new Error(`No SMTP settings configured`);
+            throw new Error("No SMTP settings configured");
         }
 
         const [options, allowedUsers] = await GitGitGadget.readOptions(notes);
@@ -114,7 +114,7 @@ export class GitGitGadget {
                           smtpOptions: ISMTPOptions,
                           publishTagsAndNotesToRemote: string) {
         if (!notes.workDir) {
-            throw new Error(`Could not determine Git worktree`);
+            throw new Error("Could not determine Git worktree");
         }
         this.workDir = notes.workDir;
         this.notes = notes;
@@ -206,10 +206,10 @@ export class GitGitGadget {
             this.publishTagsAndNotesToRemote,
             "--",
             `+${this.notes.notesRef}:${this.notes.notesRef}`,
-            `+refs/heads/maint:refs/remotes/upstream/maint`,
-            `+refs/heads/master:refs/remotes/upstream/master`,
-            `+refs/heads/next:refs/remotes/upstream/next`,
-            `+refs/heads/pu:refs/remotes/upstream/pu`,
+            "+refs/heads/maint:refs/remotes/upstream/maint",
+            "+refs/heads/master:refs/remotes/upstream/master",
+            "+refs/heads/next:refs/remotes/upstream/next",
+            "+refs/heads/pu:refs/remotes/upstream/pu",
         ];
         const prArgs = [
             `+${pullRequestRef}:${pullRequestRef}`,

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -96,7 +96,7 @@ export class GitHubGlue {
      * @returns the comment ID and the URL to the comment
      */
     public async addPRComment(pullRequestURL: string, comment: string):
-        Promise<{id: number, url: string}> {
+        Promise<{id: number; url: string}> {
         const [owner, repo, nr] =
             GitGitGadget.parsePullRequestURL(pullRequestURL);
         await this.ensureAuthenticated(owner);
@@ -124,7 +124,7 @@ export class GitHubGlue {
                                     commit: string,
                                     gitWorkDir: string | undefined,
                                     comment: string):
-        Promise<{id: number, url: string}> {
+        Promise<{id: number; url: string}> {
         const [owner, repo, nr] =
             GitGitGadget.parsePullRequestURL(pullRequestURL);
         await this.ensureAuthenticated(owner);

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -62,9 +62,8 @@ export class MailArchiveGitHelper {
             return "";
         }
 
-        return "``````````\n" +
-            body + (body.endsWith("\n") ? "" : "\n") +
-            "``````````\n";
+        return "``````````\n"
+            + body + (body.endsWith("\n") ? "" : "\n") + "``````````\n";
     }
 
     protected readonly state: IGitMailingListMirrorState;

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -88,12 +88,12 @@ export class MailArchiveGitHelper {
                 .map((line: string) => {
                     keys.add(line.substr(53).replace(/\//g, ""));
                 });
-        const seen = (messageID: string) => {
+        const seen = (messageID: string): boolean => {
             return keys.has(MailArchiveGitHelper.hashKey(messageID));
         };
 
         const mboxHandler = async (messageID: string, references: string[],
-                                   mbox: string) => {
+                                   mbox: string): Promise<void> => {
                 if (seen(messageID)) {
                     return;
                 }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -70,7 +70,7 @@ export class PatchSeries {
             headLabel: project.branchName,
             iteration: 1,
         };
-        let rangeDiff: string = "";
+        let rangeDiff = "";
 
         if (latestTag) {
             const range = latestTag + "..." + project.branchName;
@@ -150,7 +150,7 @@ export class PatchSeries {
             throw new Error(`Invalid commit range: ${currentRange}`);
         }
 
-        let rangeDiff: string = "";
+        let rangeDiff = "";
         if (metadata === undefined) {
             metadata = {
                 baseCommit,

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -86,20 +86,20 @@ export class PatchSeries {
             match = tagMessage.match(/^[\s\S]*?\n\n([\s\S]*)/);
             (match ? match[1] : tagMessage).split("\n").map((line) => {
                 // tslint:disable-next-line:max-line-length
-                match = line.match(/https:\/\/lore\.kernel\.org\/.*\/([^\/]+)/);
+                match = line.match(/https:\/\/lore\.kernel\.org\/.*\/([^/]+)/);
                 if (!match) {
                     // tslint:disable-next-line:max-line-length
-                    match = line.match(/https:\/\/public-inbox\.org\/.*\/([^\/]+)/);
+                    match = line.match(/https:\/\/public-inbox\.org\/.*\/([^/]+)/);
                 }
                 if (!match) {
                     // tslint:disable-next-line:max-line-length
-                    match = line.match(/https:\/\/www\.mail-archive\.com\/.*\/([^\/]+)/);
+                    match = line.match(/https:\/\/www\.mail-archive\.com\/.*\/([^/]+)/);
                 }
                 if (!match) {
                     match = line.match(/http:\/\/mid.gmane.org\/(.*)/);
                 }
                 if (!match) {
-                    match = line.match(/^[^ :]*: Message-ID: ([^\/]+)/);
+                    match = line.match(/^[^ :]*: Message-ID: ([^/]+)/);
                 }
                 if (match) {
                     if (metadata.referencesMessageIds) {
@@ -718,7 +718,7 @@ export class PatchSeries {
             const email = emailMatch[1];
 
             const prMatch = this.metadata.pullRequestURL
-                .match(/\/([^\/]+)\/([^\/]+)\/pull\/(\d+)$/);
+                .match(/\/([^/]+)\/([^/]+)\/pull\/(\d+)$/);
             if (prMatch) {
                 const infix = this.metadata.iteration > 1 ?
                     `.v${this.metadata.iteration}` : "";

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -61,7 +61,7 @@ export class PatchSeries {
         }
         const headCommit = await revParse("HEAD");
         if (!headCommit) {
-            throw new Error(`Cannot determine HEAD revision`);
+            throw new Error("Cannot determine HEAD revision");
         }
         const metadata: IPatchSeriesMetadata = {
             baseCommit,
@@ -75,8 +75,8 @@ export class PatchSeries {
         if (latestTag) {
             const range = latestTag + "..." + project.branchName;
             if (! await git(["rev-list", range])) {
-                throw new Error("Branch " + project.branchName
-                    + " was already submitted: " + latestTag);
+                throw new Error(`Branch ${project.branchName
+                    } was already submitted: ${latestTag}`);
             }
 
             let match = latestTag.match(/-v([1-9][0-9]*)$/);
@@ -513,8 +513,8 @@ export class PatchSeries {
         }
 
         const messageID = mail.match(/\nMessage-ID: <(.*?)>\n/i);
-        let footer: string = messageID ? "Submitted-As: " + midUrlPrefix
-            + messageID[1] : "";
+        let footer: string = messageID ? `Submitted-As: ${midUrlPrefix
+            }${messageID[1]}` : "";
         if (inReplyTo) {
             inReplyTo.map((id: string) => {
                 footer += "\nIn-Reply-To: " + midUrlPrefix + id;
@@ -523,8 +523,8 @@ export class PatchSeries {
 
         // Subjects can contain continuation lines; simply strip out the new
         // line and keep only the space
-        return match[2].replace(/\n */g, " ") + "\n\n" + match[3]
-            + (footer ? "\n\n" + footer : "");
+        return match[2].replace(/\n */g, " ") + `\n\n${match[3]
+            }${footer ? `\n\n${footer}` : ""}`;
     }
 
     protected static insertLinks(tagMessage: string, url: string,
@@ -546,14 +546,13 @@ export class PatchSeries {
         }
 
         let insert =
-            "Published-As: " + url + "/releases/tag/" + tagName + "\n" +
-            "Fetch-It-Via: git fetch " + url + " " + tagName + "\n";
+            `Published-As: ${url}/releases/tag/${tagName
+            }\nFetch-It-Via: git fetch ${url} ${tagName}\n`;
 
         if (basedOn) {
             insert =
-                "Based-On: " + basedOn + " at " + url + "\n" +
-                "Fetch-Base-Via: git fetch " + url + " " + basedOn + "\n" +
-                insert;
+                `Based-On: ${basedOn} at ${url
+                }\nFetch-Base-Via: git fetch ${url} ${basedOn}\n${insert}`;
         }
 
         if (!tagMessage.match(/\n[-A-Za-z]+: [^\n]*\n$/)) {
@@ -662,11 +661,11 @@ export class PatchSeries {
         Promise<string | undefined> {
         let globalOptions: IGitGitGadgetOptions | undefined;
         if (this.options.dryRun) {
-            logger.log("Dry-run " + this.project.branchName
-                + " v" + this.metadata.iteration);
+            logger.log(`Dry-run ${this.project.branchName
+                 } v${this.metadata.iteration}`);
         } else {
-            logger.log("Submitting " + this.project.branchName
-                + " v" + this.metadata.iteration);
+            logger.log(`Submitting ${this.project.branchName
+                 } v${this.metadata.iteration}`);
             globalOptions = await this.notes.get<IGitGitGadgetOptions>("");
         }
 
@@ -707,7 +706,7 @@ export class PatchSeries {
 
         if (this.metadata.pullRequestURL) {
             if (!coverMid) {
-                throw new Error(`Could not extract cover letter Message-ID`);
+                throw new Error("Could not extract cover letter Message-ID");
             }
 
             const tsMatch = coverMid.match(/cover\.([0-9]+)\./);
@@ -769,11 +768,10 @@ export class PatchSeries {
         }
 
         if (this.options.noUpdate) {
-            logger.log("Would generate tag " + tagName
-                + " with message:\n\n"
-                + tagMessage.split("\n").map((line: string) => {
+            logger.log(`Would generate tag ${tagName} with message:\n\n ${
+                tagMessage.split("\n").map((line: string) => {
                     return "    " + line;
-                }).join("\n"));
+                }).join("\n")}`);
         } else {
             logger.log("Generating tag object");
             await this.generateTagObject(tagName, tagMessage);
@@ -783,7 +781,7 @@ export class PatchSeries {
         const footers: string[] = [];
 
         if (pullRequestURL) {
-            const prefix = `https://github.com/gitgitgadget/git`;
+            const prefix = "https://github.com/gitgitgadget/git";
             const tagName2 = encodeURIComponent(tagName);
             footers.push(`Published-As: ${prefix}/releases/tag/${tagName2}`);
             footers.push(`Fetch-It-Via: git fetch ${prefix} ${tagName}`);
@@ -795,8 +793,8 @@ export class PatchSeries {
                 footers.push(""); // empty line
             }
             // split the range-diff and prefix with a space
-            footers.push(`Range-diff vs v${this.metadata.iteration - 1}:`
-                + `\n\n${this.rangeDiff.replace(/(^|\n(?!$))/g, "$1 ")}\n`);
+            footers.push(`Range-diff vs v${this.metadata.iteration - 1}:\n\n${
+                         this.rangeDiff.replace(/(^|\n(?!$))/g, "$1 ")}\n`);
         }
 
         logger.log("Inserting footers");
@@ -832,10 +830,10 @@ export class PatchSeries {
         }
 
         if (this.options.dryRun) {
-            logger.log("Would send this mbox:\n\n"
-                + mbox.split("\n").map((line) => {
+            logger.log(`Would send this mbox:\n\n${
+                mbox.split("\n").map((line) => {
                     return "    " + line;
-                }).join("\n"));
+                }).join("\n")}`);
         } else if (send) {
             for (const mail of mails) {
                 await send(mail);
@@ -931,8 +929,8 @@ export class PatchSeries {
         }
         if (this.patchCount > 1 ) {
             if (!this.coverLetter) {
-                    throw new Error("Branch " + this.project.branchName
-                        + " needs a description");
+                    throw new Error(`Branch ${this.project.branchName
+                        } needs a description`);
             }
             args.push("--cover-letter");
         }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -233,9 +233,9 @@ export class PatchSeries {
                                             wrapCoverLetterAtColumn: number,
                                             indentCoverLetter: string):
     Promise <{
-        coverLetter: string,
-        basedOn?: string,
-        cc: string[],
+        coverLetter: string;
+        basedOn?: string;
+        cc: string[];
     }> {
         // Replace \r\n with \n to simplify remaining parsing.
         // Note that md2text() in the end will do the replacement anyway.
@@ -279,9 +279,9 @@ export class PatchSeries {
     }
 
     protected static parsePullRequestBody(prBody: string): {
-        coverLetterBody: string,
-        basedOn?: string,
-        cc: string[],
+        coverLetterBody: string;
+        basedOn?: string;
+        cc: string[];
     } {
         let basedOn;
         const cc: string[] = [];

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -211,7 +211,7 @@ export class PatchSeries {
             cc.push(`${senderName} <${senderEmail}>`);
         }
 
-        if (basedOn && !revParse(basedOn, workDir)) {
+        if (basedOn && !await revParse(basedOn, workDir)) {
             throw new Error(`Cannot find base branch ${basedOn}`);
         }
 
@@ -685,8 +685,7 @@ export class PatchSeries {
 
         logger.log("Adding Cc: and explicit From: lines for other authors, "
             + "if needed");
-        await PatchSeries.insertCcAndFromLines(mails, thisAuthor,
-                                               this.senderName);
+        PatchSeries.insertCcAndFromLines(mails, thisAuthor, this.senderName);
         if (mails.length > 1) {
             if (this.coverLetter) {
                 const match2 = mails[0].match(
@@ -698,7 +697,7 @@ export class PatchSeries {
             }
 
             logger.log("Fixing Subject: line of the cover letter");
-            mails[0] = await PatchSeries.adjustCoverLetter(mails[0]);
+            mails[0] = PatchSeries.adjustCoverLetter(mails[0]);
         }
 
         const midMatch = mails[0].match(/\nMessage-ID: <(.*)>/i);
@@ -738,10 +737,9 @@ export class PatchSeries {
 
         logger.log("Generating tag message");
         let tagMessage =
-            await PatchSeries.generateTagMessage(mails[0], mails.length > 1,
-                                                 this.project.midUrlPrefix,
-                                                 this.metadata
-                                                 .referencesMessageIds);
+            PatchSeries.generateTagMessage(mails[0], mails.length > 1,
+                                           this.project.midUrlPrefix,
+                                           this.metadata.referencesMessageIds);
         let tagName;
         if (!this.metadata.pullRequestURL) {
             tagName = `${this.project.branchName}-v${this.metadata.iteration}`;
@@ -763,8 +761,8 @@ export class PatchSeries {
             }
 
             logger.log("Inserting links");
-            tagMessage = await PatchSeries.insertLinks(tagMessage, url, tagName,
-                                                       this.project.basedOn);
+            tagMessage = PatchSeries.insertLinks(tagMessage, url, tagName,
+                                                 this.project.basedOn);
         }
 
         if (this.options.noUpdate) {

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -37,7 +37,7 @@ export class ProjectOptions {
         Promise<ProjectOptions> {
         let upstreamBranch: string;
         let to: string;
-        let midUrlPrefix: string = " Message-ID: ";
+        let midUrlPrefix = " Message-ID: ";
 
         if (await commitExists("cb07fc2a29c86d1bc11", workDir) &&
             await revParse(`${baseCommit}:git-gui.sh`, workDir) !== undefined) {

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -87,8 +87,8 @@ export class ProjectOptions {
         if (!baseCommit &&
             await git(["rev-list", branchName + ".." + upstreamBranch],
                       { workDir })) {
-            throw new Error("Branch " + branchName + " is not rebased to " +
-                upstreamBranch);
+            throw new Error(`Branch ${branchName} is not rebased to ${
+                upstreamBranch}`);
         }
 
         return new ProjectOptions(branchName, upstreamBranch, basedOn,
@@ -118,8 +118,8 @@ export class ProjectOptions {
         const commit = await git(["rev-parse", "-q", "--verify", remoteRef],
                                  { workDir });
         if (await git(["rev-parse", basedOn]) !== commit) {
-            throw new Error(basedOn + " on " + publishToRemote +
-                " disagrees with local branch");
+            throw new Error(`${basedOn} on ${publishToRemote
+                } disagrees with local branch`);
         }
 
         return basedOn;

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -129,7 +129,7 @@ export class ProjectOptions {
         Promise<string[]> {
         // Cc: from config
         const cc: string[] = [];
-        const forEach = (email: string) => {
+        const forEach = (email: string): void => {
             if (email) {
                 cc.push(email);
             }

--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -45,7 +45,7 @@ export async function parseMBox(mbox: string, gentle?: boolean):
     Promise<IParsedMBox> {
     const headerEnd = mbox.indexOf("\n\n");
     if (headerEnd < 0) {
-        throw new Error(`Could not parse mail`);
+        throw new Error("Could not parse mail");
     }
     const headerStart = mbox.startsWith("From ") ? mbox.indexOf("\n") + 1 : 0;
 

--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -7,7 +7,7 @@ export interface IParsedMBox {
     cc?: string[];
     date?: string;
     from?: string;
-    headers?: Array<{ key: string; value: string; }>;
+    headers?: Array<{ key: string; value: string }>;
     messageId?: string;
     subject?: string;
     to?: string;
@@ -55,7 +55,7 @@ export async function parseMBox(mbox: string, gentle?: boolean):
     let cc: string[] | undefined;
     let date: string | undefined;
     let from: string | undefined;
-    const headers = new Array<{ key: string, value: string }>();
+    const headers = new Array<{ key: string; value: string }>();
     let messageId: string | undefined;
     let subject: string | undefined;
     let to: string | undefined;
@@ -98,7 +98,7 @@ export async function parseMBox(mbox: string, gentle?: boolean):
 }
 
 export async function parseMBoxMessageIDAndReferences(mbox: string):
-        Promise<{messageID: string, references: string[]}> {
+        Promise<{messageID: string; references: string[]}> {
     const parsed = await parseMBox(mbox, true);
     if (!parsed.headers) {
         throw new Error(`Could not parse ${mbox}`);

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -354,9 +354,9 @@ async function getCIHelper(): Promise<CIHelper> {
         await glue.addPRComment(pullRequestURL, comment);
     } else if (command === "set-app-token") {
         const set = async (options: {
-             appID: number,
-             installationID?: number,
-             name: string,
+             appID: number;
+             installationID?: number;
+             name: string;
         }): Promise<void> => {
             const client = new octokit();
             const appName = options.name === "gitgitgadget" ?

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -65,7 +65,7 @@ async function getCIHelper(): Promise<CIHelper> {
         const gitHub = new GitHubGlue(ci.workDir);
 
         const options = await ci.getGitGitGadgetOptions();
-        let optionsChanged: boolean = false;
+        let optionsChanged = false;
         if (!options.openPRs) {
             options.openPRs = {};
             optionsChanged = true;
@@ -298,7 +298,7 @@ async function getCIHelper(): Promise<CIHelper> {
         }
 
         const options = await ci.getGitGitGadgetOptions();
-        let optionsUpdated: boolean = false;
+        let optionsUpdated = false;
         if (!options.openPRs) {
             options.openPRs = {};
             optionsUpdated = true;
@@ -315,7 +315,7 @@ async function getCIHelper(): Promise<CIHelper> {
             optionsUpdated = true;
         }
 
-        let notesUpdated: boolean = false;
+        let notesUpdated = false;
         if (meta.baseCommit && meta.headCommit) {
             for (const rev of await ci.getOriginalCommitsForPR(meta)) {
                 const messageID = await ci.notes.getLastCommitNote(rev);

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -34,7 +34,7 @@ async function getGitGitWorkDir(): Promise<string> {
         commander.gitWorkDir = await gitConfig("gitgitgadget.workDir",
                                                commander.gitgitgadgetWorkDir);
         if (!commander.gitWorkDir) {
-            throw new Error(`Could not determine gitgitgadget.workDir`);
+            throw new Error("Could not determine gitgitgadget.workDir");
         }
     }
     if (!await isDirectory(commander.gitWorkDir)) {

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -53,7 +53,7 @@ async function getCIHelper(): Promise<CIHelper> {
                         commander.gitgitgadgetWorkDir);
 }
 
-(async () => {
+(async (): Promise<void> => {
     const ci = await getCIHelper();
     const command = commander.args[0];
     if (command === "update-open-prs") {

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -568,7 +568,7 @@ test("handle comment submit email success", async () => {
         baseOwner: "gitgitgadget",
         baseRepo: "git",
         body: `Super body\r\n${template}\r\nCc: Copy One <copy@cat.com>\r\n`
-            + `Cc: Copy Two <copycat@cat.com>`,
+            + "Cc: Copy Two <copycat@cat.com>",
         hasComments: true,
         headCommit: B,
         headLabel: "somebody:master",

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -49,22 +49,22 @@ class TestCIHelper extends CIHelper {
         // this.ghGlue.ensureAuthenticated = async (): Promise<void> => {};
     }
 
-    public setGHgetPRInfo(o: IPullRequestInfo) {
+    public setGHgetPRInfo(o: IPullRequestInfo): void {
         this.ghGlue.getPRInfo = jest.fn( async ():
             Promise<IPullRequestInfo> => o );
     }
 
-    public setGHgetPRComment(o: IPRComment) {
+    public setGHgetPRComment(o: IPRComment): void {
         this.ghGlue.getPRComment = jest.fn( async ():
             Promise<IPRComment> => o );
     }
 
-    public setGHgetPRCommits(o: IPRCommit[]) {
+    public setGHgetPRCommits(o: IPRCommit[]): void {
         this.ghGlue.getPRCommits = jest.fn( async ():
             Promise<IPRCommit[]> => o );
     }
 
-    public setGHgetGitHubUserInfo(o: IGitHubUser) {
+    public setGHgetGitHubUserInfo(o: IGitHubUser): void {
         this.ghGlue.getGitHubUserInfo = jest.fn( async ():
             Promise<IGitHubUser> => o );
     }

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -24,8 +24,8 @@ jest.setTimeout(180000);
 // The CIsmtpOpts must have the keys quoted.
 
 async function getSMTPInfo():
-    Promise <{ smtpUser: string, smtpHost: string,
-               smtpPass: string, smtpOpts: string }> {
+    Promise <{ smtpUser: string; smtpHost: string;
+               smtpPass: string; smtpOpts: string; }> {
     const smtpUser = await gitConfig("gitgitgadget.CIsmtpUser") || "";
     const smtpHost = await gitConfig("gitgitgadget.CIsmtpHost") || "";
     const smtpPass = await gitConfig("gitgitgadget.CIsmtpPass") || "";
@@ -83,7 +83,7 @@ class TestCIHelper extends CIHelper {
 // have objects present).
 
 async function setupRepos(instance: string):
-    Promise <{ worktree: TestRepo, gggLocal: TestRepo, gggRemote: TestRepo }> {
+    Promise <{ worktree: TestRepo; gggLocal: TestRepo; gggRemote: TestRepo }> {
     const worktree = await testCreateRepo(__filename, `-work-cmt${instance}`);
     const gggLocal = await testCreateRepo(__filename, `-git-lcl${instance}`);
     const gggRemote = await testCreateRepo(__filename, `-git-rmt${instance}`);

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -70,7 +70,7 @@ In-Reply-To: https://mid.lookup/cover.2.git.author@example.com
 In-Reply-To: https://mid.lookup/cover.1.git.author@example.com`;
 
 class PatchSeriesTest extends PatchSeries {
-    public static runTests() {
+    public static runTests(): void {
         const mails = PatchSeries.splitMails(mbox1);
 
         test("mails are split correctly", () => {

--- a/tests/test-lib.ts
+++ b/tests/test-lib.ts
@@ -174,8 +174,8 @@ export async function testCreateRepo(name: string, suffix?: string):
     }
     const opts = {
         env: {
-            GIT_AUTHOR_DATE: `123457689 +0000`,
-            GIT_COMMITTER_DATE: `123457689 +0000`,
+            GIT_AUTHOR_DATE: "123457689 +0000",
+            GIT_COMMITTER_DATE: "123457689 +0000",
         },
         workDir: dir,
     };


### PR DESCRIPTION
tslint is being deprecated.  There is some tooling to support the conversion to eslint and some typescript specific linting.  This is an initial pass to update the code for the low hanging fruit.  Best  reviewed at the commit level.  There are very few logic changes.

[typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) has more info about converting.  Initial playing with the conversion required turning indent rules off - the errors and warnings were not consistent.  The typescript-eslint team acknowledged in an issue they do not use the indent rules and use prettier instead.