### PR TITLE
Revert "Clarify `From:` and add `Sender:` Email fields"

### DIFF
--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -9,7 +9,6 @@ export interface IParsedMBox {
     from?: string;
     headers?: Array<{ key: string; value: string }>;
     messageId?: string;
-    sender?: string;
     subject?: string;
     to?: string;
     raw: string;
@@ -58,7 +57,6 @@ export async function parseMBox(mbox: string, gentle?: boolean):
     let from: string | undefined;
     const headers = new Array<{ key: string; value: string }>();
     let messageId: string | undefined;
-    let sender: string | undefined;
     let subject: string | undefined;
     let to: string | undefined;
 
@@ -75,7 +73,6 @@ export async function parseMBox(mbox: string, gentle?: boolean):
             case "fcc": break;
             case "from": from = decode(value.trim()); break;
             case "message-id": messageId = value; break;
-            case "sender": sender = value.trim(); break;
             case "subject": subject = value; break;
             case "to": to = value; break;
             default:
@@ -95,7 +92,6 @@ export async function parseMBox(mbox: string, gentle?: boolean):
         headers,
         messageId,
         raw: mbox,
-        sender,
         subject,
         to,
     };
@@ -181,7 +177,6 @@ export async function sendMail(mail: IParsedMBox,
                 to: mail.to,
             },
             raw: mail.raw,
