### PR TITLE
Report The Patch Tag on Submit Command

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -601,9 +601,19 @@ export class CIHelper {
                         `\n\nWARNING: ${comment.author
                         } has no public email address set on GitHub` : "";
 
-                    const coverMid = await gitGitGadget.submit(pr, userInfo);
+                    const metadata = await gitGitGadget.submit(pr, userInfo);
+                    const uri = "https://github.com/gitgitgadget/git";
+                    const code = "\n```";
                     await addComment(`Submitted as [${
-                        coverMid}](https://lore.kernel.org/git/${coverMid})${
+                            metadata?.coverLetterMessageId
+                            }](https://lore.kernel.org/git/${
+                            metadata?.coverLetterMessageId
+                            })\n\nTo fetch this version into \`FETCH_HEAD\`:${
+                            code}\ngit fetch ${uri} ${metadata?.latestTag}${code
+                            }\n\nTo fetch this version to local tag \`${
+                            metadata?.latestTag}\`:${
+                            code}\ngit fetch --no-tags ${
+                            uri} tag ${metadata?.latestTag}${code}${
                             extraComment}`);
                 }
 
@@ -626,8 +636,9 @@ export class CIHelper {
                                                            userInfo);
 
                 if (commitOkay) {
-                    const coverMid = await gitGitGadget.preview(pr, userInfo);
-                    await addComment(`Preview email sent as ${coverMid}`);
+                    const metadata = await gitGitGadget.preview(pr, userInfo);
+                    await addComment(`Preview email sent as ${
+                        metadata?.coverLetterMessageId}`);
                 }
 
             } else if (command === "/allow") {

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -171,7 +171,7 @@ export class GitGitGadget {
 
     // Send emails only to the user
     public async preview(pr: IPullRequestInfo, userInfo: IGitHubUser):
-        Promise<string | undefined> {
+        Promise<IPatchSeriesMetadata | undefined> {
 
         const send = async (mail: string): Promise<string> => {
             const mbox = await parseMBox(mail);
@@ -186,7 +186,7 @@ export class GitGitGadget {
 
     // Send emails out for review
     public async submit(pr: IPullRequestInfo, userInfo: IGitHubUser):
-        Promise<string | undefined> {
+        Promise<IPatchSeriesMetadata | undefined> {
 
         const send = async (mail: string): Promise<string> => {
             return await parseHeadersAndSendMail(mail, this.smtpOptions);
@@ -256,7 +256,7 @@ export class GitGitGadget {
     protected async genAndSend(pr: IPullRequestInfo, userInfo: IGitHubUser,
                                options: PatchSeriesOptions,
                                send: SendFunction):
-        Promise<string | undefined> {
+        Promise<IPatchSeriesMetadata | undefined> {
 
         if (!new Set(["gitgitgadget", "dscho", "git"]).has(pr.baseOwner) ||
             pr.baseRepo !== "git") {
@@ -278,10 +278,10 @@ export class GitGitGadget {
                                            pr.headCommit, options,
                                            userInfo.name, userInfo.email);
 
-        const coverMid =
+        const patchSeriesMetadata =
             await series.generateAndSend(console, send,
                                          this.publishTagsAndNotesToRemote,
                                          pr.pullRequestURL, new Date());
-        return coverMid;
+        return patchSeriesMetadata;
     }
 }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -662,7 +662,7 @@ export class PatchSeries {
                                  publishTagsAndNotesToRemote?: string,
                                  pullRequestURL?: string,
                                  forceDate?: Date):
-        Promise<string | undefined> {
+        Promise<IPatchSeriesMetadata | undefined> {
         let globalOptions: IGitGitGadgetOptions | undefined;
         if (this.options.dryRun) {
             logger.log(`Dry-run ${this.project.branchName
@@ -755,6 +755,9 @@ export class PatchSeries {
             tagName = `${tagPrefix}${prNumber}/${branch}-v${
                 this.metadata.iteration}`;
         }
+
+        this.metadata.latestTag = tagName;
+
         if (this.project.publishToRemote) {
             const url =
                 await gitConfig(`remote.${this.project.publishToRemote}.url`,
@@ -777,7 +780,6 @@ export class PatchSeries {
         } else {
             logger.log("Generating tag object");
             await this.generateTagObject(tagName, tagMessage);
-            this.metadata.latestTag = tagName;
         }
 
         const footers: string[] = [];
@@ -905,7 +907,7 @@ export class PatchSeries {
                       { workDir: this.notes.workDir });
         }
 
-        return this.metadata.coverLetterMessageId;
+        return this.metadata;
     }
 
     protected async generateMBox(): Promise<string> {

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -229,8 +229,11 @@ to have included in git.git [https://github.com/git/git].`);
 
         return "Message-ID";
     }
-    expect(await patches.generateAndSend(logger, send, undefined,
-                                         pullRequestURL))
+
+    const metadata = await patches.generateAndSend(logger, send, undefined,
+                                                   pullRequestURL);
+
+    expect(metadata?.coverLetterMessageId)
         .toMatch(/pull\.1\.git\.\d+\.gitgitgadget@example\.com/);
     expect(mails).toEqual(expectedMails);
 
@@ -244,8 +247,10 @@ to have included in git.git [https://github.com/git/git].`);
                                        "somebody:master", headCommit2,
                                        {}, "GitHub User", undefined);
     mails.splice(0);
-    expect(await patches2.generateAndSend(logger, send, undefined,
-                                          pullRequestURL))
+    const metadata2 = await patches2.generateAndSend(logger, send, undefined,
+                                                     pullRequestURL);
+
+    expect(metadata2?.coverLetterMessageId)
         .toMatch(/pull\.1\.v2\.git\.\d+\.gitgitgadget@example\.com/);
     expect(mails.length).toEqual(5);
     if (await gitCommandExists("range-diff", repo.workDir)) {


### PR DESCRIPTION
Provide easy to copy git fetch instructions for fetching the
submitted version of the patches. The comment will now include:

To fetch this version into `FETCH_HEAD`:
```
git fetch https://github.com/gitgitgadget/git <ggg-tag-name>
```

To fetch this version to local tag <ggg-tag-name>:
```
git fetch --no-tags https://github.com/gitgitgadget/git tag <ggg-tag-name>
```
This addresses issue #274. 