### PR TITLE
Clarify `From:` and add `Sender:` Email fields

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -10,6 +10,7 @@ import { md2text } from "./markdown-renderer";
 import { IPatchSeriesMetadata } from "./patch-series-metadata";
 import { PatchSeriesOptions } from "./patch-series-options";
 import { ProjectOptions } from "./project-options";
+import { decode } from "rfc2047";
 
 export interface ILogger {
     log(message: string): void;
@@ -450,7 +451,7 @@ export class PatchSeries {
             let header = match[1];
 
             const authorMatch =
-                header.match(/^([^]*\nFrom: )(.*?)(\n(?![ \t])[^]*)$/);
+                header.match(/^([^]*\nFrom: )(.*?>)(\n(?![ \t])[^]*)$/s);
             if (!authorMatch) {
                 throw new Error("No From: line found in header:\n\n" + header);
             }
@@ -486,7 +487,8 @@ export class PatchSeries {
                 header += "\nCc: " + authorMatch[2];
             }
 
-            mails[i] = header + "\n\nFrom: " + authorMatch[2] + match[2];
+            mails[i] = header + "\n\nFrom: " + decode(authorMatch[2]) +
+                match[2];
         });
     }
 

--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -9,6 +9,7 @@ export interface IParsedMBox {
     from?: string;
     headers?: Array<{ key: string; value: string }>;
     messageId?: string;
+    sender?: string;
     subject?: string;
     to?: string;
     raw: string;
@@ -57,6 +58,7 @@ export async function parseMBox(mbox: string, gentle?: boolean):
     let from: string | undefined;
     const headers = new Array<{ key: string; value: string }>();
     let messageId: string | undefined;
+    let sender: string | undefined;
     let subject: string | undefined;
     let to: string | undefined;
 
@@ -73,6 +75,7 @@ export async function parseMBox(mbox: string, gentle?: boolean):
             case "fcc": break;
             case "from": from = decode(value.trim()); break;
             case "message-id": messageId = value; break;
+            case "sender": sender = value.trim(); break;
             case "subject": subject = value; break;
             case "to": to = value; break;
             default:
@@ -92,6 +95,7 @@ export async function parseMBox(mbox: string, gentle?: boolean):
         headers,
         messageId,
         raw: mbox,
+        sender,
         subject,
         to,
     };
@@ -177,6 +181,7 @@ export async function sendMail(mail: IParsedMBox,
                 to: mail.to,
             },
             raw: mail.raw,