-            sender: mail.sender ? mail.sender : undefined,
         };
 
         transporter.sendMail(mailOptions, (error, info): void => {

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -539,22 +539,22 @@ test("handle comment submit email success", async () => {
         prNumber,
     };
     const user = {
-        email: "user@example.com",
+        email: "ggg@example.com",
         login: "ggg",
-        name: "Test User",
+        name: "e. e. cummings",
         type: "basic",
     };
     const commits = [{
         author: {
-            email: "bbb@exampleb.com",
-            login: "bbb",
-            name: "b. b. cummings",
+            email: "ggg@example.com",
+            login: "ggg",
+            name: "e. e. cummings",
         },
-        commit: B,
+        commit: "BA55FEEDBEEF",
         committer: {
-            email: "bbb@exampleb.com",
-            login: "bbb",
-            name: "b. b. cummings",
+            email: "ggg@example.com",
+            login: "ggg",
+            name: "e. e. cummings",
         },
         message: "Submit ok\n\nSuccint message\n\nSigned-off-by: x",
         parentCount: 1,
@@ -567,150 +567,6 @@ test("handle comment submit email success", async () => {
         baseRepo: "git",
         body: `Super body\r\n${template}\r\nCc: Copy One <copy@cat.com>\r\n`
             + "Cc: Copy Two <copycat@cat.com>",
-        hasComments: true,
-        headCommit: B,
-        headLabel: "somebody:master",
-        mergeable: true,
-        number: prNumber,
-        pullRequestURL: "https://github.com/gitgitgadget/git/pull/59",
-        title: "Submit a fun fix",
-    };
-
-    const { smtpUser } = await getSMTPInfo();
-
-    if (smtpUser) {                 // if configured for this test
-        ci.setGHgetPRInfo(prinfo);
-        ci.setGHgetPRComment(comment);
-        ci.setGHgetPRCommits(commits);
-        ci.setGHgetGitHubUserInfo(user);
-
-        await ci.handleComment("gitgitgadget", 433865360);
-        expect(ci.addPRComment.mock.calls[0][1]).toMatch(/Submitted as/);
-    }
-});
-
-// Multiple commits with different authors.  The email needs to be
-// correct.
-test("handle comment submit email success multi commits", async () => {
-    const { worktree, gggLocal, gggRemote } = await setupRepos("s4");
-
-    const ci = new TestCIHelper(gggLocal.workDir, false, worktree.workDir);
-    const prNumber = 59;
-
-    const template = "fine template\r\nnew line";
-    // add template to master repo
-    await gggRemote.commit("temple", ".github//PULL_REQUEST_TEMPLATE.md",
-                           template);
-    const A = await gggRemote.revParse("HEAD");
-    expect(A).not.toBeUndefined();
-
-    // Now come up with a local change
-    await worktree.git(["pull", gggRemote.workDir, "master"]);
-    const b1Author = "b1 Author";
-    const b1AuthorEmail = "b1Author@example.com";
-    const b1Commit = "b1 Commit";
-    const b1CommitEmail = "b1Commit@example.com";
-    process.env.GIT_AUTHOR_EMAIL = b1AuthorEmail;
-    process.env.GIT_AUTHOR_NAME = b1Author;
-    process.env.GIT_COMMITTER_EMAIL = b1CommitEmail;
-    process.env.GIT_COMMITTER_NAME = b1Commit;
-    const B1 = await worktree.commit("b1");
-
-    const b2Author = "Ævar Arnfjörð Bjarmason"; // "b2 Author";
-    const b2AuthorEmail = "b2Author@example.com";
-    const b2Commit = "b2 Commit";
-    const b2CommitEmail = "b2Commit@example.com";
-    process.env.GIT_AUTHOR_EMAIL = b2AuthorEmail;
-    process.env.GIT_AUTHOR_NAME = b2Author;
-    process.env.GIT_COMMITTER_EMAIL = b2CommitEmail;
-    process.env.GIT_COMMITTER_NAME = b2Commit;
-    const B2 = await worktree.commit("b2");
-
-    delete process.env.GIT_AUTHOR_EMAIL;
-    delete process.env.GIT_AUTHOR_NAME;
-    delete process.env.GIT_COMMITTER_EMAIL;
-    delete process.env.GIT_COMMITTER_NAME;
-
-    const B = await worktree.commit("b");
-
-    // get the pr refs in place
-    const pullRequestRef = `refs/pull/${prNumber}`;
-    await gggRemote.git([
-        "fetch", worktree.workDir,
-        `refs/heads/master:${pullRequestRef}/head`,
-        `refs/heads/master:${pullRequestRef}/merge`,
-    ]); // fake merge
-
-    await gggLocal.git(["config", "user.name", "GitGitGadget"]);
-    await gggLocal.git(["config", "user.email", "gitgitgadget@example.com"]);
-
-    // GitHubGlue Responses
-    const comment = {
-        author: "ggg",
-        body: "/submit   ",
-        prNumber,
-    };
-    const user = {
-        email: "user@example.com",
-        login: "ggg",
-        name: "Test User",
-        type: "basic",
-    };
-    const commits = [{
-        author: {
-            email: "ggg@example.com",
-            login: "ggg",
-            name: "e. e. cummings",
-        },
-        commit: B1,
-        committer: {
-            email: "ggg@example.com",
-            login: "ggg",
-            name: "e. e. cummings",
-        },
-        message: `Submit ok\n\nSigned-off-by: ${b1Author}`,
-        parentCount: 1,
-    },
-                     {
-        author: {
-            email: "ggg@example.com",
-            login: "ggg",
-            name: "e. e. cummings",
-        },
-        commit: B2,
-        committer: {
-            email: "ggg@example.com",
-            login: "ggg",
-            name: "e. e. cummings",
-        },
-        message: `Submit ok\n\nSigned-off-by: ${b2Author}`,
-        parentCount: 1,
-    },
-                     {
-        author: {
-            email: "bbb@exampleb.com",
-            login: "bbb",
-            name: "b. b. cummings",
-        },
-        commit: B,
-        committer: {
-            email: "bbb@exampleb.com",
-            login: "bbb",
-            name: "b. b. cummings",
-        },
-        message: "Submit ok\n\nSuccint message\n\nSigned-off-by: x",
-        parentCount: 1,
-    }];
-    // test that cc is not re-added
-    const prinfo = {
-        author: "ggg",
-        baseCommit: A,
-        baseLabel: "gitgitgadget:next",
-        baseOwner: "gitgitgadget",
-        baseRepo: "git",
-        body: `Super body\r\n${template}\r\nCc: Copy One <copy@cat.com>\r\n`
-            + `Cc: Copy Two <copycat@cat.com>, ${
-                b1Author} <${b1AuthorEmail}>`,
         hasComments: true,
         headCommit: B,
         headLabel: "somebody:master",
@@ -775,7 +631,7 @@ test("handle comment preview email success", async () => {
             login: "ggg",
             name: "e. e. cummings",
         },
-        commit: B,
+        commit: "BA55FEEDBEEF",
         committer: {
             email: "ggg@example.com",
             login: "ggg",

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -12,7 +12,7 @@ jest.setTimeout(60000);
 const expectedMails = [
     `From 91fba7811291c1064b2603765a2297c34fc843c0 Mon Sep 17 00:00:00 2001
 Message-Id: <pull.<Message-ID>>
-From: GitHub User <ghuser@example.net>
+From: "GitHub User via GitGitGadget" <gitgitgadget@example.com>
 Date: <Cover-Letter-Date>
 Subject: [PATCH 0/3] My first Pull Request!
 Fcc: Sent
@@ -21,7 +21,6 @@ Content-Transfer-Encoding: 8bit
 MIME-Version: 1.0
 To: reviewer@example.com
 Cc: Some Body <somebody@example.com>
-Sender: GitGitGadget <gitgitgadget@example.com>
 
 This Pull Request contains some really important changes that I would love
 to have included in git.git [https://github.com/git/git].
@@ -57,7 +56,7 @@ gitgitgadget
 Message-Id: <3a632624f5927565b178664f9a12b9802d2714b1.<Message-ID>>
 In-Reply-To: <pull.<Message-ID>>
 References: <pull.<Message-ID>>
-From: GitHub User <ghuser@example.net>
+From: "Test H. Dev via GitGitGadget" <gitgitgadget@example.com>
 Date: Fri, 13 Feb 2009 23:33:30 +0000
 Subject: [PATCH 1/3] A
 Fcc: Sent
@@ -67,7 +66,6 @@ MIME-Version: 1.0
 To: reviewer@example.com
 Cc: Some Body <somebody@example.com>,
     "Test H. Dev" <dev@example.com>
-Sender: GitGitGadget <gitgitgadget@example.com>
 
 From: "Test H. Dev" <dev@example.com>
 
@@ -92,7 +90,7 @@ gitgitgadget
 Message-Id: <0076a21b90c6e1f4f380deb464fe7145d4a7a56d.<Message-ID>>
 In-Reply-To: <pull.<Message-ID>>
 References: <pull.<Message-ID>>
-From: GitHub User <ghuser@example.net>
+From: "Contributor via GitGitGadget" <gitgitgadget@example.com>
 Date: Fri, 13 Feb 2009 23:34:30 +0000
 Subject: [PATCH 2/3] B
 Fcc: Sent
@@ -102,7 +100,6 @@ MIME-Version: 1.0
 To: reviewer@example.com
 Cc: Some Body <somebody@example.com>,
     Contributor <contributor@example.com>
-Sender: GitGitGadget <gitgitgadget@example.com>
 
 From: Contributor <contributor@example.com>
 
@@ -127,7 +124,7 @@ gitgitgadget
 Message-Id: <91fba7811291c1064b2603765a2297c34fc843c0.<Message-ID>>
 In-Reply-To: <pull.<Message-ID>>
 References: <pull.<Message-ID>>
-From: GitHub User <ghuser@example.net>
+From: "Developer via GitGitGadget" <gitgitgadget@example.com>
 Date: Fri, 13 Feb 2009 23:35:30 +0000
 Subject: [PATCH 3/3] C
 Fcc: Sent
@@ -137,7 +134,6 @@ MIME-Version: 1.0
 To: reviewer@example.com
 Cc: Some Body <somebody@example.com>,
     Developer <developer@example.com>
-Sender: GitGitGadget <gitgitgadget@example.com>
 
 From: Developer <developer@example.com>
 
@@ -214,7 +210,7 @@ Cc: Some Body <somebody@example.com>
                                        pullRequestBody,
                                        "gitgitgadget:next", baseCommit,
                                        "somebody:master", headCommit,
-                                       {}, "GitHub User", "ghuser@example.net");
+                                       {}, "GitHub User", undefined);
 
     expect(patches.coverLetter).toEqual(`My first Pull Request!
 

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -89,7 +89,7 @@ class PatchSeriesTest extends PatchSeries {
 
         test("non-ASCII characters are encoded correctly", () => {
             // tslint:disable-next-line:max-line-length
-            const needle = "=?UTF-8?Q?Nguy=E1=BB=85n_Th=C3=A1i_Ng=E1=BB=8Dc?= Duy";
+            const needle = "\"=?UTF-8?Q?Nguy=E1=BB=85n_Th=C3=A1i_Ng=E1=BB=8Dc?= Duy via GitGitGadget\" ";
             expect(mails[0]).toEqual(expect.stringContaining(needle));
         });
 
@@ -119,7 +119,7 @@ class PatchSeriesTest extends PatchSeries {
         test("Cc: is inserted correctly", () => {
             expect(mails[1]).toMatch(
                 // tslint:disable-next-line:max-line-length
-                /Cc: Some One Else[^]*\nSender[^]*\n\nFrom: Some One Else.*\n\n/);
+                /From: "Some One Else via GitGitGadget"[^]*\nCc: Some One Else[^]*\n\nFrom: Some One Else.*\n\n/);
         });
 
         const coverLetter = PatchSeries.adjustCoverLetter(mails[0]);


### PR DESCRIPTION
Apparently something does not quite work: https://lore.kernel.org/git/pull.411.git.1597655273.gitgitgadget@gmail.com/ has an incorrect `From:` header.

Reverts gitgitgadget/gitgitgadget#296