### PR TITLE
Change test configuration variable names

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         if [ -n "$GGG_TOKEN" ] && [ -n "$GGG_REPOSITORY" ];
         then
-          echo "GGG_REPO='gitgitgadget.githubtest.githubuser=$GITHUB_REPOSITORY_OWNER' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubrepo=$GGG_REPOSITORY' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubtoken=$GGG_TOKEN'" >> $GITHUB_ENV
+          echo "GGG_REPO='gitgitgadget.CIGitHubTestUser=$GITHUB_REPOSITORY_OWNER' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubrepo=$GGG_REPOSITORY' 'gitgitgadget.$GITHUB_REPOSITORY_OWNER.githubtoken=$GGG_TOKEN'" >> $GITHUB_ENV
         else
           echo "::error::Both GGG_TOKEN and GGG_REPOSITORY secrets must be set"
           exit 1

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -20,7 +20,7 @@ login to succeed.  This can be restricted to the test repo.
 
 For example, these configuration settings are needed (where
 `octo-kitty` is your GitHub login):
-git config --add gitgitgadget.gitHubTest.gitHubUser octo-kitty
+git config --add gitgitgadget.CIGitHubTestUser octo-kitty
 git config --add gitgitgadget.octo-kitty.gitHubRepo ggg-test
 git config --add gitgitgadget.octo-kitty.gitHubToken feedbeef...
 
@@ -47,7 +47,7 @@ let owner: string;
 let repo: string;
 
 beforeAll(async () => {
-    owner = await gitConfig(`gitgitgadget.gitHubTest.gitHubUser`) || "";
+    owner = await gitConfig(`gitgitgadget.CIGitHubTestUser`) || "";
     repo = await gitConfig(`gitgitgadget.${owner}.gitHubRepo`) || "";
 });
 


### PR DESCRIPTION
Change `gitgitgadget.gitHubTest.gitHubUser` to `gitgitgadget.CIGitHubTestUser`.  This allows the git configuration names to be case insensitive, reducing the risk of user error.

This addresses issue #348.

