### PR TITLE
Upgrade nodemailer to v6.4.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5623,9 +5623,9 @@
       }
     },
     "nodemailer": {
-      "version": "6.4.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.11.tgz",
-      "integrity": "sha512-BVZBDi+aJV4O38rxsUh164Dk1NCqgh6Cm0rQSb9SK/DHGll/DrCMnycVDD7msJgZCnmVa8ASo8EZzR7jsgTukQ=="
+      "version": "6.4.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.13.tgz",
+      "integrity": "sha512-XmtiiKza2Cqtr+ZRMchMZn9s2nmwQDeakbf+yL0ODsIXOv58UZgk/MKPOkDKqY+mvxHs87PrJK7Nf/tcpKHqYQ=="
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jsonwebtoken": "^8.5.1",
     "libqp": "^1.1.0",
     "marked": "^1.2.0",
-    "nodemailer": "^6.4.11",
+    "nodemailer": "^6.4.13",
     "rfc2047": "^2.0.1"
   },
   "engines": {

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -94,13 +94,13 @@ class PatchSeriesTest extends PatchSeries {
         });
 
         test("sender names are quoted properly", () => {
-            const pairs: { [sender: string]: string | boolean } = {
+            const pairs: { [sender: string]: string | string[] | boolean } = {
                 "bee <nobody <email.org>": "\"bee <nobody\" <email.org>",
                 "bob@obo <email.org>": "\"bob@obo\" <email.org>",
                 "excited! <email.org>": false,
                 "foo [bar] name <email.org>": "\"foo [bar] name\" <email.org>",
                 "harry \"s\" truman <usa.gov>":
-                    "\"harry \\\"s\\\" truman\" <usa.gov>",
+                    [ "\"harry \\\"s\\\" truman\" <usa.gov>", "harry =?UTF-8?Q?=22s=22?= truman <usa.gov>" ],
                 "mr. name <email.org>": "\"mr. name\" <email.org>",
                 "ms. \\backslash <email.org>":
                     "\"ms. \\\\backslash\" <email.org>",
@@ -112,7 +112,11 @@ class PatchSeriesTest extends PatchSeries {
             for (const sender of Object.keys(pairs)) {
                 const expected = pairs[sender] || sender;
                 const quoted = PatchSeries.encodeSender(sender);
-                expect(quoted).toEqual(expected);
+                if (Array.isArray(expected)) {
+                    expect(expected).toContain(quoted);
+                } else {
+                    expect(quoted).toEqual(expected);
+                }
             }
         });
 


### PR DESCRIPTION
This is a replacement for https://github.com/gitgitgadget/gitgitgadget/pull/326, accommodating the test suite to nodemailer's change in behavior.