### PR TITLE
Accommodate for git/git renaming `pu` -> `seen`

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -139,7 +139,7 @@ export class CIHelper {
                        "--tags",
                        "+refs/notes/gitgitgadget:refs/notes/gitgitgadget",
                        "+refs/heads/maint:refs/remotes/upstream/maint",
-                       "+refs/heads/pu:refs/remotes/upstream/pu"],
+                       "+refs/heads/seen:refs/remotes/upstream/seen"],
                       { workDir: this.workDir });
             this.gggNotesUpdated = true;
         }
@@ -152,10 +152,10 @@ export class CIHelper {
             return false;
         }
 
-        const commitsInPu: Set<string> = new Set<string>(
+        const commitsInSeen: Set<string> = new Set<string>(
             (await git(["rev-list", "--no-merges",
                         "^refs/remotes/upstream/maint~100",
-                        "refs/remotes/upstream/pu"],
+                        "refs/remotes/upstream/seen"],
                        { workDir: this.workDir })).split("\n"),
         );
         let result = false;
@@ -182,12 +182,12 @@ export class CIHelper {
             }
             const meta = await this.getMailMetadata(messageID);
             if (!meta || meta.commitInGitGit !== undefined) {
-                if (!meta || commitsInPu.has(meta.commitInGitGit!)) {
+                if (!meta || commitsInSeen.has(meta.commitInGitGit!)) {
                     continue;
                 }
                 console.log(`Upstream commit ${meta.commitInGitGit} for ${
                     info.headCommit} of ${
-                    info.pullRequestURL} no longer found in pu`);
+                    info.pullRequestURL} no longer found in 'seen'`);
                 meta.commitInGitGit = undefined;
                 result = true;
             }
@@ -212,7 +212,7 @@ export class CIHelper {
 
             const range1 = `${await octopus(bases)}..${await octopus(heads)}`;
             const range2 =
-                "refs/remotes/upstream/maint~100..refs/remotes/upstream/pu";
+                "refs/remotes/upstream/maint~100..refs/remotes/upstream/seen";
             const start = Date.now();
             const out = await git(["-c", "core.abbrev=40", "range-diff", "-s",
                                    range1, range2],
@@ -367,7 +367,7 @@ export class CIHelper {
 
         let closePR: string | undefined;
         const prLabelsToAdd = [];
-        for (const branch of ["pu", "next", "master", "maint"]) {
+        for (const branch of ["seen", "next", "master", "maint"]) {
             const mergeCommit =
                 await this.identifyMergeCommit(branch, tipCommitInGitGit);
             if (!mergeCommit) {

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -209,7 +209,7 @@ export class GitGitGadget {
             "+refs/heads/maint:refs/remotes/upstream/maint",
             "+refs/heads/master:refs/remotes/upstream/master",
             "+refs/heads/next:refs/remotes/upstream/next",
-            "+refs/heads/pu:refs/remotes/upstream/pu",
+            "+refs/heads/seen:refs/remotes/upstream/seen",
         ];
         const prArgs = [
             `+${pullRequestRef}:${pullRequestRef}`,

--- a/lib/mail-commit-mapping.ts
+++ b/lib/mail-commit-mapping.ts
@@ -32,7 +32,7 @@ export class MailCommitMapping {
             refs.push("refs/notes/mail-to-commit:refs/notes/mail-to-commit");
         }
         if (includeUpstreamBranches) {
-            for (const ref of ["pu", "next", "master", "maint"]) {
+            for (const ref of ["seen", "next", "master", "maint"]) {
                 refs.push(`+refs/heads/${ref}:refs/remotes/upstream/${ref}`);
             }
         }

--- a/lib/patch-series-metadata.ts
+++ b/lib/patch-series-metadata.ts
@@ -1,4 +1,4 @@
-export type GitGitIntegrationBranch = "maint" | "master" | "next" | "pu";
+export type GitGitIntegrationBranch = "maint" | "master" | "next" | "seen" | "pu";
 
 export interface IPatchSeriesMetadata {
     readonly pullRequestURL?: string;

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -49,7 +49,7 @@ export class ProjectOptions {
             // Git
             to = "--to=git@vger.kernel.org";
             // Do *not* Cc: Junio Hamano by default
-            upstreamBranch = "upstream/pu";
+            upstreamBranch = "upstream/seen";
             if (await git(["rev-list", branchName + ".." + upstreamBranch],
                           { workDir })) {
                 upstreamBranch = "upstream/next";

--- a/script/lookup-commit.sh
+++ b/script/lookup-commit.sh
@@ -63,7 +63,7 @@ update_gitgit_dir () {
 	git -C "$GITGIT_DIR" fetch https://github.com/gitgitgadget/git refs/notes/commit-to-mail:refs/notes/commit-to-mail ||
 	die "Could not update refs/notes/commit-to-mail"
 
-	if git -C "$GITGIT_DIR" rev-parse --verify refs/remotes/gitster/pu >/dev/null 2>&1
+	if git -C "$GITGIT_DIR" rev-parse --verify refs/remotes/gitster/seen >/dev/null 2>&1
 	then
 		git -C "$GITGIT_DIR" fetch gitster ||
 		die "Could not update the 'gitster' remote to $GITGIT_DIR"
@@ -175,8 +175,8 @@ test notes != "$mode" || {
 		update_gitgit_dir ||
 		die "Could not update $GITGIT_DIR"
 
-		to="$(git -C "$GITGIT_DIR" rev-parse --verify refs/remotes/gitster/pu)" ||
-		die "Could not determine tip rev of gitster/pu"
+		to="$(git -C "$GITGIT_DIR" rev-parse --verify refs/remotes/gitster/seen)" ||
+		die "Could not determine tip rev of gitster/seen"
 		from="$(git -C "$GITGIT_DIR" show -s --format=%s refs/notes/commit-to-mail^{/Update.from.commit.range} 2>/dev/null | sed -ne 's/"//g' -e 's/^Update from commit range \(.*\.\.\)\?//p')"
 
 		# Already the newest? Skip

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -138,7 +138,7 @@ async function setupRepos(instance: string):
     // Set up fake upstream branches
     await gggRemote.git(["branch", "maint"]);
     await gggRemote.git(["branch", "next"]);
-    await gggRemote.git(["branch", "pu"]);
+    await gggRemote.git(["branch", "seen"]);
 
     return { worktree, gggLocal, gggRemote };
 }
@@ -165,13 +165,13 @@ test("identify merge that integrated some commit", async () => {
     const b = await repo.commit("b");
     const c = await repo.merge("c", e);
     const d = await repo.merge("d", f);
-    await repo.git(["update-ref", "refs/remotes/upstream/pu", d]);
+    await repo.git(["update-ref", "refs/remotes/upstream/seen", d]);
 
     const ci = new CIHelper(repo.workDir);
     expect(b).not.toBeUndefined();
-    expect(await ci.identifyMergeCommit("pu", g)).toEqual(d);
-    expect(await ci.identifyMergeCommit("pu", e)).toEqual(c);
-    expect(await ci.identifyMergeCommit("pu", h)).toEqual(d);
+    expect(await ci.identifyMergeCommit("seen", g)).toEqual(d);
+    expect(await ci.identifyMergeCommit("seen", e)).toEqual(c);
+    expect(await ci.identifyMergeCommit("seen", h)).toEqual(d);
 });
 
 test("identify upstream commit", async () => {
@@ -188,7 +188,7 @@ test("identify upstream commit", async () => {
     expect(A).not.toBeUndefined();
     await gggRemote.git(["branch", "maint"]);
     await gggRemote.git(["branch", "next"]);
-    await gggRemote.git(["branch", "pu"]);
+    await gggRemote.git(["branch", "seen"]);
 
     // Now come up with a local change
     await worktree.git(["pull", gggRemote.workDir, "master"]);
@@ -209,7 +209,7 @@ test("identify upstream commit", async () => {
     // "Apply" the patch, and merge it
     await gggRemote.newBranch("gg/via-pull-request");
     const B = await gggRemote.commit("B");
-    await gggRemote.git(["checkout", "pu"]);
+    await gggRemote.git(["checkout", "seen"]);
     await gggRemote.git(["merge", "--no-ff", "gg/via-pull-request"]);
 
     // Update the `mail-to-commit` notes ref, at least the part we care about


### PR DESCRIPTION
There is actually no more `pu` branch in https://github.com/git/git.

For the announcement, see https://lore.kernel.org/git/nycvar.QRO.7.76.6.2006231445190.54@tvgsbejvaqbjf.bet/T/#m5e56de8993832619e8412589946449f002735b6e (and https://github.com/git/git/blob/a4a549d7cbd23a401f0c6db9602c6fbacb6ad8c2/whats-cooking.txt#L21-L26).

The only slightly tricky aspect is the `GitGitIntegrationBranch` type: for backwards-compatibility, we should _expect_ the metadata to contain `pu` as a valid value.