### PR TITLE
dependabot: increase pull request limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
+    open-pull-requests-limit: 10


### PR DESCRIPTION
There are frequently more than five updates each week so an increase should help to get @types and base packages updated in one set of pull requests.
