### PR TITLE
Autoclose/flag questionable PRs from new contributors

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -420,7 +420,7 @@ export class CIHelper {
                 optionsUpdated = true;
             }
 
-            await this.github.closePR(pullRequestURL, closePR);
+            await this.github.closePR(pullRequestURL, `Closed via ${closePR}.`);
         }
 
         if (notesUpdated) {

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -473,6 +473,20 @@ export class GitHubGlue {
         };
     }
 
+    /**
+     * Perform a graphql query or mutation.  The results are managed and known
+     * by the requestor.  The caller specifies the return data type.
+     *
+     * @param owner GitHub user to be authenticated for this request
+     * @param query graphql query/mutate to operate on data
+     * @returns the set of data based on the user request
+     */
+    public async graphql<ResponseData>(owner: string, query: string):
+        Promise<ResponseData> {
+        await this.ensureAuthenticated(owner);
+        return await this.client.graphql<ResponseData>(query);
+    }
+
     protected async ensureAuthenticated(repositoryOwner: string):
         Promise<void> {
         if (repositoryOwner !== this.authenticated) {

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -281,7 +281,7 @@ export class GitHubGlue {
         return result.data.map((res: { id: number }) => `${res.id}`);
     }
 
-    public async closePR(pullRequestURL: string, viaMergeCommit: string):
+    public async closePR(pullRequestURL: string, closeComment: string):
         Promise<number> {
         const [owner, repo, prNo] =
             GitGitGadget.parsePullRequestURL(pullRequestURL);
@@ -295,7 +295,7 @@ export class GitHubGlue {
         });
 
         const result = await this.client.issues.createComment({
-            body: `Closed via ${viaMergeCommit}.`,
+            body: closeComment,
             issue_number: prNo,
             owner,
             repo,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1184,6 +1184,15 @@
         }
       }
     },
+    "@octokit/graphql-schema": {
+      "version": "10.19.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql-schema/-/graphql-schema-10.19.1.tgz",
+      "integrity": "sha512-tDkAkECjPSigOlVcVpfxvQeuM9DUPIkX+MYbV5sDMyQaMRe0r+3AeaB/dsL0cVTZtKOcz3ITY7e5i/IVNWckDQ==",
+      "requires": {
+        "graphql": "^15.0.0",
+        "graphql-tag": "^2.10.3"
+      }
+    },
     "@octokit/openapi-types": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-3.4.1.tgz",
@@ -3917,6 +3926,16 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
+    },
+    "graphql": {
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+    },
+    "graphql-tag": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
+      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
     },
     "growly": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@octokit/auth-app": "^2.10.6",
+    "@octokit/graphql-schema": "^10.19.1",
     "@octokit/rest": "^18.0.15",
     "commander": "^7.0.0",
     "dugite": "^1.96.0",

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -954,7 +954,7 @@ test("handle push/comment merge commits fails", async () => {
         baseRepo: "git",
         body: "Never seen - merge commits.",
         commits: commits.length,
-        hasComments: false,
+        hasComments: true,
         headCommit: commitB,
         headLabel: "somebody:master",
         mergeable: true,
@@ -996,9 +996,7 @@ test("handle push/comment merge commits fails", async () => {
     await expect(ci.handlePush("gitgitgadget", 433865360)).
         rejects.toThrow(/Failing check due/);
 
-    expect(ci.addPRCommentCalls[0][1]).toMatch(/Welcome/);
-    expect(ci.addPRCommentCalls[1][1]).toMatch(commits[0].commit);
-    expect(ci.addPRLabelsCalls[0][1]).toEqual(["new user"]);
+    expect(ci.addPRCommentCalls[0][1]).toMatch(commits[0].commit);
     ci.addPRCommentCalls.length = 0;
 
     // Test Multiple merges
@@ -1036,10 +1034,9 @@ test("handle push/comment merge commits fails", async () => {
     await expect(ci.handlePush("gitgitgadget", 433865360)).
         rejects.toThrow(/Failing check due/);
 
-    expect(ci.addPRCommentCalls[0][1]).toMatch(/Welcome/);
-    expect(ci.addPRCommentCalls[1][1]).toMatch(commits[0].commit);
-    expect(ci.addPRCommentCalls[1][1]).not.toMatch(commits[1].commit);
-    expect(ci.addPRCommentCalls[1][1]).toMatch(commits[2].commit);
+    expect(ci.addPRCommentCalls[0][1]).toMatch(commits[0].commit);
+    expect(ci.addPRCommentCalls[0][1]).not.toMatch(commits[1].commit);
+    expect(ci.addPRCommentCalls[0][1]).toMatch(commits[2].commit);
     ci.addPRCommentCalls.length = 0;
 
 });


### PR DESCRIPTION
This relates to issue #402.  New PRs by 'unallowed' users will have extra checks.  If the contents appear to be questionable, a label will be added to the PR to request a check be done.  Anyone (authorized?) reviewing the PR can remove the check.  Some PRs will be closed based on history of bad PR requests.

Commits in the PR;

1. Make GitHubGlue::closePR comment generic
The caller will now control the narrative on why a PR is closed.

2. tests: remove redundant new user check
The test did not need to have a new user to be a valid test.

3. Add enhanced linting for new contributors
For first time contributors, extra checks will be done to validate the PR.  A label will be added to flag the PR for further review in many instances.  The label can then be removed by any reviewer.  The intent is to NOT close PRs that may be valid.  Some PRs will be closed based on the content.

Changing some of the tests to flagged PRs instead of closed may be the preferred initial implementation.