### PR TITLE
CI: verify emails have been received

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,6 +7,7 @@
 # Optional GitHub secrets
 
 # See ci-helper.test.ts for information on the following
+# GGG_IMAP_HOST = <email_imap_hostname>
 # GGG_SMTP_USER = <email_userid>
 # GGG_SMTP_PASS = <email_password>
 # GGG_SMTP_HOST = <email_hostname>
@@ -44,6 +45,7 @@ jobs:
       GGG_SMTP_USER: ${{ secrets.GGG_SMTP_USER }}
       GGG_SMTP_PASS: ${{ secrets.GGG_SMTP_PASS }}
       GGG_SMTP_HOST: ${{ secrets.GGG_SMTP_HOST }}
+      GGG_IMAP_HOST: ${{ secrets.GGG_IMAP_HOST }}
 
     steps:
     # Check out repo under sub-dir so other repo can be checked out
@@ -68,9 +70,9 @@ jobs:
         GGG_SMTP_OPTS: ${{ secrets.GGG_SMTP_OPTS }}
       shell: bash
       run: |
-        if [ -n "$GGG_SMTP_USER" ] && [ -n "$GGG_SMTP_PASS" ] && [ -n "$GGG_SMTP_HOST" ];
+        if [ -n "$GGG_SMTP_USER" ] && [ -n "$GGG_SMTP_PASS" ] && [ -n "$GGG_SMTP_HOST" ] && [ -n "$GGG_IMAP_HOST" ];
         then
-          m="'gitgitgadget.cismtpuser=$GGG_SMTP_USER' 'gitgitgadget.cismtppass=$GGG_SMTP_PASS' 'gitgitgadget.cismtphost=$GGG_SMTP_HOST'";
+          m="'gitgitgadget.cismtpuser=$GGG_SMTP_USER' 'gitgitgadget.cismtppass=$GGG_SMTP_PASS' 'gitgitgadget.cismtphost=$GGG_SMTP_HOST' 'gitgitgadget.ciimaphost=$GGG_IMAP_HOST'";
           if [ -n "$GGG_SMTP_OPTS" ];
           then
             m+=" 'gitgitgadget.cismtpopts=$GGG_SMTP_OPTS'"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1381,6 +1381,25 @@
       "resolved": "https://registry.npmjs.org/@types/html-to-text/-/html-to-text-5.1.2.tgz",
       "integrity": "sha512-56PHFwRe18fmZ+UsN6GqUaoKfalOwFzxaBMRA2O5URde3d5mxdH1HvnIV7LSugCiO8JWlRdSL2L3xJXykCTKVg=="
     },
+    "@types/imap": {
+      "version": "0.8.31",
+      "resolved": "https://registry.npmjs.org/@types/imap/-/imap-0.8.31.tgz",
+      "integrity": "sha512-ZnIThvIZ7FyxLCnC4qOAqjEHQzrPydHGdqcZ9oMSDpZcTV7Z3HKJuCmlXbwFX3gYIZW8jQC+LtOiDSnxN10Hcg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/imap-simple": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@types/imap-simple/-/imap-simple-4.2.4.tgz",
+      "integrity": "sha512-RNNOlFhKMPaRkIT2TYruB4SSuD3hDmTQjQsspmRkDsKorKODskZ5j5TwBg3LxnI9uAN75rZ17bCB9cDyGxNiPQ==",
+      "dev": true,
+      "requires": {
+        "@types/imap": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -2428,8 +2447,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -4065,6 +4083,61 @@
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
+    "imap": {
+      "version": "0.8.19",
+      "resolved": "https://registry.npmjs.org/imap/-/imap-0.8.19.tgz",
+      "integrity": "sha1-NniHOTSrCc6mukh0HyhNoq9Z2NU=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "utf7": ">=1.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "imap-simple": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/imap-simple/-/imap-simple-5.0.0.tgz",
+      "integrity": "sha512-/wLRwy8tmKdzacVDOZUeD05GkqIax38tEFwAToFB2Jhb7zfmGdaxzYWOvPZi2t6kumrjNhSyt5BstCemKzcV+A==",
+      "requires": {
+        "iconv-lite": "~0.4.13",
+        "imap": "^0.8.18",
+        "nodeify": "^1.0.0",
+        "quoted-printable": "^1.0.0",
+        "utf8": "^2.1.1",
+        "uuencode": "0.0.4"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -4285,6 +4358,11 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
       "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
       "dev": true
+    },
+    "is-promise": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+      "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU="
     },
     "is-regex": {
       "version": "1.1.1",
@@ -6015,6 +6093,15 @@
         }
       }
     },
