### PR TITLE
Update @types/html-to-text to 5.1.1

### DIFF
--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -1,41 +1,33 @@
-import { fromString } from "html-to-text";
+import { fromString, HtmlToTextOptions } from "html-to-text";
 import marked from "marked";
 
-// @types/html-to-text v1.4.31 does not handle the `format` attribute; To work
-// around that, we simply implement a class that has that (we want a different
-// rendering of headings than html-to-text provides by default).
+// Provide our own renderings of headings and blockquotes.
 
-class MyOptions implements HtmlToTextOptions {
-    public hideLinkHrefIfSameAsText = true;
-    public uppercaseHeadings = false;
-    public wordwrap = 76;
+export function md2text(markdown: string, columns = 76): string {
+    const formatOptions: HtmlToTextOptions = {
+        hideLinkHrefIfSameAsText: true,
+        uppercaseHeadings: false,
+        wordwrap: columns,
 
-    public format = {
-        heading(elem: any, fn: any, options: any): string {
-            const heading: string = fn(elem.children, options);
-            const underline = heading.substr(heading.lastIndexOf("\n") + 1)
-                .replace(/./g, "=");
-            return `${heading}\n${underline}\n\n`;
-        },
-        blockquote(elem: any, fn: any, options: any): string {
-            const indentOptions = Object.assign({}, options);
-            // decrease word wrap, but only to a minimum of 20 columns/line
-            indentOptions.wordwrap = Math.max(20, options.wordwrap - 2);
+        format: {
+            heading: (elem, fn, options) => {
+                const heading = fn(elem.children, options);
+                const underline = heading.substr(heading.lastIndexOf("\n") + 1)
+                    .replace(/./g, "=");
+                return `${heading}\n${underline}\n\n`;
+            },
+            blockquote: (elem, fn, options) => {
+                const indentOptions = Object.assign({ wordwrap: 76 }, options);
+                // decrease word wrap, but only to a minimum of 20 columns/line
+                indentOptions.wordwrap = Math.max(20, indentOptions.wordwrap-2);
 
-            const block: string = fn(elem.children, indentOptions);
-            return block.replace(/^>/mg, ">>") // add to quote
-                .replace(/^(?!>|$)/mg, "> ")   // new quote
-                .replace(/(^|\n)(\n)(?!$)/g, "$1>$2"); // quote empty lines
+                const block = fn(elem.children, indentOptions);
+                return block.replace(/^>/mg, ">>") // add to quote
+                    .replace(/^(?!>|$)/mg, "> ")   // new quote
+                    .replace(/(^|\n)(\n)(?!$)/g, "$1>$2"); // quote empty lines
+            },
         },
     };
 
-    public constructor(columns?: number) {
-        if (columns !== undefined) {
-            this.wordwrap = columns;
-        }
-    }
-}
-
-export function md2text(markdown: string, columns?: number): string {
-    return fromString(marked(markdown), new MyOptions(columns));
+    return fromString(marked(markdown), formatOptions);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1326,9 +1326,9 @@
       }
     },
     "@types/html-to-text": {
-      "version": "1.4.31",
-      "resolved": "https://registry.npmjs.org/@types/html-to-text/-/html-to-text-1.4.31.tgz",
-      "integrity": "sha512-9vTFw6vYZNnjPOep9WRXs7cw0vg04pAZgcX9bqx70q1BNT7y9sOJovpbiNIcSNyHF/6LscLvGhtb5Og1T0UEvA=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/html-to-text/-/html-to-text-5.1.1.tgz",
+      "integrity": "sha512-V4eDOSqT3+Md4MBJvV3zF1u9ImXFQJp62qceBZlI9LTkH5lj8m6QWVWKmlQNWVB0XDKLezL0CBi318JF69S5SQ=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@octokit/auth-app": "^2.4.4",
     "@octokit/rest": "^17.9.3",
-    "@types/html-to-text": "^1.4.31",
+    "@types/html-to-text": "^5.1.1",
     "@types/rfc2047": "^2.0.1",
     "commander": "^5.1.0",
     "dugite": "^1.91.1",


### PR DESCRIPTION
The types are updated to support the format attribute so a local instance of HtmlToTextOptions is now used.

In `blockquote(),` `indentOptions.wordwrap` is provided in the target for Object.assign to overcome `wordwrap` being optional in the interface (and a couple of possible types).  It is provided in `formatOptions` but the compiler can not know that is the instance that will be passed to `blockquote()`.