### PR TITLE
Add a Cc: for replies on the Git mailing list

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -92,6 +92,33 @@ export class GitHubGlue {
     }
 
     /**
+     * Add a cc to a Pull Request
+     *
+     * @param {string} pullRequestURL the Pull Request to comment on
+     * @param {string} cc to add
+     * @returns the comment ID and the URL to the comment
+     */
+    public async addPRCc(pullRequestURL: string, cc: string):
+        Promise<void> {
+        const id = cc.match(/(<.*>)/);
+
+        if (!id || id[1].match(/gitster@pobox\.com/)) {
+            return;
+        }
+
+        const url = GitGitGadget.parsePullRequestURL(pullRequestURL);
+        const pr = await this.getPRInfo(url[0], url[2]);
+        const ccNow = pr.body.match(/\n\n(cc:.*)/is);
+
+        if (!ccNow || !ccNow[1].match(id[1])) {
+            await this.updatePR(url[0], url[2], `${pr.body}${
+                ccNow ? "" : "\n"}\ncc: ${cc}`);
+            await this.addPRComment(pullRequestURL, `User \`${
+                                    cc}\` has been added to the cc: list.`);
+        }
+    }
+
+    /**
      * Add a Pull Request comment
      *
      * @param {string} pullRequestURL the Pull Request to comment on

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -180,6 +180,30 @@ export class GitHubGlue {
         };
     }
 
+    /**
+     * Update a Pull Request body or title
+     *
+     * @param {string} pullRequestURL the Pull Request to comment on
+     * @param {string} body the updated body
+     * @param {string} title the updated title
+     * @returns the PR number
+     */
+    public async updatePR(owner: string, prNumber: number,
+                          body?: string | undefined, title?: string):
+        Promise<number> {
+
+        await this.ensureAuthenticated(owner);
+        const result = await this.client.pulls.update({
+            "body": body || undefined,
+            owner,
+            pull_number: prNumber,
+            repo: this.repo,
+            "title": title || undefined,
+        });
+
+        return result.data.id;
+    }
+
     public async setPRLabels(pullRequestURL: string, labels: string[]):
         Promise<string[]> {
         const [owner, repo, prNo] =

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -157,6 +157,9 @@ export class MailArchiveGitHelper {
                         .addPRComment(pullRequestURL, comment);
                 }
 
+                await this.githubGlue.addPRCc(pullRequestURL,
+                                              parsedMbox.from || "");
+
                 await this.gggNotes.set(parsed.messageID, {
                     issueCommentId,
                     messageID: parsed.messageID,

--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -97,12 +97,8 @@ export async function parseMBox(mbox: string, gentle?: boolean):
     };
 }
 
-export async function parseMBoxMessageIDAndReferences(mbox: string):
+export async function parseMBoxMessageIDAndReferences(parsed: IParsedMBox):
         Promise<{messageID: string; references: string[]}> {
-    const parsed = await parseMBox(mbox, true);
-    if (!parsed.headers) {
-        throw new Error(`Could not parse ${mbox}`);
-    }
     const references: string[] = [];
     const seen: Set<string> = new Set<string>();
     /*
@@ -117,7 +113,7 @@ export async function parseMBoxMessageIDAndReferences(mbox: string):
      */
     const msgIdRegex =
         /^\s*<([^>]+)>(\s*|,)(\([^")]*("[^"]*")?\)\s*|\([^)]*\)$)?(<.*)?$/;
-    for (const header of parsed.headers) {
+    for (const header of parsed.headers ?? []) {
         if (header.key === "In-Reply-To" || header.key === "References") {
             let value: string = header.value;
             while (value) {
@@ -137,7 +133,7 @@ export async function parseMBoxMessageIDAndReferences(mbox: string):
         }
     }
     if (!parsed.messageId) {
-        throw new Error(`No Message-ID found in ${mbox}`);
+        throw new Error(`No Message-ID found in ${parsed.raw}`);
     }
     const messageID = parsed.messageId.match(/^<(.*)>$/);
     if (!messageID) {

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -167,6 +167,17 @@ test("pull requests", async () => {
         const prNewTitle = await github.getPRInfo(owner, prData.number);
         expect(prNewTitle.title).toMatch(prTitle);
 
+        // Test cc update to PR
+        const prCc = "Not Real <ReallyNot@saturn.cosmos>";
+        const prCcGitster = "Git Real <gitster@pobox.com>"; // filtered out
+        await github.addPRCc(prData.html_url, prCc);
+        await github.addPRCc(prData.html_url, prCc);
+        const prccinfo = await github.getPRInfo(owner, prData.number);
+        expect(prccinfo.body).toMatch(prCc);
+        const ccFound = prccinfo.body.match(prCc);
+        expect(ccFound?.length).toEqual(1);
+        expect(prccinfo.body).not.toMatch(prCcGitster);
+
         const newComment = "Adding a comment to the PR";
         const {id, url} = await github.addPRComment(prData.html_url,
                                                     newComment);

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -155,6 +155,18 @@ test("pull requests", async () => {
         const prInfo = await github.getPRInfo(owner, prData.number);
         expect(prInfo.headLabel).toMatch(branch);
 
+        // Test update to PR body
+        const prBody = `${prInfo.body}\nGlue`;
+        await github.updatePR(owner, prData.number, prBody);
+        const prNewInfo = await github.getPRInfo(owner, prData.number);
+        expect(prNewInfo.body).toMatch(prBody);
+
+        // Test update to PR title
+        const prTitle = `${prInfo.title} Glue`;
+        await github.updatePR(owner, prData.number, undefined, prTitle);
+        const prNewTitle = await github.getPRInfo(owner, prData.number);
+        expect(prNewTitle.title).toMatch(prTitle);
+
         const newComment = "Adding a comment to the PR";
         const {id, url} = await github.addPRComment(prData.html_url,
                                                     newComment);


### PR DESCRIPTION
When processing email replies to the Git mailing list the cc: footer will be updated to include people who were not already on the list.  gitster@pobox.com will be excluded from the list.

A comment is added to indicate the cc: list has been updated.

**Refactor mbox Parsing in handle-new-mails**

Function parseMBox was called from both mail-archive-helper processMails() and send-mail parseMBoxMessageIDAndReferences(). processMails() will now call parseMBoxMessageIDAndReferences() with a parsed mail.

**Add GitHubGlue::updatePR() to Update Title or Body**

Tests are also included.