### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Keep npm dependencies up to date
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
As per [this blog post](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/), DependaBot can be used for regular package updates, not just security ones.

Let's hope that I got the syntax right, as there is not really any way to test this (apart from pushing to `master`).