### PR TITLE
Relax lowerCaseAfterPrefix to permit ALLCAPS after prefix

### DIFF
--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -87,10 +87,11 @@ export class LintCommit {
     }
 
     // Verify if the first line starts with a prefix (e.g. tests:), it continues
-    // in lower-case
+    // in lower-case (except for ALLCAPS as that is likely to be a code
+    // identifier)
 
     private lowerCaseAfterPrefix(): void {
-        const match = this.lines[0].match(/^\S+?:\s*?([A-Z])/);
+        const match = this.lines[0].match(/^\S+?:\s*?([A-Z][a-z ])/);
 
         if (match) {
             this.block(`Prefixed commit message must be in lower case: ${

--- a/tests/commit-lint.test.ts
+++ b/tests/commit-lint.test.ts
@@ -76,7 +76,34 @@ test("basic lint tests", () => {
         }
     }
 
+    commit.message = `tests: A title that should also be lower case\n
+Signed-off-by: x`;
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/lower/);
+        }
+    }
+
+    commit.message = "tests: THIS can be allcaps\n\nSigned-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).toBeUndefined();
+    }
+
     commit.message = "doc: success as Lower Case\n\nSigned-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).toBeUndefined();
+    }
+
+    commit.message = `doc: a single-letter Lower Case message also succeeds\n
+Signed-off-by: x`;
     {
         const linter = new LintCommit(commit);
         const lintError = linter.lint();


### PR DESCRIPTION
We do want to block things like:
init: A bad example
init: Another bad example

However this should be acceptable:
init: UNLEAK foo

Therefore we tweak the regex to permit ALLCAPS after the prefix.

See also discussion in #488 .