### PR TITLE
Fix parsing of mails fetched from lore.kernel.org

### DIFF
--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -178,7 +178,7 @@ export class MailArchiveGitHelper {
                     counter = parseInt(match[3], 10);
                     buffer = "";
                 }
-            } else if (counter) {
+            } else if (counter && line.match(/^[ +]/)) {
                 buffer += line.substr(1) + "\n";
                 if (--counter) {
                     return;

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -244,7 +244,7 @@ export class MailArchiveGitHelper {
         }
 
         const range = `${this.state.latestRevision}..${head}`;
-        await git(["log", "-p", "--reverse", range],
+        await git(["log", "-p", "-U99999", "--reverse", range],
                   { lineHandler, workDir: this.mailArchiveGitDir });
 
         this.state.latestRevision = head;

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -201,6 +201,10 @@ export class MailArchiveGitHelper {
              */
             this.state.latestRevision =
                 "3b38d8d206c64bf3dc873ba8ae9dbd48ed43f612";
+        } else if (this.state.latestRevision ===
+            "205655703b0501ef14e0f0dddf8e57bb726fae97") {
+            this.state.latestRevision =
+                "26674e9a36ae1871f69197798d30f6d3d2af7a56";
         } else if (await revParse(this.state.latestRevision,
                                   this.mailArchiveGitDir) === undefined) {
             const publicInboxGitDir = process.env.PUBLIC_INBOX_DIR;

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -95,6 +95,7 @@ export class MailArchiveGitHelper {
         const mboxHandler = async (messageID: string, references: string[],
                                    mbox: string): Promise<void> => {
                 if (seen(messageID)) {
+                    console.log(`Already handled: ${messageID}`);
                     return;
                 }
                 let pullRequestURL: string | undefined;
@@ -248,6 +249,7 @@ export class MailArchiveGitHelper {
         }
 
         const range = `${this.state.latestRevision}..${head}`;
+        console.log(`Handling commit range ${range}`);
         await git(["log", "-p", "-U99999", "--reverse", range],
                   { lineHandler, workDir: this.mailArchiveGitDir });
 

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -172,6 +172,9 @@ export class MailArchiveGitHelper {
             if (line.startsWith("@@ ")) {
                 const match = line.match(/^@@ -(\d+,)?\d+ \+(\d+,)?(\d+)?/);
                 if (match) {
+                    if (counter) {
+                        console.log(`Oops: unprocessed buffer ${buffer}`);
+                    }
                     counter = parseInt(match[3], 10);
                     buffer = "";
                 }


### PR DESCRIPTION
Due to a mistake of yours truly, the [Azure Pipeline that takes care of synchronizing the replies on the Git mailing list back to their corresponding PRs](https://dev.azure.com/gitgitgadget/git/_build?definitionId=5&_a=summary) did _not_ actually switch to using lore.kernel.org.

Which is a good thing because due to another mistake of yours truly, the parser was not adjusted to reflect that lore.kernel.org uses a different layout than public-inbox.org: instead of adding new mails to the tree, the single file in the tree is overwritten with the latest mail all the time.

This has a couple interesting ramifications, e.g. we need to skip the `-` lines in the diffs (which was not a problem before because there simply were no `-` lines), we need to increase the diff context (which was not a problem because there was no pre-image, i.e. we automatically knew that we saw all of the post-image's lines).

This PR should fix that.