### PR TITLE
ci: _really_ only handle Dependabot via `pull_request`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ name: Build & run tests
 on:
   push:
     branches-ignore:
-      - dependabot/*
+      - dependabot/**
   pull_request:
 
 jobs:


### PR DESCRIPTION
Currently, Dependabot PRs trigger each build _twice_: one time because of the PR, the other one because of the push. We wanted to prevent the latter specifically, but apparently I got the syntax wrong, see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-ignoring-branches-and-tags.