+            sender: mail.sender ? mail.sender : undefined,
         };
 
         transporter.sendMail(mailOptions, (error, info): void => {

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -12,7 +12,7 @@ jest.setTimeout(60000);
 const expectedMails = [
     `From 91fba7811291c1064b2603765a2297c34fc843c0 Mon Sep 17 00:00:00 2001
 Message-Id: <pull.<Message-ID>>
-From: "GitHub User via GitGitGadget" <gitgitgadget@example.com>
+From: GitHub User <ghuser@example.net>
 Date: <Cover-Letter-Date>
 Subject: [PATCH 0/3] My first Pull Request!
 Fcc: Sent
@@ -21,6 +21,7 @@ Content-Transfer-Encoding: 8bit
 MIME-Version: 1.0
 To: reviewer@example.com
 Cc: Some Body <somebody@example.com>
+Sender: GitGitGadget <gitgitgadget@example.com>
 
 This Pull Request contains some really important changes that I would love
 to have included in git.git [https://github.com/git/git].
@@ -56,7 +57,7 @@ gitgitgadget
 Message-Id: <3a632624f5927565b178664f9a12b9802d2714b1.<Message-ID>>
 In-Reply-To: <pull.<Message-ID>>
 References: <pull.<Message-ID>>
-From: "Test H. Dev via GitGitGadget" <gitgitgadget@example.com>
+From: GitHub User <ghuser@example.net>
 Date: Fri, 13 Feb 2009 23:33:30 +0000
 Subject: [PATCH 1/3] A
 Fcc: Sent
@@ -66,6 +67,7 @@ MIME-Version: 1.0
 To: reviewer@example.com
 Cc: Some Body <somebody@example.com>,
     "Test H. Dev" <dev@example.com>
+Sender: GitGitGadget <gitgitgadget@example.com>
 
 From: "Test H. Dev" <dev@example.com>
 
@@ -90,7 +92,7 @@ gitgitgadget
 Message-Id: <0076a21b90c6e1f4f380deb464fe7145d4a7a56d.<Message-ID>>
 In-Reply-To: <pull.<Message-ID>>
 References: <pull.<Message-ID>>
-From: "Contributor via GitGitGadget" <gitgitgadget@example.com>
+From: GitHub User <ghuser@example.net>
 Date: Fri, 13 Feb 2009 23:34:30 +0000
 Subject: [PATCH 2/3] B
 Fcc: Sent
@@ -100,6 +102,7 @@ MIME-Version: 1.0
 To: reviewer@example.com
 Cc: Some Body <somebody@example.com>,
     Contributor <contributor@example.com>
+Sender: GitGitGadget <gitgitgadget@example.com>
 
 From: Contributor <contributor@example.com>
 
@@ -124,7 +127,7 @@ gitgitgadget
 Message-Id: <91fba7811291c1064b2603765a2297c34fc843c0.<Message-ID>>
 In-Reply-To: <pull.<Message-ID>>
 References: <pull.<Message-ID>>
-From: "Developer via GitGitGadget" <gitgitgadget@example.com>
+From: GitHub User <ghuser@example.net>
 Date: Fri, 13 Feb 2009 23:35:30 +0000
 Subject: [PATCH 3/3] C
 Fcc: Sent
@@ -134,6 +137,7 @@ MIME-Version: 1.0
 To: reviewer@example.com
 Cc: Some Body <somebody@example.com>,
     Developer <developer@example.com>
+Sender: GitGitGadget <gitgitgadget@example.com>
 
 From: Developer <developer@example.com>
 
@@ -210,7 +214,7 @@ Cc: Some Body <somebody@example.com>
                                        pullRequestBody,
                                        "gitgitgadget:next", baseCommit,
                                        "somebody:master", headCommit,
-                                       {}, "GitHub User", undefined);
+                                       {}, "GitHub User", "ghuser@example.net");
 
     expect(patches.coverLetter).toEqual(`My first Pull Request!
 

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -89,7 +89,7 @@ class PatchSeriesTest extends PatchSeries {
 
         test("non-ASCII characters are encoded correctly", () => {
             // tslint:disable-next-line:max-line-length
-            const needle = "\"=?UTF-8?Q?Nguy=E1=BB=85n_Th=C3=A1i_Ng=E1=BB=8Dc?= Duy via GitGitGadget\" ";
+            const needle = "=?UTF-8?Q?Nguy=E1=BB=85n_Th=C3=A1i_Ng=E1=BB=8Dc?= Duy";
             expect(mails[0]).toEqual(expect.stringContaining(needle));
         });
 
@@ -119,7 +119,7 @@ class PatchSeriesTest extends PatchSeries {
         test("Cc: is inserted correctly", () => {
             expect(mails[1]).toMatch(
                 // tslint:disable-next-line:max-line-length
-                /From: "Some One Else via GitGitGadget"[^]*\nCc: Some One Else[^]*\n\nFrom: Some One Else.*\n\n/);
+                /Cc: Some One Else[^]*\nSender[^]*\n\nFrom: Some One Else.*\n\n/);
         });
 
         const coverLetter = PatchSeries.adjustCoverLetter(mails[0]);


### PR DESCRIPTION
For GGG, record the user who did the pull request on the "From:" header of cover letter and patches in the series.  Do not add the user to the `Cc:` list.

Only add in-body From: as necessary to record the commit author name when it is different from the user who created the pull request.  Do not re-add the commit author name if already in the `Cc:` list.

Use "Sender:" to record the fact that the message is sent from gitgitgadget@gmail.com.

This addresses issue #228. 

This initial PR includes comments to be removed (they may or may not be helpful).

Are more unit tests needed to verify the handling of `cc` and in body `from` lines?