### PR TITLE
Don't require "cover letter" for single-patch contributions

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -762,7 +762,7 @@ export class CIHelper {
                 pullRequestURL}`);
         }
 
-        if (!pr.title || !pr.body) {
+        if (!pr.title || (!pr.body && pr.commits !== 1)) {
             throw new Error("Ignoring PR with empty title and/or body");
         }
 


### PR DESCRIPTION
In https://github.com/git/git/pull/740, @phil-blain noticed that we should not require non-empty PR descriptions for single-patch PRs.