### PR TITLE
CVE-2020-15228 fix to set-env and other workflow updates

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -22,7 +22,9 @@ name: pr-test
 
 on:
   push:
-    branches-ignore: [ master, main ]
+    branches-ignore:
+      - master
+      - main
 
 jobs:
   build-test:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -91,7 +91,7 @@ jobs:
         path: ${{ env.GGG_REPOSITORY }}
       if: env.GGG_TOKEN
 
-    - uses: actions/setup-node@v1.4.2
+    - uses: actions/setup-node@v1
       with:
         node-version: '${{ matrix.node-version }}' # optional, default is 10.x
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         if [ -n "$GGG_TOKEN" ] && [ -n "$GGG_REPOSITORY" ];
         then
-          echo "::set-env name=GGG_REPO::'gitgitgadget.githubtest.githubuser=$GITHUB_REPOSITORY_OWNER' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubrepo=$GGG_REPOSITORY' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubtoken=$GGG_TOKEN'"
+          echo "GGG_REPO='gitgitgadget.githubtest.githubuser=$GITHUB_REPOSITORY_OWNER' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubrepo=$GGG_REPOSITORY' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubtoken=$GGG_TOKEN'" >> $GITHUB_ENV
         else
           echo "::error::Both GGG_TOKEN and GGG_REPOSITORY secrets must be set"
           exit 1
@@ -74,7 +74,7 @@ jobs:
             m+=" 'gitgitgadget.cismtpopts=$GGG_SMTP_OPTS'"
           fi
           # trailing space is required
-          echo "::set-env name=GGG_SMTP::$m "
+          echo "GGG_SMTP=$m " >> $GITHUB_ENV
         else
           echo "::error::All of GGG_SMTP_USER, GGG_SMTP_PASS and GGG_SMTP_HOST secrets must be set"
           exit 1


### PR DESCRIPTION
Workflows will now use environment files to set variables.  See [CVE-2020-15228](https://github.com/advisories/GHSA-mfwh-5m23-j46w) for background information.

Updated the `branches-ignore` to match current documentation.

Change from a specific release to the more generic version which should get the latest code.

This gets rid of the warning:
`The 'add-path' command is deprecated and will be disabled soon.`
