### PR TITLE
Resolve eslint unbound method error

### DIFF
--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -217,16 +217,14 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
         ].join("\n");
         test("different MIME-Version headers write to log", () => {
             const mails1 = [mimeBox2];
-            const log = jest.fn();
-            // eslint-disable-next-line @typescript-eslint/unbound-method
-            const realLog = global.console.log; // capture calls to log
-            global.console.log = log;
+            const logSpy = jest.spyOn(console, "log")
+                .mockImplementation(() => {return;});
 
             PatchSeries.removeDuplicateHeaders(mails1);
 
-            global.console.log = realLog;
-            expect(log.mock.calls[0][0]).toMatch(/Found multiple headers/);
-            expect(log).toHaveBeenCalledTimes(1); // verify no more errors
+            expect(logSpy.mock.calls[0][0]).toMatch(/Found multiple headers/);
+            expect(logSpy).toHaveBeenCalledTimes(1); // verify no more errors
+            logSpy.mockRestore();
         });
 
         const contentTypeBox1 = [
@@ -260,16 +258,14 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
         ].join("\n");
         test("different Content-Type headers write to log", () => {
             const mails1 = [contentTypeBox2];
-            // eslint-disable-next-line @typescript-eslint/unbound-method
-            const realLog = global.console.log; // capture calls to log
-            const log = jest.fn();
-            global.console.log = log;
+            const logSpy = jest.spyOn(console, "log")
+                .mockImplementation(() => {return;});
 
             PatchSeries.removeDuplicateHeaders(mails1);
 
-            global.console.log = realLog;
-            expect(log.mock.calls[0][0]).toMatch(/Found multiple headers/);
-            expect(log).toHaveBeenCalledTimes(1); // verify no more errors
+            expect(logSpy.mock.calls[0][0]).toMatch(/Found multiple headers/);
+            expect(logSpy).toHaveBeenCalledTimes(1); // verify no more errors
+            logSpy.mockRestore();
         });
 
         const contentTypeBox3 = [
@@ -320,16 +316,14 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
         ].join("\n");
         test("different Content-Transfer-Encoding headers write to log", () => {
             const mails1 = [contentTransferEncodingBox2];
-            // eslint-disable-next-line @typescript-eslint/unbound-method
-            const realLog = global.console.log; // capture calls to log
-            const log = jest.fn();
-            global.console.log = log;
+            const logSpy = jest.spyOn(console, "log")
+                .mockImplementation(() => {return;});
 
             PatchSeries.removeDuplicateHeaders(mails1);
 
-            global.console.log = realLog;
-            expect(log.mock.calls[0][0]).toMatch(/Found multiple headers/);
-            expect(log).toHaveBeenCalledTimes(1); // verify no more errors
+            expect(logSpy.mock.calls[0][0]).toMatch(/Found multiple headers/);
+            expect(logSpy).toHaveBeenCalledTimes(1); // verify no more errors
+            logSpy.mockRestore();
         });
 
         const contentDescriptionBox1 = [
@@ -363,16 +357,14 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
         ].join("\n");
         test("different Content-Description headers write to log", () => {
             const mails1 = [contentDescriptionBox2];
-            // eslint-disable-next-line @typescript-eslint/unbound-method
-            const realLog = global.console.log; // capture calls to log
-            const log = jest.fn();
-            global.console.log = log;
+            const logSpy = jest.spyOn(console, "log")
+                .mockImplementation(() => {return;});
 
             PatchSeries.removeDuplicateHeaders(mails1);
 
-            global.console.log = realLog;
-            expect(log.mock.calls[0][0]).toMatch(/Found multiple headers/);
-            expect(log).toHaveBeenCalledTimes(1); // verify no more errors
+            expect(logSpy.mock.calls[0][0]).toMatch(/Found multiple headers/);
+            expect(logSpy).toHaveBeenCalledTimes(1); // verify no more errors
+            logSpy.mockRestore();
         });
 
         const contentIDBox1 = [
@@ -405,16 +397,14 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
         ].join("\n");
         test("different Content-ID headers write to log", () => {
             const mails1 = [contentIDBox2];
-            // eslint-disable-next-line @typescript-eslint/unbound-method
-            const realLog = global.console.log; // capture calls to log
-            const log = jest.fn();
-            global.console.log = log;
+            const logSpy = jest.spyOn(console, "log")
+                .mockImplementation(() => {return;});
 
             PatchSeries.removeDuplicateHeaders(mails1);
 
-            global.console.log = realLog;
-            expect(log.mock.calls[0][0]).toMatch(/Found multiple headers/);
-            expect(log).toHaveBeenCalledTimes(1); // verify no more errors
+            expect(logSpy.mock.calls[0][0]).toMatch(/Found multiple headers/);
+            expect(logSpy).toHaveBeenCalledTimes(1); // verify no more errors
+            logSpy.mockRestore();
         });
 
         test("test parsePullRequest()", async () => {


### PR DESCRIPTION
Removing the need to specify this override:
`eslint-disable-next-line @typescript-eslint/unbound-method`

The code will now use `jest.spyOn()`, which provides a cleaner implementation of swapping out the `console.log()` function.