### PR TITLE
azure-pipeline: target the new main branch, too

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
+- main
 - master
 
 pool:


### PR DESCRIPTION
This is needed to keep the CI and PR builds going.

I also considered using `main` in some of the integration tests, but decided that this is not really needed right now.