### PR TITLE
/allow: gracefully handle absence of GitHub user name again

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -464,15 +464,11 @@ export class GitHubGlue {
             username: login,
         });
 
-        if (!response.data.name) {
-            throw new Error(`Unable to get name for ${login} - ${
-                response.data.toString()}`);
-        }
 
         return {
             email: response.data.email,
             login: response.data.login,
-            name: response.data.name,
+            name: response.data.name || "",
             type: response.data.type,
         };
     }

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -587,9 +587,7 @@ test("test missing values in response using small schema", async () => {
 
     (sampleUser as IPrivateUser).name = null;
     // if (!response.data.name) {
-    await expect(github.getGitHubUserInfo(owner)).rejects.toThrow(
-        /Unable to get name/
-    );
+    await expect(github.getGitHubUserInfo(owner)).toBeTruthy();
 
     // if (!response.data.name) {
     await expect(github.getGitHubUserName(owner)).rejects.toThrow(


### PR DESCRIPTION
We became a bit too strict; for details, see

https://github.com/git/git/pull/943#issuecomment-756815087

/cc @ugultopu