### PR TITLE
Handle missing secrets in github push workflow

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,10 +7,10 @@
 # Optional GitHub secrets
 
 # See ci-helper.test.ts for information on the following
-# GGG_SMTP_USER = 'gitgitgadget.cismtpuser=<email_userid>'
-# GGG_SMTP_PASS = 'gitgitgadget.cismtppass=<email_password>'
-# GGG_SMTP_HOST = 'gitgitgadget.cismtphost=<email_hostname>'
-# GGG_SMTP_OPTS = 'gitgitgadget.cismtpopts=<email_smtp_options>'
+# GGG_SMTP_USER = <email_userid>
+# GGG_SMTP_PASS = <email_password>
+# GGG_SMTP_HOST = <email_hostname>
+# GGG_SMTP_OPTS = <email_smtp_options> This is a json object.
 
 # See github-glue.test.ts for information on the following
 # GGG_TOKEN = token to access the test repo
@@ -37,15 +37,49 @@ jobs:
 
     # job level env vars used for a couple of steps
     env:
-      # see github-glue.test.ts for info on setting these
       GGG_TOKEN: ${{ secrets.GGG_TOKEN }}
       GGG_REPOSITORY: ${{ secrets.GGG_REPOSITORY }}
+      GGG_SMTP_USER: ${{ secrets.GGG_SMTP_USER }}
+      GGG_SMTP_PASS: ${{ secrets.GGG_SMTP_PASS }}
+      GGG_SMTP_HOST: ${{ secrets.GGG_SMTP_HOST }}
 
     steps:
     # Check out repo under sub-dir so other repo can be checked out
     - uses: actions/checkout@v2
       with:
         path: gitgitgadget
+
+    - name: Set git test repo config
+      shell: bash
+      run: |
+        if [ -n "$GGG_TOKEN" ] && [ -n "$GGG_REPOSITORY" ];
+        then
+          echo "::set-env name=GGG_REPO::'gitgitgadget.githubtest.githubuser=$GITHUB_REPOSITORY_OWNER' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubrepo=$GGG_REPOSITORY' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubtoken=$GGG_TOKEN'"
+        else
+          echo "::error::Both GGG_TOKEN and GGG_REPOSITORY secrets must be set"
+          exit 1
+        fi
+      if: env.GGG_TOKEN || env.GGG_REPOSITORY
+
+    - name: Set smtp config
+      env:
+        GGG_SMTP_OPTS: ${{ secrets.GGG_SMTP_OPTS }}
+      shell: bash
+      run: |
+        if [ -n "$GGG_SMTP_USER" ] && [ -n "$GGG_SMTP_PASS" ] && [ -n "$GGG_SMTP_HOST" ];
+        then
+          m="'gitgitgadget.cismtpuser=$GGG_SMTP_USER' 'gitgitgadget.cismtppass=$GGG_SMTP_PASS' 'gitgitgadget.cismtphost=$GGG_SMTP_HOST'";
+          if [ -n "$GGG_SMTP_OPTS" ];
+          then
+            m+=" 'gitgitgadget.cismtpopts=$GGG_SMTP_OPTS'"
+          fi
+          # trailing space is required
+          echo "::set-env name=GGG_SMTP::$m "
+        else
+          echo "::error::All of GGG_SMTP_USER, GGG_SMTP_PASS and GGG_SMTP_HOST secrets must be set"
+          exit 1
+        fi
+      if: env.GGG_SMTP_USER || env.GGG_SMTP_PASS || env.GGG_SMTP_HOST
 
     # Check out github-glue.test.ts repo if configured for it
     - uses: actions/checkout@v2
@@ -63,17 +97,12 @@ jobs:
       run: npm ci
       working-directory: gitgitgadget
 
-    - name: Set git test repo config
-      shell: bash
-      run: echo "::set-env name=GGG_REPO::'gitgitgadget.githubtest.githubuser=$GITHUB_REPOSITORY_OWNER' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubrepo=$GGG_REPOSITORY' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubtoken=$GGG_TOKEN'"
-      if: env.GGG_TOKEN
-
     - name: Run build
       run: npm run build
       working-directory: gitgitgadget
 
     - name: Run tests
       env:
-        GIT_CONFIG_PARAMETERS: ${{ secrets.GGG_SMTP_USER }} ${{ secrets.GGG_SMTP_PASS }} ${{ secrets.GGG_SMTP_HOST }} ${{ secrets.GGG_SMTP_OPTS }} ${{ env.GGG_REPO }}
+        GIT_CONFIG_PARAMETERS: ${{ env.GGG_SMTP }}${{ env.GGG_REPO }}
       run: npm run test
       working-directory: gitgitgadget


### PR DESCRIPTION
Git does not allow leading spaces in the `GIT_CONFIG_PARAMETERS` environment variable.  This corrects that for when no secrets are defined for the workflow.  Trailing spaces are allowed.

Additionally, the workflow will now get an error if only some of the secrets in a group (there are two) are defined.

The format of the smtp related secrets are now just the basic values and not the internal formats.

