### PR TITLE
Clarify "prefix" for subjects

### DIFF
--- a/res/WELCOME.md
+++ b/res/WELCOME.md
@@ -7,7 +7,7 @@ Please make sure that your Pull Request has a good description, as it will be us
 Also, it is a good idea to review the commit messages one last time, as the Git project expects them in a quite specific form:
 
 * the lines should not exceed 76 columns,
-* the first line should be like a header and typically start with a prefix like "tests:" or "commit:", and
+* the first line should be like a header and typically start with a prefix like "tests:" or "revisions:" to state which subsystem the change is about, and
 * the commit messages' body should be describing the "why?" of the change.
 * Finally, the commit messages should end in a [Signed-off-by:](https://git-scm.com/docs/SubmittingPatches#dco) line matching the commits' author.
 


### PR DESCRIPTION
It is not wrong per-se to say that our commit titles begin with "<area>:" prefix, but "prefix like tests and commit" is too weak to explain to newbies what these "prefix" words are trying to convey. It's not like a commit that includes tests get "test:" prefix while others get "commit:" prefix, but there is no way for new people to know that.

Instead, hint that the prefix is to state which subsystem the change is about to guide them to form a better commit title.