### PR TITLE
Be smarter about updating commit mappings

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -111,7 +111,7 @@ export class CIHelper {
                 await this.mail2commit.getGitGitCommitForMessageId(messageID);
         }
         if (!upstreamCommit || upstreamCommit === mailMeta.commitInGitGit) {
-                return false;
+            return false;
         }
         mailMeta.commitInGitGit = upstreamCommit;
         if (!mailMeta.originalCommit) {

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -136,6 +136,7 @@ export class CIHelper {
     public async updateCommitMappings(): Promise<boolean> {
         if (!this.gggNotesUpdated) {
             await git(["fetch", "https://github.com/gitgitgadget/git",
+                       "--tags",
                        "+refs/notes/gitgitgadget:refs/notes/gitgitgadget",
                        "+refs/heads/maint:refs/remotes/upstream/maint",
                        "+refs/heads/pu:refs/remotes/upstream/pu"],

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -184,10 +184,16 @@ export class CIHelper {
                 result = true;
             }
 
+            const start = Date.now();
             const out = await git(["-c", "core.abbrev=40", "range-diff", "-s",
                                    info.baseCommit, info.headCommit,
                                    "refs/remotes/upstream/pu"],
                                   { workDir: this.workDir });
+            const duration = Date.now() - start;
+            if (duration > 2000)
+                console.log(`warning: \`git range-diff ${
+                    info.baseCommit} ${info.headCommit} upstream/pu\` took ${
+                    duration / 1000} seconds`);
             for (const line of out.split("\n")) {
                 const match =
                     line.match(/^[^:]*: *([^ ]*) [!=][^:]*: *([^ ]*)/);

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -13,6 +13,7 @@ export interface IGitOptions {
 }
 
 export const emptyBlobName = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391";
+export const emptyTreeName = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
 function trimTrailingNewline(str: string): string {
     return str.replace(/\r?\n$/, "");


### PR DESCRIPTION
The `Update commit mappings` step of https://dev.azure.com/gitgitgadget/git/_build?definitionId=2&_a=summary takes a painfully long time: some 20 minutes.

The reason is that it runs a potentially costly `range-diff` for every single open PR on git/git and gitgitgadget/git, and `range-diff` is inherently costly because it compares every diff in the source range to every diff in the target range (and we use `<baseCommit>..pu` as target range, which can contain thousands of commits).

Let's coalesce the base commits and the head commits (by generating throw-away octopus merges with no ref associated with them) so that we can do a single `range-diff`. This will still be expensive, but not as expensive as running several dozens of them.

For technical reasons (a PR might be based on `pu`), that `range-diff` cannot use the same base for the second commit range. We'll be using `maint~100..pu` instead. Technically, this is a change of behavior, but a good one: we really do not need to look at commits that have been merged into `maint` _long_ ago: a previous run would have already seen those commits.

This addresses https://github.com/gitgitgadget/gitgitgadget/issues/157.