### PR TITLE
Add /cc command

### DIFF
--- a/azure-function/index.js
+++ b/azure-function/index.js
@@ -139,7 +139,7 @@ module.exports = async (context, req) => {
             }
 
             /* Only trigger the Pipeline for valid commands */
-            if (!comment.body || !comment.body.match(/^\/(submit|preview|allow|disallow|test)\b/)) {
+            if (!comment.body || !comment.body.match(/^\/(submit|preview|allow|disallow|test|cc)\b/)) {
                 context.res = {
                     body: `Not a command: '${comment.body}'`,
                 };


### PR DESCRIPTION
The value passed may be one or more email addresses.  The format is the same as for the cc: footer in the PR body.
