### PR TITLE
ESLint: quote globs to avoid expanding to invalid patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsc",
     "cleanbranch": "node ./build/script/delete-test-branches.js",
-    "lint": "eslint -c .eslintrc.js --ext .ts,.js {lib,script,tests}/**/*.{ts,tsx,js}",
+    "lint": "eslint -c .eslintrc.js --ext .ts,.js '{lib,script,tests}/**/*.{ts,tsx,js}'",
     "start": "node server.js",
     "test": "npm run lint && jest --env=node",
     "test:watch": "jest --watch --notify --notifyMode=change --coverage",


### PR DESCRIPTION
When I try to run 'npm test' I see the following error:

  > gitgitgadget@1.0.0 lint /home/ahunt/git/gitgitgadget
  > eslint -c .eslintrc.js --ext .ts,.js {lib,script,tests}/**/*.{ts,tsx,js}

  Oops! Something went wrong! :(

  ESLint: 7.21.0

  No files matching the pattern "lib/**/*.tsx" were found.
  Please check for typing mistakes in the pattern.

This is because my shell appears to be performing brace expansion before
passing the globs to eslint. Quoting the globs avoids this, and lets me
run 'npm test' locally.

An alternative is to use --no-error-on-unmatched-pattern - however
that's noisier than just quoting the globs.