+    "nodeify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
+      "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
+      "requires": {
+        "is-promise": "~1.0.0",
+        "promise": "~1.3.0"
+      }
+    },
     "nodemailer": {
       "version": "6.4.14",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.14.tgz",
@@ -6413,6 +6500,14 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
+    "promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
+      "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
+      "requires": {
+        "is-promise": "~1"
+      }
+    },
     "prompts": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
@@ -6449,6 +6544,14 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "quoted-printable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/quoted-printable/-/quoted-printable-1.0.1.tgz",
+      "integrity": "sha1-nuv16z0R7vAismT9LStrK7O4TMM=",
+      "requires": {
+        "utf8": "^2.1.0"
+      }
     },
     "react-is": {
       "version": "17.0.1",
@@ -6716,8 +6819,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -7859,10 +7961,35 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "utf7": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utf7/-/utf7-1.0.2.tgz",
+      "integrity": "sha1-lV9JCq5lO6IguUVqCod2wZk2CZE=",
+      "requires": {
+        "semver": "~5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+        }
+      }
+    },
+    "utf8": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuencode": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uuencode/-/uuencode-0.0.4.tgz",
+      "integrity": "sha1-yNUDcIhWY4eThas34zPH6OOwIYw="
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "testRegex": "/tests/(?!test-lib).*\\.(ts|tsx|js)$"
   },
   "devDependencies": {
+    "@types/imap-simple": "^4.2.4",
     "@types/jest": "^26.0.15",
     "@types/json-stable-stringify": "^1.0.32",
     "@types/jsonwebtoken": "^8.5.0",
@@ -60,6 +61,7 @@
     "commander": "^6.2.0",
     "dugite": "^1.92.0",
     "html-to-text": "^5.1.1",
+    "imap-simple": "^5.0.0",
     "json-stable-stringify": "^1.0.1",
     "jsonwebtoken": "^8.5.1",
     "libqp": "^1.1.0",

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -6,7 +6,10 @@ import {
      GitHubGlue, IGitHubUser, IPRComment, IPRCommit, IPullRequestInfo,
 } from "../lib/github-glue";
 import { IMailMetadata } from "../lib/mail-metadata";
+import { connect, ImapSimple } from "imap-simple";
 import { testCreateRepo, TestRepo } from "./test-lib";
+import { promisify } from "util";
+const sleep = promisify(setTimeout);
 
 jest.setTimeout(180000);
 
@@ -16,19 +19,21 @@ jest.setTimeout(180000);
 //
 // Sample config settings:
 // [gitgitgadget]
+//  CIimapHost = imap.ethereal.email
 //  CIsmtpUser = first.last@ethereal.email
 //  CIsmtphost = smtp.ethereal.email
 //  CIsmtppass = feedeadbeeffeeddeadbeef
 //  CIsmtpopts = {port: 587, secure: false, tls: {rejectUnauthorized: false}}
 
-async function getSMTPInfo():
-    Promise <{ smtpUser: string; smtpHost: string;
+async function getEmailInfo():
+    Promise <{ smtpUser: string; smtpHost: string; imapHost: string;
                smtpPass: string; smtpOpts: string; }> {
     const smtpUser = await gitConfig("gitgitgadget.CIsmtpUser") || "";
     const smtpHost = await gitConfig("gitgitgadget.CIsmtpHost") || "";
     const smtpPass = await gitConfig("gitgitgadget.CIsmtpPass") || "";
     const smtpOpts = await gitConfig("gitgitgadget.CIsmtpOpts") || "";
-    return { smtpUser, smtpHost, smtpPass, smtpOpts };
+    const imapHost = await gitConfig("gitgitgadget.CIimapHost") || "";
+    return { smtpUser, smtpHost, imapHost, smtpPass, smtpOpts };
 }
 
 // Mocking class to replace GithubGlue with mock of GitHubGlue
@@ -120,7 +125,7 @@ async function setupRepos(instance: string):
     ]);
 
     const { smtpUser, smtpHost, smtpPass, smtpOpts } =
-        await getSMTPInfo();
+        await getEmailInfo();
 
     await worktree.git([
         "config", "--add", "gitgitgadget.smtpUser",
@@ -156,6 +161,75 @@ async function setupRepos(instance: string):
     await gggRemote.git(["branch", "seen"]);
 
     return { worktree, gggLocal, gggRemote };
+}
+
+/**
+ * Connect to imap mail server.  Opens the INBOX as the current folder.
+ */
+async function imapConnect(): Promise <ImapSimple> {
+    const { smtpUser, smtpPass, imapHost } = await getEmailInfo();
+
+    const config = {
+        imap: {
+            user: smtpUser,
+            password: smtpPass,
+            host: imapHost,
+            port: 993,
+            tls: true,
+            authTimeout: 3000
+        }
+    };
+
+    const connection = await connect(config);
+    await connection.openBox("INBOX");
+
+    return connection;
+}
+
+/**
+ * Terminate the imap mail server connection.
+ *
+ * @param connection
+ */
+async function imapDisConnect(connection: ImapSimple): Promise <void> {
+    await connection.closeBox(false);
+    connection.end();
+}
+
+/**
+ * Check the inbox to see if an email has arrived after 1 second.
+ *
+ * @param messageId string to search for in inbox
+ */
+async function checkMsgId(messageId: string): Promise <boolean> {
+    await sleep(1000);
+    const connection = await imapConnect();
+
+    const searchCriteria = [
+        "UNSEEN"
+    ];
+
+    const fetchOptions = {
+        bodies: ["HEADER"],
+        markSeen: false
+    };
+
+    const results = await connection.search(searchCriteria, fetchOptions);
+
+    type bodyObject = {
+        "message-id": string;
+    };
+
+    const ids = results.map(res => {
+        const body = res.parts[0].body as bodyObject;
+        const id = body["message-id"];
+        const baseId = id.match(/\<(.*)\>/);
+        return (baseId && baseId[1]) ? baseId[1] : null ;
+    });
+
+    await imapDisConnect(connection);
+
+    return ids.includes(messageId);
 }
 
 test("identify merge that integrated some commit", async () => {
@@ -593,7 +667,7 @@ test("handle comment submit email success", async () => {
         title: "Submit a fun fix",
     };
 
-    const { smtpUser } = await getSMTPInfo();
+    const { smtpUser } = await getEmailInfo();
 
     if (smtpUser) {                 // if configured for this test
         ci.setGHGetPRInfo(prInfo);
@@ -603,6 +677,13 @@ test("handle comment submit email success", async () => {
 
         await ci.handleComment("gitgitgadget", 433865360);
         expect(ci.addPRCommentCalls[0][1]).toMatch(/Submitted as/);
+
+        const msgId = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
+        expect(msgId).not.toBeUndefined();
+        if (msgId && msgId[1]) {
+            const msgFound = await checkMsgId(msgId[1]);
+            expect(msgFound).toBeTruthy();
+        }
     }
 });
 
@@ -673,7 +754,7 @@ test("handle comment preview email success", async () => {
         title: "Preview a fun fix",
     };
 
-    const { smtpUser } = await getSMTPInfo();
+    const { smtpUser } = await getEmailInfo();
 
     if (smtpUser) {                 // if configured for this test
         ci.setGHGetPRInfo(prInfo);
@@ -684,13 +765,34 @@ test("handle comment preview email success", async () => {
         await ci.handleComment("gitgitgadget", 433865360);
         expect(ci.addPRCommentCalls[0][1]).toMatch(/Submitted as/);
 
+        const msgId1 = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
+        expect(msgId1).not.toBeUndefined();
+        if (msgId1 && msgId1[1]) {
+            const msgFound1 = await checkMsgId(msgId1[1]);
+            expect(msgFound1).toBeTruthy();
+        }
+
         comment.body = " /preview";
         ci.setGHGetPRComment(comment);
         await ci.handleComment("gitgitgadget", 433865360); // do it again
         expect(ci.addPRCommentCalls[1][1])
             .toMatch(/Preview email sent as/);
 
+        const msgId2 = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
+        expect(msgId2).not.toBeUndefined();
+        if (msgId2 && msgId2[1]) {
+            const msgFound2 = await checkMsgId(msgId2[1]);
+            expect(msgFound2).toBeTruthy();
+        }
+
         await ci.handleComment("gitgitgadget", 433865360); // should still be v2
+
+        const msgId3 = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
+        expect(msgId3).not.toBeUndefined();
+        if (msgId3 && msgId3[1]) {
+            const msgFound3 = await checkMsgId(msgId3[1]);
+            expect(msgFound3).toBeTruthy();
+        }
     }
 });
 


### PR DESCRIPTION
If configured, an email imap session will verify the sent test emails have been received.  This requires, in addition to existing environment variables, gitgitgadget.CIimapHost to be set.

For GitHub workflows, a new secret GGG_IMAP_HOST must be set.

This feature waits one second after sending the email to check for it.  If this is found to be insufficient (tests failing for not found), retry logic can be added.

This has been tested with the ethereal email service.

For local testing, if the `Error: self signed certificate in certificate chain` message is issued, set environment variable `NODE_TLS_REJECT_UNAUTHORIZED=0`.