### PR TITLE
Use libqp to decode quoted-printable strings

### DIFF
--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -1,4 +1,5 @@
 import { createHash } from "crypto";
+import * as libqp from "libqp";
 import { git, revParse } from "./git";
 import { GitNotes } from "./git-notes";
 import { GitHubGlue } from "./github-glue";
@@ -47,13 +48,8 @@ export class MailArchiveGitHelper {
                 if (value === "base64") {
                     body = Buffer.from(body, "base64").toString();
                 } else if (value === "quoted-printable") {
-                    const stringFromCharCode = String.fromCharCode;
-                    body = body.replace(/[\t\x20]$/gm, "")
-                        .replace(/=(?:\r\n?|\n|$)/g, "")
-                        .replace(/=([a-fA-F0-9]{2})/g, (_$0, $1) => {
-                            const codePoint = parseInt($1, 16);
-                            return stringFromCharCode(codePoint);
-                    });
+                    const buffer = libqp.decode(body);
+                    body = buffer.toString("utf-8");
                 }
             }
         }
@@ -62,8 +58,8 @@ export class MailArchiveGitHelper {
             return "";
         }
 
-        return "``````````\n"
-            + body + (body.endsWith("\n") ? "" : "\n") + "``````````\n";
+        const wrap = "``````````\n";
+        return `${wrap}${body}${body.endsWith("\n") ? "" : "\n"}${wrap}`;
     }
 
     protected readonly state: IGitMailingListMirrorState;

--- a/package-lock.json
+++ b/package-lock.json
@@ -646,6 +646,14 @@
         "@types/node": "*"
       }
     },
+    "@types/libqp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/libqp/-/libqp-1.1.0.tgz",
+      "integrity": "sha512-TfuW9rDtHBdCa+6ny5l1gWPkj3nb1V2YYnH7pftj2WQRPbVd/XERNao2OZOnfngxm5gQcS7AsNY6EM+u8vZKIA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/lru-cache": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
@@ -4024,6 +4032,11 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
+    },
+    "libqp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
+      "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
     },
     "load-json-file": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/jest": "^22.2.3",
     "@types/json-stable-stringify": "^1.0.32",
     "@types/jsonwebtoken": "^8.3.0",
+    "@types/libqp": "^1.1.0",
     "@types/marked": "^0.3.0",
     "@types/nodemailer": "^4.6.5",
     "jest": "^24.7.1",
@@ -55,6 +56,7 @@
     "html-to-text": "^4.0.0",
     "json-stable-stringify": "^1.0.1",
     "jsonwebtoken": "^8.4.0",
+    "libqp": "^1.1.0",
     "marked": "^0.7.0",
     "nodemailer": "^4.6.8",
     "rfc2047": "^2.0.1"

--- a/tests/send-mail.test.ts
+++ b/tests/send-mail.test.ts
@@ -73,6 +73,36 @@ To: reviewer@example.com
 Cc: Some Body <somebody@example.com>,
  And Somebody Else <somebody@else.org>
 
+Test the various length utf-8 characters.
+=31=32=33=34
+two byte /=[CDcd][0-9A-Fa-f]/=c2=a9
+three byte /=[Ee][0-9A-Fa-f]/=e1=99=ad
+four byte /=[Ff][0-7]/=f0=90=8d=88
+`;
+
+    const parsed = await parseMBox(mbox);
+    const body = MailArchiveGitHelper.mbox2markdown(parsed);
+    expect(body).toMatch(/1234/);
+    expect(body).toMatch(/©/);
+    expect(body).toMatch(/᙭/);
+    expect(body).toMatch(/𐍈/);
+});
+
+test("test quoted printable ascii", async () => {
+    const mbox =
+    `From 566155e00ab72541ff0ac21eab84d087b0e882a5 Mon Sep 17 00:00:00 2001
+Message-Id: <pull.12345.v17.git.gitgitgadget@example.com>
+From:   =?utf-8?B?w4Z2YXIgQXJuZmrDtnLDsA==?= Bjarmason <avarab@gmail.com>
+Date: Fri Sep 21 12:34:56 2001
+Subject: [PATCH 0/3] My first Pull Request!
+Fcc: Sent
+Content-Type: text/plain
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+To: reviewer@example.com
+Cc: Some Body <somebody@example.com>,
+ And Somebody Else <somebody@else.org>
+
 This Pull Request contains some really important changes that I would love to
 have included in git.git.
 =31=32=33=34


### PR DESCRIPTION
Multi-byte utf-8 characters were being treated as single byte
characters, with each byte converted to a character.  This
caused quoted-printable strings to be decoded incorrectly.
The libqp package is now used to convert each byte to the
hex value in a buffer.  The buffer is converted to a string.

Also, return in `mbox2markdown()` will now use a constant on
the return statement to avoid repetition.

This corrects a problem in PR #160 as noted by recent comments in issue #158.