### PR TITLE
Convert to eslint from tslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+**/script/mail-patch-series.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,169 @@
+module.exports = {
+    "env": {
+        "es6": true,
+        node: true,
+    },
+    "extends": [
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "prettier",
+        "prettier/@typescript-eslint"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "project": "tsconfig.eslint.json",
+        "sourceType": "module"
+    },
+    "plugins": [
+        "eslint-plugin-jsdoc",
+        "@typescript-eslint"
+    ],
+    "rules": {
+        "@typescript-eslint/adjacent-overload-signatures": "error",
+        "@typescript-eslint/array-type": [
+            "error",
+            {
+                "default": "array-simple"
+            }
+        ],
+        "@typescript-eslint/ban-types": [
+            "error",
+            {
+                "types": {
+                    "Object": {
+                        "message": "Avoid using the `Object` type. Did you mean `object`?"
+                    },
+                    "Function": {
+                        "message": "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."
+                    },
+                    "Boolean": {
+                        "message": "Avoid using the `Boolean` type. Did you mean `boolean`?"
+                    },
+                    "Number": {
+                        "message": "Avoid using the `Number` type. Did you mean `number`?"
+                    },
+                    "String": {
+                        "message": "Avoid using the `String` type. Did you mean `string`?"
+                    },
+                    "Symbol": {
+                        "message": "Avoid using the `Symbol` type. Did you mean `symbol`?"
+                    }
+                }
+            }
+        ],
+        "@typescript-eslint/consistent-type-assertions": "error",
+        "@typescript-eslint/dot-notation": "error",
+        "@typescript-eslint/indent": "off",
+        "@typescript-eslint/naming-convention": [
+            "error",
+            {
+              "selector": "variable",
+              "format": ["camelCase", "snake_case"]
+            }
+        ],
+        "@typescript-eslint/no-empty-function": "error",
+        "@typescript-eslint/no-empty-interface": "error",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-misused-new": "error",
+        "@typescript-eslint/no-namespace": "error",
+        "@typescript-eslint/no-parameter-properties": "off",
+        "@typescript-eslint/no-unused-expressions": "error",
+        "@typescript-eslint/no-use-before-define": "off",
+        "@typescript-eslint/no-var-requires": "error",
+        "@typescript-eslint/prefer-for-of": "error",
+        "@typescript-eslint/prefer-function-type": "error",
+        "@typescript-eslint/prefer-namespace-keyword": "error",
+        "@typescript-eslint/prefer-regexp-exec": "off",
+        "@typescript-eslint/restrict-template-expressions": "off",
+        "@typescript-eslint/triple-slash-reference": [
+            "error",
+            {
+                "path": "always",
+                "types": "prefer-import",
+                "lib": "always"
+            }
+        ],
+        "@typescript-eslint/unified-signatures": "error",
+        "complexity": "off",
+        "constructor-super": "error",
+        "eqeqeq": [
+            "error",
+            "smart"
+        ],
+        "guard-for-in": "error",
+        "id-blacklist": [
+            "error",
+            "any",
+            "Number",
+            "String",
+            "string",
+            "Boolean",
+            "boolean",
+            "Undefined",
+            "undefined"
+        ],
+        "id-match": "error",
+        "jsdoc/check-alignment": "error",
+        "jsdoc/check-indentation": [
+            "error",
+            {
+                "excludeTags":[
+                    "param",
+                ],
+            },
+        ],
+        "jsdoc/newline-after-description": "error",
+        "max-classes-per-file": [
+            "error",
+            1
+        ],
+        "max-len": [
+            "error",
+            {
+                "code": 80
+            }
+        ],
+        "new-parens": "error",
+        "no-bitwise": "error",
+        "no-caller": "error",
+        "no-cond-assign": "error",
+        "no-console": "off",
+        "no-debugger": "error",
+        "no-empty": "error",
+        "no-eval": "error",
+        "no-fallthrough": "off",
+        "no-invalid-this": "off",
+        "no-new-wrappers": "error",
+        "no-shadow": [
+            "error",
+            {
+                "hoist": "never"
+            }
+        ],
+        "no-throw-literal": "error",
+        "no-trailing-spaces": "error",
+        "no-undef-init": "error",
+        "no-underscore-dangle": "error",
+        "no-unsafe-finally": "error",
+        "no-unused-labels": "error",
+        "no-var": "error",
+        "object-shorthand": "error",
+        "one-var": [
+            "error",
+            "never"
+        ],
+        "prefer-const": "error",
+        "radix": "error",
+        "spaced-comment": [
+            "error",
+            "always",
+            {
+                "markers": [
+                    "/"
+                ]
+            }
+        ],
+        "use-isnan": "error",
+        "valid-typeof": "off"
+    }
+};

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "tslint.autoFixOnSave": true,
     "[typescript]": {
         "editor.detectIndentation": false,
         "editor.autoIndent": false,
@@ -9,13 +8,20 @@
         "editor.wordWrapColumn": 80,
         "files.trimTrailingWhitespace": true
     },
-    "markdownlint.config": {
-        "MD033": {
-            "allowed_elements": [
-                "img"
-            ]
-        }
-    },
+    "cSpell.enabledLanguageIds": [
+        "git-commit",
+        "html",
+        "javascript",
+        "json",
+        "markdown",
+        "plaintext",
+        "typescript"
+    ],
+    "cSpell.ignorePaths": [
+        "node_modules",
+        "**/node_modules"
+    ],
+    "cSpell.language": "en-US",
     "cSpell.words": [
         "Arnfjörð",
         "Bjarmason",
@@ -79,18 +85,12 @@
         "yadavpratyush",
         "Ævar"
     ],
-    "cSpell.language": "en-US",
-    "cSpell.enabledLanguageIds": [
-        "git-commit",
-        "html",
-        "javascript",
-        "json",
-        "markdown",
-        "plaintext",
-        "typescript"
-    ],
-    "cSpell.ignorePaths": [
-        "node_modules",
-        "**/node_modules"
-    ]
+    "markdownlint.config": {
+        "MD033": {
+            "allowed_elements": [
+                "img"
+            ]
+        }
+    },
+    "tslint.autoFixOnSave": true
 }

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -183,7 +183,7 @@ export class CIHelper {
             }
             const meta = await this.getMailMetadata(messageID);
             if (!meta || meta.commitInGitGit !== undefined) {
-                if (!meta || commitsInSeen.has(meta.commitInGitGit!)) {
+                if (!meta || commitsInSeen.has(meta.commitInGitGit as string)) {
                     continue;
                 }
                 console.log(`Upstream commit ${meta.commitInGitGit} for ${
@@ -684,7 +684,7 @@ export class CIHelper {
                     pullRequestURL}#issuecomment-${commentID}`);
             }
         } catch (e) {
-            await addComment(e.toString());
+            await addComment((e as Error).toString());
         }
     }
 
