### PR TITLE
Octokit - convert to new `rest` endpoints

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -73,7 +73,7 @@ export class GitHubGlue {
         const url = `https://github.com/git/git/commit/${gitGitCommit}`;
 
         await this.ensureAuthenticated(repositoryOwner);
-        const checks = await this.client.checks.create({
+        const checks = await this.client.rest.checks.create({
             completed_at: completedAt,
             conclusion: "success",
             details_url: url,
@@ -165,7 +165,7 @@ export class GitHubGlue {
         const [owner, repo, nr] =
             GitGitGadget.parsePullRequestURL(pullRequestURL);
         await this.ensureAuthenticated(owner);
-        const status = await this.client.issues.createComment({
+        const status = await this.client.rest.issues.createComment({
             body: comment,
             issue_number: nr,
             owner,
@@ -199,7 +199,7 @@ export class GitHubGlue {
                                 {workDir: gitWorkDir});
         const path = files.replace(/\n[^]*/, "");
 
-        const status = await this.client.pulls.createReviewComment({
+        const status = await this.client.rest.pulls.createReviewComment({
             body: comment,
             commit_id: commit,
             owner,
@@ -229,13 +229,14 @@ export class GitHubGlue {
             GitGitGadget.parsePullRequestURL(pullRequestURL);
         await this.ensureAuthenticated(owner);
 
-        const status = await this.client.pulls.createReplyForReviewComment({
-            body: comment,
-            comment_id: id,
-            owner,
-            pull_number: nr,
-            repo,
-        });
+        const status = await this.client.rest.pulls.createReplyForReviewComment(
+            {
+                body: comment,
+                comment_id: id,
+                owner,
+                pull_number: nr,
+                repo,
+            });
         return {
             id: status.data.id,
             url: status.data.html_url,
@@ -255,7 +256,7 @@ export class GitHubGlue {
         Promise<number> {
 
         await this.ensureAuthenticated(owner);
-        const result = await this.client.pulls.update({
+        const result = await this.client.rest.pulls.update({
             "body": body || undefined,
             owner,
             pull_number: prNumber,
@@ -272,7 +273,7 @@ export class GitHubGlue {
             GitGitGadget.parsePullRequestURL(pullRequestURL);
 
         await this.ensureAuthenticated(owner);
-        const result = await this.client.issues.addLabels({
+        const result = await this.client.rest.issues.addLabels({
             issue_number: prNo,
             labels,
             owner,
@@ -287,14 +288,14 @@ export class GitHubGlue {
             GitGitGadget.parsePullRequestURL(pullRequestURL);
 
         await this.ensureAuthenticated(owner);
-        await this.client.pulls.update({
+        await this.client.rest.pulls.update({
             owner,
             pull_number: prNo,
             repo,
             state: "closed",
         });
 
-        const result = await this.client.issues.createComment({
+        const result = await this.client.rest.issues.createComment({
             body: `Closed via ${viaMergeCommit}.`,
             issue_number: prNo,
             owner,
@@ -308,7 +309,7 @@ export class GitHubGlue {
     public async getOpenPRs(repositoryOwner: string):
         Promise<IPullRequestInfo[]> {
         const result: IPullRequestInfo[] = [];
-        const response = await this.client.pulls.list({
+        const response = await this.client.rest.pulls.list({
             owner: repositoryOwner,
             per_page: 1000,
             repo: this.repo,
@@ -349,7 +350,7 @@ export class GitHubGlue {
      */
     public async getPRInfo(repositoryOwner: string, prNumber: number):
         Promise<IPullRequestInfo> {
-        const response = await this.client.pulls.get({
+        const response = await this.client.rest.pulls.get({
             owner: repositoryOwner,
             pull_number: prNumber,
             repo: this.repo,
@@ -387,7 +388,7 @@ export class GitHubGlue {
      */
     public async getPRComment(repositoryOwner: string, commentID: number):
         Promise<IPRComment> {
-        const response = await this.client.issues.getComment({
+        const response = await this.client.rest.issues.getComment({
             comment_id: commentID,
             owner: repositoryOwner,
             repo: this.repo,
@@ -416,7 +417,7 @@ export class GitHubGlue {
      */
     public async getPRCommits(repositoryOwner: string, prNumber: number):
          Promise<IPRCommit[]> {
-        const response = await this.client.pulls.listCommits({
+        const response = await this.client.rest.pulls.listCommits({
             owner: repositoryOwner,
             pull_number: prNumber,
             repo: this.repo,
@@ -460,7 +461,7 @@ export class GitHubGlue {
         // required to get email
         await this.ensureAuthenticated(this.authenticated || "gitgitgadget");
 
-        const response = await this.client.users.getByUsername({
+        const response = await this.client.rest.users.getByUsername({
             username: login,
         });
 

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -377,14 +377,15 @@ async function getCIHelper(): Promise<CIHelper> {
 
             if (options.installationID === undefined) {
                 options.installationID =
-                    (await client.apps.getRepoInstallation({
+                    (await client.rest.apps.getRepoInstallation({
                         owner: options.name,
                         repo: "git",
                 })).data.id;
             }
-            const result = await client.apps.createInstallationAccessToken({
-                installation_id: options.installationID,
-            });
+            const result = await client.rest.apps.createInstallationAccessToken(
+                {
+                    installation_id: options.installationID,
+                });
             const configKey = options.name === "gitgitgadget" ?
                 "gitgitgadget.githubToken" :
                 `gitgitgadget.${options.name}.githubToken`;

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -102,7 +102,7 @@ test("pull requests", async () => {
             }
 
             try {                   // delete remote branch
-                await github.octo.git.deleteRef({
+                await github.octo.rest.git.deleteRef({
                     owner,
                     ref: `heads/${branchBase}`,
                     repo,
@@ -129,13 +129,13 @@ test("pull requests", async () => {
         const branchRef = `refs/heads/${branch}`;
         const title = titleBase + suffix;
 
-        const gRef = await github.octo.git.getRef({
+        const gRef = await github.octo.rest.git.getRef({
             owner,
             ref: `heads/master`,
             repo,
         });
 
-        const cRef = await github.octo.git.createRef({
+        const cRef = await github.octo.rest.git.createRef({
             owner,
             ref: branchRef,
             repo,
@@ -144,7 +144,7 @@ test("pull requests", async () => {
 
         expect(cRef.data.object.sha).toMatch(gRef.data.object.sha);
 
-        const cFile = await github.octo.repos.createOrUpdateFileContents({
+        const cFile = await github.octo.rest.repos.createOrUpdateFileContents({
             branch,
             content,
             message: "Commit a new file",
@@ -153,7 +153,7 @@ test("pull requests", async () => {
             repo,
         });
 
-        const newPR = await github.octo.pulls.create({
+        const newPR = await github.octo.rest.pulls.create({
             base: "master",
             body: "Test for a pull request\r\non a test repo.",
             head: branch,
@@ -216,7 +216,7 @@ test("pull requests", async () => {
 
         // delete local and remote branches
         try {
-            await github.octo.git.deleteRef({
+            await github.octo.rest.git.deleteRef({
                 owner,
                 ref: `heads/${branch}`,
                 repo,


### PR DESCRIPTION
GitHub REST API endpoints are moving to the `rest` object in Octokit.  This change supports that move.