### PR TITLE
Change to use crlf for new lines when adding cc

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -108,11 +108,11 @@ export class GitHubGlue {
 
         const url = GitGitGadget.parsePullRequestURL(pullRequestURL);
         const pr = await this.getPRInfo(url[0], url[2]);
-        const ccNow = pr.body.match(/\n\n(cc:.*)/is);
+        const ccNow = pr.body.match(/\r?\n\r?\n(cc:.*)/is);
 
         if (!ccNow || !ccNow[1].match(id[1])) {
             await this.updatePR(url[0], url[2], `${pr.body}${
-                ccNow ? "" : "\n"}\ncc: ${cc}`);
+                ccNow ? "" : "\r\n"}\r\ncc: ${cc}`);
             await this.addPRComment(pullRequestURL, `User \`${
                                     cc}\` has been added to the cc: list.`);
         }

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -156,7 +156,7 @@ test("pull requests", async () => {
         expect(prInfo.headLabel).toMatch(branch);
 
         // Test update to PR body
-        const prBody = `${prInfo.body}\nGlue`;
+        const prBody = `${prInfo.body}\r\nGlue`;
         await github.updatePR(owner, prData.number, prBody);
         const prNewInfo = await github.getPRInfo(owner, prData.number);
         expect(prNewInfo.body).toMatch(prBody);
@@ -169,13 +169,17 @@ test("pull requests", async () => {
 
         // Test cc update to PR
         const prCc = "Not Real <ReallyNot@saturn.cosmos>";
+        const prCc2 = "Not Real <RealNot@saturn.cosmos>";
         const prCcGitster = "Git Real <gitster@pobox.com>"; // filtered out
         await github.addPRCc(prData.html_url, prCc);
         await github.addPRCc(prData.html_url, prCc);
+        await github.addPRCc(prData.html_url, prCc2);
+        await github.addPRCc(prData.html_url, prCcGitster);
         const prccinfo = await github.getPRInfo(owner, prData.number);
         expect(prccinfo.body).toMatch(prCc);
         const ccFound = prccinfo.body.match(prCc);
         expect(ccFound?.length).toEqual(1);
+        expect(prccinfo.body).toMatch(prCc2);
         expect(prccinfo.body).not.toMatch(prCcGitster);
 
         const newComment = "Adding a comment to the PR";


### PR DESCRIPTION
GitHub PR body uses `\r\n` for newline.  That convention will now be followed when updating the `cc:` list.

Fixes the duplicate `cc:` problem in issue #310.