@@ -791,7 +791,7 @@ export class CIHelper {
         if (!pr.hasComments && !gitGitGadget.isUserAllowed(pr.author)) {
             const welcome = (await readFile("res/WELCOME.md")).toString()
                     .replace(/\${username}/g, pr.author);
-            this.github.addPRComment(pullRequestURL, welcome);
+            await this.github.addPRComment(pullRequestURL, welcome);
         }
 
         const commitOkay = await this.checkCommits(pr, addComment);

--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -62,6 +62,7 @@ export class LintCommit {
     // Test for a minimum viable commit message.
     // - the body of the commit message should not be empty
 
+    // eslint-disable-next-line @typescript-eslint/require-await
     private async commitViable(): Promise<boolean> {
         if (this.lines.length < 3) {
             this.block("Commit checks stopped - the message is too short");
@@ -75,6 +76,7 @@ export class LintCommit {
     // - the first line should not exceed 76 characters
     // - the first line should be followed by an empty line
 
+    // eslint-disable-next-line @typescript-eslint/require-await
     private async commitMessageLength(): Promise<void> {
         const maxColumns = 76;
         if (this.lines[0].length > maxColumns) {
@@ -83,7 +85,7 @@ export class LintCommit {
         }
 
         if (this.lines[1].length) {
-            // tslint:disable-next-line:max-line-length
+            // eslint-disable-next-line max-len
             this.block("The first line must be separated from the rest by an empty line");
         }
     }
@@ -91,6 +93,7 @@ export class LintCommit {
     // Verify if the first line starts with a prefix (e.g. tests:), it continues
     // in lower-case
 
+    // eslint-disable-next-line @typescript-eslint/require-await
     private async lowerCaseAfterPrefix(): Promise<void> {
         const match = this.lines[0].match(/^\S+?:\s*?([A-Z])/);
 
@@ -103,6 +106,7 @@ export class LintCommit {
     // Verify there is a Signed-off-by: line - DCO check does this
     // already, but put out a message if it is indented
 
+    // eslint-disable-next-line @typescript-eslint/require-await
     private async signedOffBy(): Promise<void> {
         let signedFound = false;
 
@@ -128,6 +132,7 @@ export class LintCommit {
     // Low hanging fruit: check the first line.
     // Hyperlink validation is NOT part of the test.
 
+    // eslint-disable-next-line @typescript-eslint/require-await
     private async moreThanAHyperlink(): Promise<void> {
         const line = this.lines[2];
         const match = line.match(/^(\w*)\s*https*:\/\/\S+\s*(\w*)/);

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -176,7 +176,7 @@ export class GitGitGadget {
         const send = async (mail: string): Promise<string> => {
             const mbox = await parseMBox(mail);
             mbox.cc = [];
-            mbox.to = userInfo.email!;
+            mbox.to = userInfo.email as string;
             console.log(mbox);
             return await sendMail(mbox, this.smtpOptions);
         };

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -79,7 +79,7 @@ export class GitHubGlue {
             head_sha: originalCommit,
             name: "upstream commit",
             output: {
-                // tslint:disable-next-line:max-line-length
+                // eslint-disable-next-line max-len
                 summary: `Integrated into git.git as [${short}](${url}).`,
                 title: `In git.git: ${short}`,
             },
@@ -235,7 +235,7 @@ export class GitHubGlue {
     }
 
     public async setPRLabels(pullRequestURL: string, labels: string[]):
-        Promise<string[]> {
+        Promise<number[]> {
         const [owner, repo, prNo] =
             GitGitGadget.parsePullRequestURL(pullRequestURL);
 
@@ -246,7 +246,9 @@ export class GitHubGlue {
             owner,
             repo,
         });
-        return result.data.map((res: any) => res.id);
+
+        const items = result.data;
+        return items.map((item) => item.id);
     }
 
     public async closePR(pullRequestURL: string, viaMergeCommit: string):

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -4,7 +4,7 @@ import { git, revParse } from "./git";
 import { GitNotes } from "./git-notes";
 import { GitHubGlue } from "./github-glue";
 import { IMailMetadata } from "./mail-metadata";
-import { IParsedMBox, parseMBox,
+import { IHeaderHash, IParsedMBox, parseMBox,
     parseMBoxMessageIDAndReferences } from "./send-mail";
 
 const stateKey = "git@vger.kernel.org <-> GitGitGadget";
@@ -42,7 +42,7 @@ export class MailArchiveGitHelper {
     public static mbox2markdown(mbox: IParsedMBox): string {
         let body = mbox.body;
 
-        for (const header of mbox.headers!) {
+        for (const header of mbox.headers as IHeaderHash[]) {
             if (header.key === "Content-Transfer-Encoding") {
                 const value = header.value.toLowerCase();
                 if (value === "base64") {

--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -11,6 +11,7 @@ export function md2text(markdown: string, columns = 76): string {
 
         format: {
             heading: (elem, fn, options) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 const heading = fn(elem.children, options);
                 const underline = heading.substr(heading.lastIndexOf("\n") + 1)
                     .replace(/./g, "=");
@@ -21,6 +22,7 @@ export function md2text(markdown: string, columns = 76): string {
                 // decrease word wrap, but only to a minimum of 20 columns/line
                 indentOptions.wordwrap = Math.max(20, indentOptions.wordwrap-2);
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 const block = fn(elem.children, indentOptions);
                 return block.replace(/^>/mg, ">>") // add to quote
                     .replace(/^(?!>|$)/mg, "> ")   // new quote

--- a/lib/patch-series-metadata.ts
+++ b/lib/patch-series-metadata.ts
@@ -1,4 +1,5 @@
-export type GitGitIntegrationBranch = "maint" | "master" | "next" | "seen" | "pu";
+export type GitGitIntegrationBranch = "maint" | "master" |
+                                      "next" | "seen" | "pu";
 
 export interface IPatchSeriesMetadata {
     readonly pullRequestURL?: string;

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -85,14 +85,14 @@ export class PatchSeries {
             const tagMessage = await git(["cat-file", "tag", latestTag]);
             match = tagMessage.match(/^[\s\S]*?\n\n([\s\S]*)/);
             (match ? match[1] : tagMessage).split("\n").map((line) => {
-                // tslint:disable-next-line:max-line-length
+                // eslint-disable-next-line max-len
                 match = line.match(/https:\/\/lore\.kernel\.org\/.*\/([^/]+)/);
                 if (!match) {
-                    // tslint:disable-next-line:max-line-length
+                    // eslint-disable-next-line max-len
                     match = line.match(/https:\/\/public-inbox\.org\/.*\/([^/]+)/);
                 }
                 if (!match) {
-                    // tslint:disable-next-line:max-line-length
+                    // eslint-disable-next-line max-len
                     match = line.match(/https:\/\/www\.mail-archive\.com\/.*\/([^/]+)/);
                 }
                 if (!match) {
@@ -133,7 +133,7 @@ export class PatchSeries {
                                      baseLabel: string, baseCommit: string,
                                      headLabel: string, headCommit: string,
                                      options: PatchSeriesOptions,
-                                     senderName?: string,
+                                     senderName: string,
                                      senderEmail?: string | null):
         Promise<PatchSeries> {
         const workDir = notes.workDir;
@@ -350,7 +350,7 @@ export class PatchSeries {
     }
 
     protected static splitMails(mbox: string): string[] {
-        // tslint:disable-next-line:max-line-length
+        // eslint-disable-next-line max-len
         const separatorRegex = /\n(?=From [0-9a-f]{40} Mon Sep 17 00:00:00 2001\n)/;
         return mbox.split(separatorRegex);
     }
@@ -433,7 +433,7 @@ export class PatchSeries {
             return encoded;
         }
 
-        // tslint:disable-next-line:max-line-length
+        // eslint-disable-next-line max-len
         return `"${match[1].replace(/["\\\\]/g, "\\$&")}"${match[2]}${match[3]}`;
     }
 
@@ -445,7 +445,7 @@ export class PatchSeries {
         mails.map((mail, i) => {
             const match = mail.match(/^([^]*?)(\n\n[^]*)$/);
             if (!match) {
-                throw new Error("No header found in mail #" + i + ":\n" + mail);
+                throw new Error(`No header found in mail #${i}:\n` + mail);
             }
             let header = match[1];
 
@@ -492,7 +492,7 @@ export class PatchSeries {
 
     protected static adjustCoverLetter(coverLetter: string): string {
         const regex =
-            // tslint:disable-next-line:max-line-length
+            // eslint-disable-next-line max-len
             /^([^]*?\nSubject: .* )\*\*\* SUBJECT HERE \*\*\*(?=\n)([^]*?\n\n)\*\*\* BLURB HERE \*\*\*\n\n([^]*?)\n\n([^]*)$/;
         const match = coverLetter.match(regex);
         if (!match) {
@@ -705,7 +705,7 @@ export class PatchSeries {
         }
 
         const midMatch = mails[0].match(/\nMessage-ID: <(.*)>/i);
-        let coverMid = midMatch ? midMatch[1] : undefined;
+        let coverMid = midMatch ? midMatch[1] : "";
 
         if (this.metadata.pullRequestURL) {
             if (!coverMid) {
@@ -732,7 +732,7 @@ export class PatchSeries {
                     timeStamp}.${email}`;
                 mails.map((value: string, index: number): void => {
                     // cheap replace-all
-                    mails[index] = value.split(coverMid!).join(newCoverMid);
+                    mails[index] = value.split(coverMid).join(newCoverMid);
                 });
                 coverMid = newCoverMid;
             }

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -12,7 +12,7 @@ export class ProjectOptions {
         if (!match) {
             throw new Error("Not on a branch (" + ref + ")?");
         }
-        return match![1];
+        return match[1];
     }
 
     public static async getLocal(workDir?: string): Promise<ProjectOptions> {

--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -2,12 +2,17 @@ import { createTransport, SendMailOptions } from "nodemailer";
 import SMTPTransport = require("nodemailer/lib/smtp-transport");
 import { decode } from "rfc2047";
 
+export interface IHeaderHash {
+    key: string;
+    value: string
+}
+
 export interface IParsedMBox {
     body: string;
     cc?: string[];
     date?: string;
     from?: string;
-    headers?: Array<{ key: string; value: string }>;
+    headers?: IHeaderHash[];
     messageId?: string;
     subject?: string;
     to?: string;
@@ -41,6 +46,7 @@ function replaceAll(input: string, pattern: string, replacement: string):
  * @param {string} mbox The mail, in mbox format
  * @returns {IParsedMBox} the parsed headers/body
  */
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function parseMBox(mbox: string, gentle?: boolean):
     Promise<IParsedMBox> {
     const headerEnd = mbox.indexOf("\n\n");
@@ -97,6 +103,7 @@ export async function parseMBox(mbox: string, gentle?: boolean):
     };
 }
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function parseMBoxMessageIDAndReferences(parsed: IParsedMBox):
         Promise<{messageID: string; references: string[]}> {
     const references: string[] = [];
@@ -159,6 +166,7 @@ export async function sendMail(mail: IParsedMBox,
         const smtpOpts = smtpOptions.smtpOpts
             .replace(/([ {])([a-zA-Z0-9.]+?) *?:/g,"$1\"$2\":");
         Object.entries(JSON.parse(smtpOpts))
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             .forEach(([key, value]) => transportOpts[key] = value);
     }
 
@@ -179,6 +187,7 @@ export async function sendMail(mail: IParsedMBox,
             if (error) {
                 reject(error);
             } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 resolve(info.messageId);
             }
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -652,6 +652,41 @@
         "minimist": "^1.2.0"
       }
     },
+    "@eslint/eslintrc": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
+      "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -982,6 +1017,20 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "expect": {
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.1.tgz",
+          "integrity": "sha512-BRfxIBHagghMmr1D2MRY0Qv5d3Nc8HCqgbDwNXw/9izmM5eBb42a2YjLKSbsqle76ozGkAEPELQX4IdNHAKRNA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.1",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.6.1",
+            "jest-message-util": "^26.6.1",
+            "jest-regex-util": "^26.0.0"
+          }
         }
       }
     },
@@ -1218,6 +1267,32 @@
         "@types/node": "*",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0"
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
       }
     },
     "@octokit/auth-app": {
@@ -1572,10 +1647,22 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
     "@types/json-stable-stringify": {
       "version": "1.0.32",
       "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz",
       "integrity": "sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw==",
+      "dev": true
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/jsonwebtoken": {
@@ -1658,6 +1745,123 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.5.0.tgz",
+      "integrity": "sha512-mjb/gwNcmDKNt+6mb7Aj/TjKzIJjOPcoCJpjBQC9ZnTRnBt1p4q5dJSSmIqAtsZ/Pff5N+hJlbiPc5bl6QN4OQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "4.5.0",
+        "@typescript-eslint/scope-manager": "4.5.0",
+        "debug": "^4.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^3.0.0",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "3.17.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.5.0.tgz",
+      "integrity": "sha512-bW9IpSAKYvkqDGRZzayBXIgPsj2xmmVHLJ+flGSoN0fF98pGoKFhbunIol0VF2Crka7z984EEhFi623Rl7e6gg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/scope-manager": "4.5.0",
+        "@typescript-eslint/types": "4.5.0",
+        "@typescript-eslint/typescript-estree": "4.5.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.5.0.tgz",
+      "integrity": "sha512-xb+gmyhQcnDWe+5+xxaQk5iCw6KqXd8VQxGiTeELTMoYeRjpocZYYRP1gFVM2C8Yl0SpUvLa1lhprwqZ00w3Iw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "4.5.0",
+        "@typescript-eslint/types": "4.5.0",
+        "@typescript-eslint/typescript-estree": "4.5.0",
+        "debug": "^4.1.1"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.5.0.tgz",
+      "integrity": "sha512-C0cEO0cTMPJ/w4RA/KVe4LFFkkSh9VHoFzKmyaaDWAnPYIEzVCtJ+Un8GZoJhcvq+mPFXEsXa01lcZDHDG6Www==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.5.0",
+        "@typescript-eslint/visitor-keys": "4.5.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-n2uQoXnyWNk0Les9MtF0gCK3JiWd987JQi97dMSxBOzVoLZXCNtxFckVqt1h8xuI1ix01t+iMY4h4rFMj/303g==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.5.0.tgz",
+      "integrity": "sha512-gN1mffq3zwRAjlYWzb5DanarOPdajQwx5MEWkWCk0XvqC8JpafDTeioDoow2L4CA/RkYZu7xEsGZRhqrTsAG8w==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.5.0",
+        "@typescript-eslint/visitor-keys": "4.5.0",
+        "debug": "^4.1.1",
+        "globby": "^11.0.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "3.17.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.5.0.tgz",
+      "integrity": "sha512-UHq4FSa55NDZqscRU//O5ROFhHa9Hqn9KWTEvJGTArtTQp5GKv9Zqf6d/Q3YXXcFv4woyBml7fJQlQ+OuqRcHA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.5.0",
+        "eslint-visitor-keys": "^2.0.0"
+      }
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -1680,6 +1884,12 @@
         "acorn-walk": "^7.1.1"
       }
     },
+    "acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true
+    },
     "acorn-walk": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -1697,6 +1907,12 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.1",
@@ -1774,11 +1990,38 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-includes": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+      "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0",
+        "is-string": "^1.0.5"
+      }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "array.prototype.flat": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -1799,6 +2042,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "asynckit": {
@@ -2062,12 +2311,6 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -2289,6 +2532,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
       "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
     },
+    "comment-parser": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
+      "integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -2299,6 +2548,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -2436,6 +2691,15 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -2511,6 +2775,24 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
       "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
       "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "dom-serializer": {
       "version": "0.2.2",
@@ -2628,6 +2910,15 @@
         "once": "^1.4.0"
       }
     },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
@@ -2640,6 +2931,36 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-string-regexp": {
@@ -2661,11 +2982,542 @@
         "source-map": "~0.6.1"
       }
     },
+    "eslint": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.11.0.tgz",
+      "integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.1.3",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.0",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "optionator": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+          "dev": true,
+          "requires": {
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.13.0.tgz",
+      "integrity": "sha512-LcT0i0LSmnzqK2t764pyIt7kKH2AuuqKRTtJTdddWxOiUja9HdG5GXBVF2gmCTvVYWVsTu8J2MhJLVGRh+pj8w==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.1",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.18.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+          "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.0.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "30.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.7.3.tgz",
+      "integrity": "sha512-slzJeKrm3vXabRYcFBpbUgWgdnATN9rNOFAr7IhmkxmR9Vk/6qN1c/IdvTqVSEctDRQ08chR+Lvk8fRayXgYZg==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^0.7.6",
+        "debug": "^4.2.0",
+        "jsdoctypeparser": "^9.0.0",
+        "lodash": "^4.17.20",
+        "regextras": "^0.7.1",
+        "semver": "^7.3.2",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
     },
     "estraverse": {
       "version": "4.3.0",
@@ -2751,60 +3603,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
-    },
-    "expect": {
-      "version": "26.6.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.1.tgz",
-      "integrity": "sha512-BRfxIBHagghMmr1D2MRY0Qv5d3Nc8HCqgbDwNXw/9izmM5eBb42a2YjLKSbsqle76ozGkAEPELQX4IdNHAKRNA==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^26.6.1",
-        "ansi-styles": "^4.0.0",
-        "jest-get-type": "^26.3.0",
-        "jest-matcher-utils": "^26.6.1",
-        "jest-message-util": "^26.6.1",
-        "jest-regex-util": "^26.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.1",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
-          "integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
           "dev": true
         }
       }
@@ -2928,6 +3726,20 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2940,6 +3752,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -2947,6 +3768,15 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
       }
     },
     "fill-range": {
@@ -2967,6 +3797,34 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -3026,6 +3884,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -3042,6 +3906,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -3080,11 +3950,34 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "globby": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      }
     },
     "got": {
       "version": "9.6.0",
@@ -3146,6 +4039,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "has-value": {
@@ -3285,6 +4184,30 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz",
       "integrity": "sha1-nFdLcMMNYVhZ8gZNK+QzWtaxqNY="
     },
+    "ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
     "import-local": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
@@ -3353,6 +4276,12 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-callable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "dev": true
+    },
     "is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -3391,6 +4320,12 @@
         }
       }
     },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -3423,6 +4358,12 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3433,6 +4374,21 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
       "dev": true
     },
     "is-number": {
@@ -3455,10 +4411,34 @@
       "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -4232,6 +5212,20 @@
             "supports-color": "^7.1.0"
           }
         },
+        "expect": {
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.1.tgz",
+          "integrity": "sha512-BRfxIBHagghMmr1D2MRY0Qv5d3Nc8HCqgbDwNXw/9izmM5eBb42a2YjLKSbsqle76ozGkAEPELQX4IdNHAKRNA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.1",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.6.1",
+            "jest-message-util": "^26.6.1",
+            "jest-regex-util": "^26.0.0"
+          }
+        },
         "jest-util": {
           "version": "26.6.1",
           "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.1.tgz",
@@ -4913,6 +5907,20 @@
           "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
           "dev": true
         },
+        "expect": {
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.1.tgz",
+          "integrity": "sha512-BRfxIBHagghMmr1D2MRY0Qv5d3Nc8HCqgbDwNXw/9izmM5eBb42a2YjLKSbsqle76ozGkAEPELQX4IdNHAKRNA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.1",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.6.1",
+            "jest-message-util": "^26.6.1",
+            "jest-regex-util": "^26.0.0"
+          }
+        },
         "jest-diff": {
           "version": "26.6.1",
           "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.1.tgz",
@@ -5145,6 +6153,12 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
+    "jsdoctypeparser": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
+      "dev": true
+    },
     "jsdom": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
@@ -5215,6 +6229,12 @@
       "requires": {
         "jsonify": "~0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -5330,6 +6350,35 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
     },
     "locate-path": {
       "version": "5.0.0",
@@ -5473,6 +6522,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "micromatch": {
@@ -5757,6 +6812,18 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -5771,6 +6838,40 @@
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
+        }
+      }
+    },
+    "object.assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.0",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
         }
       }
     },
@@ -5789,6 +6890,18 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
+      }
+    },
+    "object.values": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "once": {
@@ -5879,6 +6992,15 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-json": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
@@ -5925,6 +7047,12 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -5935,6 +7063,12 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pirates": {
@@ -6085,6 +7219,18 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
+    "regextras": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
+      "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
+      "dev": true
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -6231,6 +7377,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rfc2047": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rfc2047/-/rfc2047-3.0.1.tgz",
@@ -6251,6 +7403,12 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
     },
     "safe-buffer": {
@@ -6514,6 +7672,49 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -6813,6 +8014,26 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6847,6 +8068,12 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
     "supports-color": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -6871,6 +8098,58 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "tar": {
       "version": "4.4.13",
@@ -6906,6 +8185,12 @@
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "throat": {
       "version": "5.0.0",
@@ -7044,99 +8329,40 @@
         "yn": "3.1.1"
       }
     },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
-    },
-    "tslint": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
-      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^4.0.1",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.3",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.13.0",
-        "tsutils": "^2.29.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "tsutils": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.1"
-      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -7304,6 +8530,12 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
+    "v8-compile-cache": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "dev": true
+    },
     "v8-to-istanbul": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-6.0.1.tgz",
@@ -7462,6 +8694,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   },
   "scripts": {
     "build": "tsc",
-    "lint": "tslint -c tslint.json '{lib,script,tests}/**/*.{ts,tsx}'",
+    "lint": "eslint -c .eslintrc.js --ext .ts,.js {lib,script,tests}/**/*.{ts,tsx,js}",
     "start": "node server.js",
-    "test": "tslint --project . && jest --env=node",
+    "test": "npm run lint && jest --env=node",
     "test:watch": "jest --watch --notify --notifyMode=change --coverage",
-    "ci": "tslint --project . && jest --env=node --ci --reporters=default --reporters=jest-junit"
+    "ci": "npm run lint && jest --env=node --ci --reporters=default --reporters=jest-junit"
   },
   "bugs": {
     "url": "https://github.com/gitgitgadget/gitgitgadget/issues"
@@ -39,11 +39,16 @@
     "@types/libqp": "^1.1.0",
     "@types/marked": "^1.1.0",
     "@types/nodemailer": "^6.4.0",
+    "@typescript-eslint/eslint-plugin": "^4.2.0",
+    "@typescript-eslint/parser": "^4.2.0",
+    "eslint": "^7.10.0",
+    "eslint-config-prettier": "^6.13.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jsdoc": "^30.7.3",
     "jest": "^26.6.1",
     "jest-junit": "^12.0.0",
     "ts-jest": "^26.4.2",
     "ts-node": "^9.0.0",
-    "tslint": "^6.1.3",
     "typescript": "^4.0.3"
   },
   "dependencies": {

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -45,7 +45,7 @@ async function getGitGitWorkDir(): Promise<string> {
             commander.gitWorkDir,
         ]);
     }
-    return commander.gitWorkDir;
+    return (commander.gitWorkDir as string);
 }
 
 async function getCIHelper(): Promise<CIHelper> {
@@ -381,7 +381,7 @@ async function getCIHelper(): Promise<CIHelper> {
                 })).data.id;
             }
             const result = await client.apps.createInstallationAccessToken({
-                installation_id: options.installationID!,
+                installation_id: options.installationID,
             });
             const configKey = options.name === "gitgitgadget" ?
                 "gitgitgadget.githubToken" :
@@ -428,14 +428,15 @@ async function getCIHelper(): Promise<CIHelper> {
         for (const arg of commander.args.slice(1)) {
             onlyPRs.add(parseInt(arg, 10));
         }
-        await ci.handleNewMails(mailArchiveGitDir!,
+        await ci.handleNewMails(mailArchiveGitDir,
                                 onlyPRs.size ? onlyPRs : undefined);
     } else {
         process.stderr.write(`${command}: unhandled sub-command\n`);
         process.exit(1);
     }
 })().catch((reason) => {
-    console.log(`Caught error ${reason}:\n${reason.stack}\n`);
-    process.stderr.write(`Caught error ${reason}:\n${reason.stack}\n`);
+    const error = reason as Error;
+    console.log(`Caught error ${error}:\n${error.stack}\n`);
+    process.stderr.write(`Caught error ${error}:\n${error.stack}\n`);
     process.exit(1);
 });

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { expect, jest, test } from "@jest/globals";
 import { CIHelper } from "../lib/ci-helper";
 import { gitConfig } from "../lib/git";
@@ -43,8 +44,10 @@ class TestCIHelper extends CIHelper {
         this.testing = true;
         this.ghGlue = this.github;
         this.addPRComment = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         this.ghGlue.addPRComment = this.addPRComment;
         this.updatePR = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         this.ghGlue.updatePR = this.updatePR;
         // need keys to authenticate
         // this.ghGlue.ensureAuthenticated = async (): Promise<void> => {};
@@ -52,21 +55,25 @@ class TestCIHelper extends CIHelper {
 
     public setGHgetPRInfo(o: IPullRequestInfo): void {
         this.ghGlue.getPRInfo = jest.fn( async ():
+            // eslint-disable-next-line @typescript-eslint/require-await
             Promise<IPullRequestInfo> => o );
     }
 
     public setGHgetPRComment(o: IPRComment): void {
         this.ghGlue.getPRComment = jest.fn( async ():
+            // eslint-disable-next-line @typescript-eslint/require-await
             Promise<IPRComment> => o );
     }
 
     public setGHgetPRCommits(o: IPRCommit[]): void {
         this.ghGlue.getPRCommits = jest.fn( async ():
+            // eslint-disable-next-line @typescript-eslint/require-await
             Promise<IPRCommit[]> => o );
     }
 
     public setGHgetGitHubUserInfo(o: IGitHubUser): void {
         this.ghGlue.getGitHubUserInfo = jest.fn( async ():
+            // eslint-disable-next-line @typescript-eslint/require-await
             Promise<IGitHubUser> => o );
     }
 }
@@ -133,8 +140,8 @@ async function setupRepos(instance: string):
     await notes.set("", {allowedUsers: ["ggg", "user1"]}, true);
 
     // Initial empty commit
-    const A = await gggRemote.commit("A");
-    expect(A).not.toBeUndefined();
+    const commitA = await gggRemote.commit("A");
+    expect(commitA).not.toBeUndefined();
 
     // Set up fake upstream branches
     await gggRemote.git(["branch", "maint"]);
@@ -185,8 +192,8 @@ test("identify upstream commit", async () => {
                         "https://github.com/gitgitgadget/git"]);
 
     // Set up fake upstream branches
-    const A = await gggRemote.commit("A");
-    expect(A).not.toBeUndefined();
+    const commitA = await gggRemote.commit("A");
+    expect(commitA).not.toBeUndefined();
     await gggRemote.git(["branch", "maint"]);
     await gggRemote.git(["branch", "next"]);
     await gggRemote.git(["branch", "seen"]);
@@ -209,26 +216,26 @@ test("identify upstream commit", async () => {
 
     // "Apply" the patch, and merge it
     await gggRemote.newBranch("gg/via-pull-request");
-    const B = await gggRemote.commit("B");
+    const commitB = await gggRemote.commit("B");
     await gggRemote.git(["checkout", "seen"]);
     await gggRemote.git(["merge", "--no-ff", "gg/via-pull-request"]);
 
     // Update the `mail-to-commit` notes ref, at least the part we care about
     const mail2CommitNotes = new GitNotes(gggRemote.workDir,
                                           "refs/notes/mail-to-commit");
-    await mail2CommitNotes.setString(messageID, B);
+    await mail2CommitNotes.setString(messageID, commitB);
 
     // "publish" the gitgitgadget notes
     await worktree.git(["push", gggRemote.workDir, notes.notesRef]);
 
     const ci = new TestCIHelper(worktree.workDir);
-    expect(await ci.identifyUpstreamCommit(b)).toEqual(B);
+    expect(await ci.identifyUpstreamCommit(b)).toEqual(commitB);
 
     expect(await ci.updateCommitMapping(messageID)).toBeTruthy();
     const bMetaNew = await notes.get<IMailMetadata>(messageID);
     expect(bMetaNew).not.toBeUndefined();
-    expect(bMetaNew!.originalCommit).toEqual(b);
-    expect(bMetaNew!.commitInGitGit).toEqual(B);
+    expect(bMetaNew?.originalCommit).toEqual(b);
+    expect(bMetaNew?.commitInGitGit).toEqual(commitB);
 });
 
 test("handle comment allow basic test", async () => {
@@ -255,7 +262,7 @@ test("handle comment allow basic test", async () => {
     ci.setGHgetGitHubUserInfo(user);
 
     await ci.handleComment("gitgitgadget", 433865360);
-    // tslint:disable-next-line:max-line-length
+    // eslint-disable-next-line max-len
     expect(ci.addPRComment.mock.calls[0][1]).toMatch(/is now allowed to use GitGitGadget/);
 });
 
@@ -274,7 +281,7 @@ test("handle comment allow fail invalid user", async () => {
     ci.setGHgetPRComment(comment);
 
     await ci.handleComment("gitgitgadget", 433865360);
-    // tslint:disable-next-line:max-line-length
+    // eslint-disable-next-line max-len
     expect(ci.addPRComment.mock.calls[0][1]).toMatch(/is not a valid GitHub username/);
 });
 
@@ -300,9 +307,9 @@ test("handle comment allow no public email", async () => {
     ci.setGHgetGitHubUserInfo(user);
 
     await ci.handleComment("gitgitgadget", 433865360);
-    // tslint:disable-next-line:max-line-length
+    // eslint-disable-next-line max-len
     expect(ci.addPRComment.mock.calls[0][1]).toMatch(/is now allowed to use GitGitGadget/);
-    // tslint:disable-next-line:max-line-length
+    // eslint-disable-next-line max-len
     expect(ci.addPRComment.mock.calls[0][1]).toMatch(/no public email address set/);
 });
 
@@ -329,7 +336,7 @@ test("handle comment allow already allowed", async () => {
     ci.setGHgetGitHubUserInfo(user);
 
     await ci.handleComment("gitgitgadget", 433865360);
-    // tslint:disable-next-line:max-line-length
+    // eslint-disable-next-line max-len
     expect(ci.addPRComment.mock.calls[0][1]).toMatch(/already allowed to use GitGitGadget/);
 });
 
@@ -373,7 +380,7 @@ test("handle comment allow no name specified (with trailing white space)",
     ci.setGHgetGitHubUserInfo(user);
 
     await ci.handleComment("gitgitgadget", 433865360);
-    // tslint:disable-next-line:max-line-length
+    // eslint-disable-next-line max-len
     expect(ci.addPRComment.mock.calls[0][1]).toMatch(/already allowed to use GitGitGadget/);
 });
 
@@ -400,7 +407,7 @@ test("handle comment disallow basic test", async () => {
     ci.setGHgetGitHubUserInfo(user);
 
     await ci.handleComment("gitgitgadget", 433865360);
-    // tslint:disable-next-line:max-line-length
+    // eslint-disable-next-line max-len
     expect(ci.addPRComment.mock.calls[0][1]).toMatch(/is no longer allowed to use GitGitGadget/);
 });
 
@@ -420,7 +427,7 @@ test("handle comment disallow was not allowed", async () => {
     ci.setGHgetPRComment(comment);
 
     await ci.handleComment("gitgitgadget", 433865360);
-    // tslint:disable-next-line:max-line-length
+    // eslint-disable-next-line max-len
     expect(ci.addPRComment.mock.calls[0][1]).toMatch(/already not allowed to use GitGitGadget/);
 });
 
@@ -463,7 +470,7 @@ test("handle comment submit not author", async () => {
     ci.setGHgetGitHubUserInfo(user);
 
     await ci.handleComment("gitgitgadget", 433865360);
-    // tslint:disable-next-line:max-line-length
+    // eslint-disable-next-line max-len
     expect(ci.addPRComment.mock.calls[0][1]).toMatch(/Only the owner of a PR can submit/);
 });
 
@@ -520,12 +527,12 @@ test("handle comment submit email success", async () => {
     // add template to master repo
     await gggRemote.commit("temple", ".github//PULL_REQUEST_TEMPLATE.md",
                            template);
-    const A = await gggRemote.revParse("HEAD");
-    expect(A).not.toBeUndefined();
+    const commitA = await gggRemote.revParse("HEAD");
+    expect(commitA).not.toBeUndefined();
 
     // Now come up with a local change
     await worktree.git(["pull", gggRemote.workDir, "master"]);
-    const B = await worktree.commit("b");
+    const commitB = await worktree.commit("b");
 
     // get the pr refs in place
     const pullRequestRef = `refs/pull/${prNumber}`;
@@ -564,14 +571,14 @@ test("handle comment submit email success", async () => {
     }];
     const prinfo = {
         author: "ggg",
-        baseCommit: A,
+        baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
         baseOwner: "gitgitgadget",
         baseRepo: "git",
         body: `Super body\r\n${template}\r\nCc: Copy One <copy@cat.com>\r\n`
             + "Cc: Copy Two <copycat@cat.com>",
         hasComments: true,
-        headCommit: B,
+        headCommit: commitB,
         headLabel: "somebody:master",
         mergeable: true,
         number: prNumber,
@@ -601,12 +608,12 @@ test("handle comment preview email success", async () => {
     const template = "fine template\nnew line";
     await gggRemote.commit("temple", ".github//PULL_REQUEST_TEMPLATE.md",
                            template);
-    const A = await gggRemote.revParse("HEAD");
-    expect(A).not.toBeUndefined();
+    const commitA = await gggRemote.revParse("HEAD");
+    expect(commitA).not.toBeUndefined();
 
     // Now come up with a local change
     await worktree.git(["pull", gggRemote.workDir, "master"]);
-    const B = await worktree.commit("b");
+    const commitB = await worktree.commit("b");
 
     // get the pr refs in place
     const pullRequestRef = `refs/pull/${prNumber}`;
@@ -645,13 +652,13 @@ test("handle comment preview email success", async () => {
     }];
     const prinfo = {
         author: "ggg",
-        baseCommit: A,
+        baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
         baseOwner: "gitgitgadget",
         baseRepo: "git",
         body: "There will be a submit email and a preview email.",
         hasComments: true,
-        headCommit: B,
+        headCommit: commitB,
         headLabel: "somebody:master",
         mergeable: true,
         number: prNumber,
@@ -673,7 +680,7 @@ test("handle comment preview email success", async () => {
         comment.body = " /preview";
         ci.setGHgetPRComment(comment);
         await ci.handleComment("gitgitgadget", 433865360); // do it again
-        // tslint:disable-next-line:max-line-length
+        // eslint-disable-next-line max-len
         expect(ci.addPRComment.mock.calls[1][1]).toMatch(/Preview email sent as/);
 
         await ci.handleComment("gitgitgadget", 433865360); // should still be v2
@@ -686,13 +693,13 @@ test("handle push/comment too many commits fails", async () => {
     const ci = new TestCIHelper(gggLocal.workDir, false, worktree.workDir);
     const prNumber = 59;
 
-    const A = await gggRemote.revParse("HEAD");
-    expect(A).not.toBeUndefined();
+    const commitA = await gggRemote.revParse("HEAD");
+    expect(commitA).not.toBeUndefined();
 
     // Now come up with a local change
     // this should be in a separate repo from the worktree
     await worktree.git(["pull", gggRemote.workDir, "master"]);
-    const B = await worktree.commit("b");
+    const commitB = await worktree.commit("b");
 
     // get the pr refs in place
     const pullRequestRef = `refs/pull/${prNumber}`;
@@ -718,14 +725,14 @@ test("handle push/comment too many commits fails", async () => {
     };
     const prinfo = {
         author: "ggg",
-        baseCommit: A,
+        baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
         baseOwner: "gitgitgadget",
         baseRepo: "git",
         body: "Never seen - too many commits.",
         commits,
         hasComments: false,
-        headCommit: B,
+        headCommit: commitB,
         headLabel: "somebody:master",
         mergeable: true,
         number: prNumber,
@@ -779,13 +786,13 @@ test("handle push/comment merge commits fails", async () => {
     const ci = new TestCIHelper(gggLocal.workDir, false, worktree.workDir);
     const prNumber = 59;
 
-    const A = await gggRemote.revParse("HEAD");
-    expect(A).not.toBeUndefined();
+    const commitA = await gggRemote.revParse("HEAD");
+    expect(commitA).not.toBeUndefined();
 
     // Now come up with a local change
     // this should be in a separate repo from the worktree
     await worktree.git(["pull", gggRemote.workDir, "master"]);
-    const B = await worktree.commit("b");
+    const commitB = await worktree.commit("b");
 
     // get the pr refs in place
     const pullRequestRef = `refs/pull/${prNumber}`;
@@ -824,14 +831,14 @@ test("handle push/comment merge commits fails", async () => {
 
     const prinfo = {
         author: "ggg",
-        baseCommit: A,
+        baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
         baseOwner: "gitgitgadget",
         baseRepo: "git",
         body: "Never seen - merge commits.",
         commits: commits.length,
         hasComments: false,
-        headCommit: B,
+        headCommit: commitB,
         headLabel: "somebody:master",
         mergeable: true,
         number: prNumber,
@@ -925,13 +932,13 @@ test("disallow noreply emails", async () => {
     const ci = new TestCIHelper(gggLocal.workDir, false, worktree.workDir);
     const prNumber = 59;
 
-    const A = await gggRemote.revParse("HEAD");
-    expect(A).not.toBeUndefined();
+    const commitA = await gggRemote.revParse("HEAD");
+    expect(commitA).not.toBeUndefined();
 
     // Now come up with a local change
     // this should be in a separate repo from the worktree
     await worktree.git(["pull", gggRemote.workDir, "master"]);
-    const B = await worktree.commit("b");
+    const commitB = await worktree.commit("b");
 
     // get the pr refs in place
     const pullRequestRef = `refs/pull/${prNumber}`;
@@ -970,14 +977,14 @@ test("disallow noreply emails", async () => {
 
     const prinfo = {
         author: "ggg",
-        baseCommit: A,
+        baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
         baseOwner: "gitgitgadget",
         baseRepo: "git",
         body: "Never seen - merge commits.",
         commits: commits.length,
         hasComments: false,
-        headCommit: B,
+        headCommit: commitB,
         headLabel: "somebody:master",
         mergeable: true,
         number: prNumber,
@@ -1004,13 +1011,13 @@ test("basic lint tests", async () => {
     const ci = new TestCIHelper(gggLocal.workDir, false, worktree.workDir);
     const prNumber = 59;
 
-    const A = await gggRemote.revParse("HEAD");
-    expect(A).not.toBeUndefined();
+    const commitA = await gggRemote.revParse("HEAD");
+    expect(commitA).not.toBeUndefined();
 
     // Now come up with a local change
     // this should be in a separate repo from the worktree
     await worktree.git(["pull", gggRemote.workDir, "master"]);
-    const B = await worktree.commit("b");
+    const commitB = await worktree.commit("b");
 
     // get the pr refs in place
     const pullRequestRef = `refs/pull/${prNumber}`;
@@ -1096,14 +1103,14 @@ test("basic lint tests", async () => {
 
     const prinfo = {
         author: "ggg",
-        baseCommit: A,
+        baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
         baseOwner: "gitgitgadget",
         baseRepo: "git",
         body: "Never seen - merge commits.",
         commits: commits.length,
         hasComments: false,
-        headCommit: B,
+        headCommit: commitB,
         headLabel: "somebody:master",
         mergeable: true,
         number: prNumber,
@@ -1173,6 +1180,7 @@ test("Handle comment cc", async () => {
     expect(ci.updatePR.mock.calls[0][2]).toMatch(/Some Body/);
     ci.updatePR.mock.calls.length = 0;
 
+    // eslint-disable-next-line max-len
     comment.body = "/cc \"A Body\" <abody@example.com>, \"S Body\" <sbody@example.com>";
 
     await ci.handleComment("gitgitgadget", prNumber);

--- a/tests/git-notes.test.ts
+++ b/tests/git-notes.test.ts
@@ -38,9 +38,9 @@ test("set/get notes", async () => {
 
     const commit = await revParse(notes.notesRef, notes.workDir);
     expect(commit).not.toBeUndefined();
-    expect(await notes.appendCommitNote(commit!, "1")).toEqual("");
-    expect(await notes.getCommitNotes(commit!)).toEqual("1");
-    expect(await notes.appendCommitNote(commit!, "2")).toEqual("");
-    expect(await notes.getCommitNotes(commit!)).toEqual("1\n\n2");
-    expect(await notes.getLastCommitNote(commit!)).toEqual("2");
+    expect(await notes.appendCommitNote(commit as string, "1")).toEqual("");
+    expect(await notes.getCommitNotes(commit as string)).toEqual("1");
+    expect(await notes.appendCommitNote(commit as string, "2")).toEqual("");
+    expect(await notes.getCommitNotes(commit as string)).toEqual("1\n\n2");
+    expect(await notes.getLastCommitNote(commit as string)).toEqual("2");
 });

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -194,7 +194,7 @@ test("generate tag/notes from a Pull Request", async () => {
 
     const pullRequestURL = "https://github.com/gitgitgadget/git/pull/1";
     const pullRequestTitle = "My first Pull Request!";
-    // tslint:disable-next-line:max-line-length
+    // eslint-disable-next-line max-len
     const pullRequestBody = `This Pull Request contains some really important changes that I would love to${
         ""} have included in [git.git](https://github.com/git/git).
 
@@ -219,8 +219,9 @@ to have included in git.git [https://github.com/git/git].`);
 
     const mails: string[] = [];
     const midRegex =
-        // tslint:disable-next-line:max-line-length
+        // eslint-disable-next-line max-len
         /<(pull|[0-9a-f]{40})\.\d+(\.v\d+)?\.git(\.*\d*)\.gitgitgadget@example\.com>/g;
+    // eslint-disable-next-line @typescript-eslint/require-await
     async function send(mail: string): Promise<string> {
         if (mails.length === 0) {
             mail = mail.replace(/(\nDate: ).*/, "$1<Cover-Letter-Date>");
@@ -260,12 +261,13 @@ to have included in git.git [https://github.com/git/git].`);
 
     const seriesMeta = await notes.get<IPatchSeriesMetadata>(pullRequestURL);
     expect(seriesMeta).not.toBeNull();
-    expect(seriesMeta!.coverLetterMessageId).not.toBeUndefined();
-    const coverMid: string = seriesMeta!.coverLetterMessageId!;
+    expect(seriesMeta?.coverLetterMessageId).not.toBeUndefined();
+    const coverMid = seriesMeta?.coverLetterMessageId as string;
     expect(coverMid)
         .toMatch(/pull\.1\.v2\.git\.\d+\.gitgitgadget@example\.com/);
-    expect(seriesMeta!.referencesMessageIds).not.toBeUndefined();
-    const refMid: string = seriesMeta!.referencesMessageIds![0];
+    expect(seriesMeta?.referencesMessageIds).not.toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const refMid = (seriesMeta?.referencesMessageIds![0]) as string;
     expect(refMid)
         .toMatch(/pull\.1\.git\.\d+\.gitgitgadget@example\.com/);
     expect(seriesMeta).toEqual({

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -29,9 +29,9 @@ located at the same directory level as this project (ie ../).
 */
 
 class GitHubProxy extends GitHubGlue {
-    public octo: Octokit | any;
-    public constructor(workDir?: string, repo = "git") {
-        super(workDir, repo);
+    public octo: Octokit;
+    public constructor(workDir?: string, repoName = "git") {
+        super(workDir, repoName);
         this.octo = this.client;
     }
 
@@ -101,13 +101,13 @@ test("pull requests", async () => {
                 repo,
                 });
         } catch (error) {
-            expect(error.toString()).toMatch(/Reference does not exist/);
+            expect((error as Error).toString()).toMatch(/does not exist/);
         }
 
         try {                       // delete local branch
             await git(["branch", "-D", branch], { workDir: repoDir });
         } catch (error) {
-            expect(error.toString()).toMatch(/not found/);
+            expect((error as Error).toString()).toMatch(/not found/);
         }
 
         const gRef = await github.octo.git.getRef({

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -88,7 +88,7 @@ class PatchSeriesTest extends PatchSeries {
         PatchSeries.insertCcAndFromLines(mails, thisAuthor, senderName);
 
         test("non-ASCII characters are encoded correctly", () => {
-            // tslint:disable-next-line:max-line-length
+            // eslint-disable-next-line max-len
             const needle = "\"=?UTF-8?Q?Nguy=E1=BB=85n_Th=C3=A1i_Ng=E1=BB=8Dc?= Duy via GitGitGadget\" ";
             expect(mails[0]).toEqual(expect.stringContaining(needle));
         });
@@ -100,6 +100,7 @@ class PatchSeriesTest extends PatchSeries {
                 "excited! <email.org>": false,
                 "foo [bar] name <email.org>": "\"foo [bar] name\" <email.org>",
                 "harry \"s\" truman <usa.gov>":
+                    // eslint-disable-next-line max-len
                     [ "\"harry \\\"s\\\" truman\" <usa.gov>", "harry =?UTF-8?Q?=22s=22?= truman <usa.gov>" ],
                 "mr. name <email.org>": "\"mr. name\" <email.org>",
                 "ms. \\backslash <email.org>":
@@ -122,7 +123,7 @@ class PatchSeriesTest extends PatchSeries {
 
         test("Cc: is inserted correctly", () => {
             expect(mails[1]).toMatch(
-                // tslint:disable-next-line:max-line-length
+                // eslint-disable-next-line max-len
                 /From: "Some One Else via GitGitGadget"[^]*\nCc: Some One Else[^]*\n\nFrom: Some One Else.*\n\n/);
         });
 
@@ -167,10 +168,9 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             PatchSeries.insertFooters(mails[1], false, footers);
         test("range-diff is inserted correctly", () => {
             expect(coverLetterWithRangeDiff).toMatch(
-                // tslint:disable-next-line:max-line-length
                 /\n\nHEADER\n This\n is\n a\n fake\n cover letter\n-- \n2\.17/);
             expect(mailWithRangeDiff).toMatch(
-                // tslint:disable-next-line:max-line-length
+                // eslint-disable-next-line max-len
                 /\n---\n\nHEADER\n This\n is\n a\n fake\n cover letter\n\n README/);
         });
 
@@ -218,6 +218,7 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
         ].join("\n");
         test("different MIME-Version headers write to log", () => {
             const mails1 = [mimeBox2];
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             const realLog = global.console.log; // capture calls to log
             const log = jest.fn();
             global.console.log = log;
@@ -229,7 +230,7 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             expect(log).toHaveBeenCalledTimes(1); // verify no more errors
         });
 
-        const ContentTypeBox1 = [
+        const contentTypeBox1 = [
             "From xyz",
             "Content-Type: text/plain; charset=UTF-8",
             "From: bogus@example.org",
@@ -243,12 +244,12 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             "Hi!",
         ].join("\n");
         test("duplicate Content-Type headers are eliminated", () => {
-            const mails1 = [ContentTypeBox1];
+            const mails1 = [contentTypeBox1];
             PatchSeries.removeDuplicateHeaders(mails1);
             expect(mails1[0]).not.toMatch(/Content-Type[^]*Content-Type/);
         });
 
-        const ContentTypeBox2 = [
+        const contentTypeBox2 = [
             "From xyz",
             "Content-Type: text/plain; charset=UTF-8",
             "From: bogus@example.org",
@@ -259,7 +260,8 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             "Hi!",
         ].join("\n");
         test("different Content-Type headers write to log", () => {
-            const mails1 = [ContentTypeBox2];
+            const mails1 = [contentTypeBox2];
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             const realLog = global.console.log; // capture calls to log
             const log = jest.fn();
             global.console.log = log;
@@ -271,7 +273,7 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             expect(log).toHaveBeenCalledTimes(1); // verify no more errors
         });
 
-        const ContentTypeBox3 = [
+        const contentTypeBox3 = [
             "From xyz",
             "Content-Type: text/plain; charset=UTF-8",
             "From: bogus@example.org",
@@ -283,12 +285,12 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             "Hi!",
         ].join("\n");
         test("duplicate Content-Type headers are eliminated", () => {
-            const mails1 = [ContentTypeBox3];
+            const mails1 = [contentTypeBox3];
             PatchSeries.removeDuplicateHeaders(mails1);
             expect(mails1[0]).not.toMatch(/Content-Type[^]*Content-Type/);
         });
 
-        const ContentTransferEncodingBox1 = [
+        const contentTransferEncodingBox1 = [
             "From xyz",
             "Content-Transfer-Encoding: 8bit",
             "From: bogus@example.org",
@@ -301,13 +303,13 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
         ].join("\n");
         test("duplicate Content-Transfer-Encoding headers are eliminated",
              () => {
-            const mails1 = [ContentTransferEncodingBox1];
+            const mails1 = [contentTransferEncodingBox1];
             PatchSeries.removeDuplicateHeaders(mails1);
-            // tslint:disable-next-line:max-line-length
+            // eslint-disable-next-line max-len
             expect(mails1[0]).not.toMatch(/Content-Transfer-Encoding[^]*Content-Transfer-Encoding/);
         });
 
-        const ContentTransferEncodingBox2 = [
+        const contentTransferEncodingBox2 = [
             "From xyz",
             "Content-Transfer-Encoding: 8bit",
             "From: bogus@example.org",
@@ -318,7 +320,8 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             "Hi!",
         ].join("\n");
         test("different Content-Transfer-Encoding headers write to log", () => {
-            const mails1 = [ContentTransferEncodingBox2];
+            const mails1 = [contentTransferEncodingBox2];
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             const realLog = global.console.log; // capture calls to log
             const log = jest.fn();
             global.console.log = log;
@@ -330,7 +333,7 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             expect(log).toHaveBeenCalledTimes(1); // verify no more errors
         });
 
-        const ContentDescriptionBox1 = [
+        const contentDescriptionBox1 = [
             "From xyz",
             "Content-Description: fooba",
             "From: bogus@example.org",
@@ -342,13 +345,13 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             "Hi!",
         ].join("\n");
         test("duplicate Content-Description headers throw error", () => {
-            const mails1 = [ContentDescriptionBox1];
+            const mails1 = [contentDescriptionBox1];
             PatchSeries.removeDuplicateHeaders(mails1);
-            // tslint:disable-next-line:max-line-length
+            // eslint-disable-next-line max-len
             expect(mails1[0]).not.toMatch(/Content-Description[^]*Content-Description/);
         });
 
-        const ContentDescriptionBox2 = [
+        const contentDescriptionBox2 = [
             "From xyz",
             "Content-Description: fooba",
             "From: bogus@example.org",
@@ -360,7 +363,8 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             "Hi!",
         ].join("\n");
         test("different Content-Description headers write to log", () => {
-            const mails1 = [ContentDescriptionBox2];
+            const mails1 = [contentDescriptionBox2];
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             const realLog = global.console.log; // capture calls to log
             const log = jest.fn();
             global.console.log = log;
@@ -372,7 +376,7 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             expect(log).toHaveBeenCalledTimes(1); // verify no more errors
         });
 
-        const ContentIDBox1 = [
+        const contentIDBox1 = [
             "From xyz",
             "Content-ID: 1.0",
             "From: bogus@example.org",
@@ -384,12 +388,12 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             "Hi!",
         ].join("\n");
         test("duplicate Content-ID headers throw error", () => {
-            const mails1 = [ContentIDBox1];
+            const mails1 = [contentIDBox1];
             PatchSeries.removeDuplicateHeaders(mails1);
             expect(mails1[0]).not.toMatch(/Content-ID[^]*Content-ID/);
         });
 
-        const ContentIDBox2 = [
+        const contentIDBox2 = [
             "From xyz",
             "Content-ID: 1.0",
             "From: bogus@example.org",
@@ -401,7 +405,8 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             "Hi!",
         ].join("\n");
         test("different Content-ID headers write to log", () => {
-            const mails1 = [ContentIDBox2];
+            const mails1 = [contentIDBox2];
+            // eslint-disable-next-line @typescript-eslint/unbound-method
             const realLog = global.console.log; // capture calls to log
             const log = jest.fn();
             global.console.log = log;

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "script/**/*.ts",
+    "tests/**/*.ts",
+  ]
+}


### PR DESCRIPTION
Many generic types are now more specific.

The linting will now be based on eslint and prettier.  Both with typescript extensions.

There are some ignore rules (file and line level) to be cleaned up.  One file is being ignored at the moment.  Issues will be opened after this is approved to ensure they are not missed.