### PR TITLE
GitHubGlue specify started_at for check-run create

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -85,6 +85,7 @@ export class GitHubGlue {
             },
             owner: repositoryOwner,
             repo: this.repo,
+            started_at: completedAt,
             status: "completed",
         });
         return checks.data.id;


### PR DESCRIPTION
Checks on GitHub will now appear to be completed.  Previously
the checks showed a 'running elapsed' timer when the completion
timestamp preceded the started timestamp.

The started_at and completed_at values are now the same.
