### PR TITLE
Allow unquoted keys in gitgitgadget.cismtpopts in config

### DIFF
--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -159,7 +159,10 @@ export async function sendMail(mail: IParsedMBox,
     };
 
     if (smtpOptions.smtpOpts) {
-        Object.entries(JSON.parse(smtpOptions.smtpOpts))
+        // Add quoting for JSON.parse
+        const smtpOpts = smtpOptions.smtpOpts
+            .replace(/([ {])([a-zA-Z0-9.]+?) *?:/g,"$1\"$2\":");
+        Object.entries(JSON.parse(smtpOpts))
             .forEach(([key, value]) => transportOpts[key] = value);
     }
 

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -19,9 +19,7 @@ jest.setTimeout(180000);
 //  CIsmtpUser = first.last@ethereal.email
 //  CIsmtphost = smtp.ethereal.email
 //  CIsmtppass = feedeadbeeffeeddeadbeef
-//  CIsmtpopts = { \"port\": 587, \"secure\": false, \
-//     \"tls\": { \"rejectUnauthorized\": false } }
-// The CIsmtpOpts must have the keys quoted.
+//  CIsmtpopts = {port: 587, secure: false, tls: {rejectUnauthorized: false}}
 
 async function getSMTPInfo():
     Promise <{ smtpUser: string; smtpHost: string;


### PR DESCRIPTION
Quotes will now be added to gitgitgadget.cismtpopts JSON keys as needed.
Quoting can be difficult to set in automation where env variables may
be used to issue git config commands.

A possible GitHub [action](https://github.com/webstech/gitgitgadget/blob/workflow/.github/workflows/dev-test.yml) may need the cismtopts set as a secret.  The windows cmd environment has problems setting the config.