### PR TITLE
Do not add PR owner to CC list

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -111,10 +111,13 @@ export class GitHubGlue {
         const ccNow = pr.body.match(/\r?\n\r?\n(cc:.*)/is);
 
         if (!ccNow || !ccNow[1].match(id[1])) {
-            await this.updatePR(url[0], url[2], `${pr.body}${
-                ccNow ? "" : "\r\n"}\r\ncc: ${cc}`);
-            await this.addPRComment(pullRequestURL, `User \`${
-                                    cc}\` has been added to the cc: list.`);
+            const user = await this.getGitHubUserInfo(pr.author);
+            if (!user.email || !user.email.match(id[1])) {
+                await this.updatePR(url[0], url[2], `${pr.body}${
+                    ccNow ? "" : "\r\n"}\r\ncc: ${cc}`);
+                await this.addPRComment(pullRequestURL, `User \`${
+                                        cc}\` has been added to the cc: list.`);
+            }
         }
     }
 

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -171,16 +171,24 @@ test("pull requests", async () => {
         const prCc = "Not Real <ReallyNot@saturn.cosmos>";
         const prCc2 = "Not Real <RealNot@saturn.cosmos>";
         const prCcGitster = "Git Real <gitster@pobox.com>"; // filtered out
+        const ghUser = await github.getGitHubUserInfo(owner);
+
         await github.addPRCc(prData.html_url, prCc);
         await github.addPRCc(prData.html_url, prCc);
         await github.addPRCc(prData.html_url, prCc2);
         await github.addPRCc(prData.html_url, prCcGitster);
+        if (ghUser.email) {
+            await github.addPRCc(prData.html_url, `PR Owner <${ghUser.email}>`);
+        }
         const prccinfo = await github.getPRInfo(owner, prData.number);
         expect(prccinfo.body).toMatch(prCc);
         const ccFound = prccinfo.body.match(prCc);
         expect(ccFound?.length).toEqual(1);
         expect(prccinfo.body).toMatch(prCc2);
         expect(prccinfo.body).not.toMatch(prCcGitster);
+        if (ghUser.email) {
+            expect(prccinfo.body).not.toMatch(ghUser.email);
+        }
 
         const newComment = "Adding a comment to the PR";
         const {id, url} = await github.addPRComment(prData.html_url,


### PR DESCRIPTION
A previous change added email reply authors to the cc list.  The owner of the PR will no longer be added to the list because they are already added internally.

Users with no public email on GitHub will be added to the list.
