### PR TITLE
Hide GitHub tokens from the PR comments

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -525,8 +525,9 @@ export class CIHelper {
             pullRequestURL}#issuecomment-${commentID}`);
 
         const addComment = async (body: string): Promise<void> => {
-            console.log(`Adding comment to ${pullRequestURL}:\n${body}`);
-            await this.github.addPRComment(pullRequestURL, body);
+            const redacted = CIHelper.redactGitHubToken(body);
+            console.log(`Adding comment to ${pullRequestURL}:\n${redacted}`);
+            await this.github.addPRComment(pullRequestURL, redacted);
         };
 
         try {
@@ -709,6 +710,10 @@ export class CIHelper {
         return result;
     }
 
+    public static redactGitHubToken(text: string): string {
+        return text.replace(/(https:\/\/)x-access-token:.*?@/g, "$1");
+    }
+
     public async handlePush(repositoryOwner: string, prNumber: number):
         Promise<void> {
         const pr = await this.github.getPRInfo(repositoryOwner, prNumber);
@@ -716,8 +721,9 @@ export class CIHelper {
                                 }/git/pull/${prNumber}`;
 
         const addComment = async (body: string): Promise<void>  => {
-            console.log(`Adding comment to ${pullRequestURL}:\n${body}`);
-            await this.github.addPRComment(pullRequestURL, body);
+            const redacted = CIHelper.redactGitHubToken(body);
+            console.log(`Adding comment to ${pullRequestURL}:\n${redacted}`);
+            await this.github.addPRComment(pullRequestURL, redacted);
         };
 
         const gitGitGadget = await GitGitGadget.get(this.gggConfigDir,


### PR DESCRIPTION
In https://github.com/gitgitgadget/git/pull/614#issuecomment-618788883, a push failed because the GitGitGadget GitHub App lacked permissions to update workflows (and pushing a tag with a `.github/workflows/main.yml` file in it qualifies for updating a workflow).

The worst part about this is not so much that the push failed; That is recoverable because GitGitGadget runs on a self-hosted Azure Pipelines agent into which I can `ssh`. The worst part is that the error message showed the token in plain text, and it was still valid for a full hour after that. And that's with Git v2.26.0 as per our recent update in #225 ...

This is the reaction work I did:

- I verified manually that nobody used that token to write bogus things into the repository.
- I wrote a patch for Git so that it anonymizes URLs when showing messages in `git push`: https://github.com/gitgitgadget/git/pull/618
- I built and installed a Git version with that patch and installed it with prefix `/usr/`.
- Then, I edited the two Pipelines (git and gitgitgadget need different Pipelines) to have the environment variable `LOCAL_GIT_DIRECTORY` point to `/usr` so that `dugite` picks up the system Git.
- After that, I edited the permissions required by GitGitGadget to include the `workflow` permission.
- Finally, I pushed the tag with a manually-created token to verify that this now works.

And here is some "defense-in-depth" PR to try to make sure that we anonymize URLs when talking to the user (via PR comments or via Azure Pipeline logs) so that this won't ever occur again. :knock-on-wood: