### PR TITLE
Test isolation

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -114,3 +114,12 @@ jobs:
         GIT_CONFIG_PARAMETERS: ${{ env.GGG_SMTP }}${{ env.GGG_REPO }}
       run: npm run test
       working-directory: gitgitgadget
+
+    - name: Clean up two day old branches and PRs
+      uses: actions/github-script@v3
+      id: clean-up
+      with:
+        script: |
+            const exports = require(`${process.env.GITHUB_WORKSPACE}/gitgitgadget/build/lib/delete-ci-test-branches.js`)
+            await exports.deleteBranches(github, process.env.GITHUB_REPOSITORY_OWNER, process.env.GGG_REPOSITORY);
+      if: env.GGG_REPOSITORY

--- a/lib/delete-ci-test-branches.ts
+++ b/lib/delete-ci-test-branches.ts
@@ -1,0 +1,133 @@
+import { Octokit } from "@octokit/rest";
+
+/*
+Tool for cleaning up old branchs left over from github-helper.test.ts
+tests that failed.  The branches are named with a timestamp.  Deleting
+branches will close open PRs.  This is primarily intended to be used by
+a workflow.  The default is to delete branches older than two days.
+*/
+
+// ref level results of the GraphQL query
+
+declare type refGraph = {
+    node: {                         // branches as refs
+        name: string,
+        id: string,
+        pulls: {
+            edges: [                // pull requests
+                {
+                    node: {
+                        number: number,
+                    }
+                }
+            ]
+        }
+    }
+};
+
+// repository level results of the GraphQL query
+
+declare type repositoryGraph = {
+    repository: {
+        refs: {
+            edges: [
+                ref: refGraph,
+            ]
+        }
+    }
+};
+
+/**
+ * Options to modify requests.  hours takes precedence over minutes.
+ * minutes is primarily for testing.  hours is relative to start of day and
+ * minutes is relative to current time.  hours defaults to two days.
+ * Refs will not be deleted if dryRun is true.
+ *
+ * @param hours is how old a branch should be
+ * @param minutes is how old a branch should be
+ * @param dryRun skip deletion if true
+ */
+export type deletionOptions = {
+    hours?: number,
+    minutes?: number,
+    dryRun?: boolean,
+};
+
+/**
+ * @param octocat GitHub connection
+ * @param owner userid of repository owner on GitHub
+ * @param repo name of repository on GitHub
+ * @param options deletionOptions to override default of two days
+ */
+export async function deleteBranches( octocat: Octokit, owner: string,
+    repo: string, options?: deletionOptions): Promise<void> {
+
+    if (!owner || !repo) {
+        throw new Error("Missing owner or repo name.");
+    }
+
+    const expires = new Date();
+    const userOptions = options || { hours: 48 };
+
+    if (userOptions.hours) {
+        expires.setUTCHours(0 - userOptions.hours, 0 ,0);
+    } else if (userOptions.minutes) {
+        expires.setUTCMinutes(expires.getUTCMinutes() - userOptions.minutes);
+    } else {
+        throw new Error("Invalid options passed.");
+    }
+
+    const expireDate = expires.toISOString().replace(/[:.]/g, "_");
+
+    const query = `query {
+        repository(name: "${repo}", owner: "${owner}") {
+            id,
+            name,
+            refs(refPrefix: "refs/heads/", first: 10) {
+                edges {
+                    node {
+                        name,
+                        id,
+                        pulls:associatedPullRequests(first: 5, states:OPEN) {
+                            edges {
+                                node {
+                                    id,
+                                    number,
+                                    title,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }`;
+
+    const result: repositoryGraph = await octocat.graphql(query);
+
+    // console.log(result.repository.refs.edges);
+
+    await Promise.all(
+        result.repository.refs.edges.map(ref => {
+            const br = ref.node;
+            const name = br.name;
+            const suffix = name.match(/ggg[_\-]test-branch-\S+?[\-_](.*)/);
+
+            if (suffix && suffix[1] < expireDate) {
+                if (br.pulls.edges.length) {
+                    console.log(
+                        `Closing PR ${br.pulls.edges[0].node.number}`);
+                }
+                console.log(`Deleting branch ${br.name}`);
+                const mutate = `mutation DeleteBranch {
+                    deleteRef(input:{refId: "${br.id}"}) {
+                    clientMutationId }}`;
+                if (!userOptions.dryRun) {
+                    return octocat.graphql(mutate);
+                } else {
+                    console.log(`Deletion of refId: "${br.id}" skipped`);
+                }
+            }
+        })
+    );
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "cleanbranch": "node ./build/script/delete-test-branches.js",
     "lint": "eslint -c .eslintrc.js --ext .ts,.js {lib,script,tests}/**/*.{ts,tsx,js}",
     "start": "node server.js",
     "test": "npm run lint && jest --env=node",

--- a/script/delete-test-branches.ts
+++ b/script/delete-test-branches.ts
@@ -1,0 +1,75 @@
+import { Octokit } from "@octokit/rest";
+import commander = require("commander");
+import { deleteBranches,
+    deletionOptions } from "../lib/delete-ci-test-branches";
+import { GitHubGlue } from "../lib/github-glue";
+
+const description = `Clean up GitHubGlue test branches.
+
+When a test fails, there may be a branch and a pull request left active on the
+test repository.  This tool can be run to delete the old branches, which will
+cause GitHub to close the pull request.  Branches from two days ago are cleaned
+up.
+
+The owner and repository name must be specified.  The cleanup criteria can be
+overridden using the --hours or --minutes options.  These would be used
+primarily for testing.`
+
+class GitHubProxy extends GitHubGlue {
+    public octo: Octokit;
+    public constructor(workDir?: string, repo = "gitty") {
+        super(workDir, repo);
+        this.octo = this.client;
+    }
+
+    public async authenticate(repositoryOwner: string): Promise<void> {
+        await this.ensureAuthenticated(repositoryOwner);
+        this.octo = this.client;
+    }
+}
+
+commander.version("1.0.0")
+    .usage("[options]")
+    .description(description)
+    .requiredOption("-o, --owner <string>",
+        "owner must be specified")
+    .requiredOption("-r, --repo <string>",
+        "repository must be specified")
+    .option("-h, --hours <number>",
+            `how old a branch is before expiring.  This is the hours
+before last midnight`,
+            undefined)
+    .option("-m, --minutes <number>",
+            "how old a branch is before expiring.  --hours has priority.",
+            undefined)
+    .option("--dry-run",
+            "do not delete the refs (useful for debugging)")
+    .parse(process.argv);
+
+if (commander.args.length > 0) {
+    commander.help();
+}
+
+(async (): Promise<void> => {
+    const options: deletionOptions = {};
+
+    if (commander.dryRun) {
+        options.dryRun = true;
+    }
+
+    if (commander.hours) {
+        options.hours = commander.hours as number;
+    } else if (commander.minutes) {
+        options.minutes = commander.minutes as number;
+    }
+
+    const github = new GitHubProxy(/* repoDir */);
+    await github.authenticate(commander.owner);
+
+    await deleteBranches(github.octo, commander.owner,
+        commander.repo, options );
+
+})().catch((reason: Error) => {
+    console.log(`Caught error ${reason}:\n${reason.stack}\n`);
+    process.exit(1);
+});


### PR DESCRIPTION
This patch series will change the GitHubGlue tests to use unique branch names and pull request titles.  This will get rid of the collisions that are happening when running workflows on multiple platforms at the same time.  Clean up for failed tests is also included.

- tests: isolate GitHubGlue test artifacts
Branch names and pull requests will now include the `platform` to
isolate tests running concurrently.  This could be GitHub, Azure
pipelines or locally on windows/wsl.  Initial cleanup of pull
requests and branches will only be done for local tests.  Other
locations will use timestamped branch names and pull requests.

- tools: new script to clean up GitHubGlue test artifacts
delete-test-branch.ts process the command line and calls
delete-branches.
delete-branches.ts retrieves a list of branches from GitHub
and deletes the ones older than the specified time.  The deletion
of the refs will result in any open pull requests on the branch
being closed.  This routine is also intended to be used from a
GitHub workflow.

- ci: add GitHubGlue test cleanup to workflow
Add a step to the workflow to delete old branches and pull
requests left from failed GitHubGlue test runs.

- tools: add cleanbranch command to package.json
Allow easy running of cleanbranch to delete test branches.
Sample command:
npm run cleanbranch -- -o mygithubuser -r gitout -h 4

**NOTE**
The GitHub GraphQL api is used here.  It was originally used so that a search for PRs could be done:
```
{
  search(
    query: "ggg repo:webstech/gitout in:title is:pr is:open created:<=2020-12-18T20:00:00.249Z", type: ISSUE, last: 100) {
    edges {
      node {
        ... on PullRequest {
          id
          url
          title
          createdAt
          updatedAt
        }      }    }  }}
```
The api provides an easy way to deletes the refs representing branches, which closes the PR (removing the need for the search).
