### PR TITLE
Touch up status updates

### DIFF
--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -128,14 +128,26 @@ export class MailArchiveGitHelper {
                     const pre = info?.text
                         .replace(/&/g, "&amp;")
                         .replace(/</g, "&lt;").replace(/>/g, "&gt;");
-                    const comment = `There was a [status update](${
-                        whatsCookingBaseURL}${
-                        sousChef.messageID}) in the "${
-                        info?.sectionName}" section about the branch [\`${
-                        branchName}\`](${
-                        branchBaseURL}${
-                        branchName}) on the Git mailing list:\n\n<pre>\n${
-                        pre}\n</pre>`;
+                    let comment;
+                    if (!pre || pre.trim() === "") {
+                        comment = `The branch [\`${
+                            branchName}\`](${
+                            branchBaseURL}${
+                            branchName}) was mentioned in the "${
+                            info?.sectionName
+                            }" section of the [status updates](${
+                            whatsCookingBaseURL}${
+                            sousChef.messageID}) on the Git mailing list.`;
+                    } else {
+                        comment = `There was a [status update](${
+                            whatsCookingBaseURL}${
+                            sousChef.messageID}) in the "${
+                            info?.sectionName}" section about the branch [\`${
+                            branchName}\`](${
+                            branchBaseURL}${
+                            branchName}) on the Git mailing list:\n\n<pre>\n${
+                            pre}\n</pre>`;
+                    }
                     console.log(`\n${pullRequestURL}: ${comment}`);
                     await this.githubGlue
                         .addPRComment(pullRequestURL, comment);

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -124,12 +124,14 @@ export class MailArchiveGitHelper {
                 if (pullRequestURL) {
                     const branchBaseURL
                         = "https://github.com/gitgitgadget/git/commits/";
-                    const pre = sousChef.branches.get(branchName)?.text
+                    const info = sousChef.branches.get(branchName);
+                    const pre = info?.text
                         .replace(/&/g, "&amp;")
                         .replace(/</g, "&lt;").replace(/>/g, "&gt;");
                     const comment = `There was a [status update](${
                         whatsCookingBaseURL}${
-                        sousChef.messageID}) about the branch [\`${
+                        sousChef.messageID}) in the "${
+                        info?.sectionName}" section about the branch [\`${
                         branchName}\`](${
                         branchBaseURL}${
                         branchName}) on the Git mailing list:\n\n<pre>\n${

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -825,8 +825,24 @@ test("handle push/comment too many commits fails", async () => {
         `refs/heads/master:${pullRequestRef}/merge`,
     ]); // fake merge
 
-    const commits = 40;
-
+    const commits: IPRCommit[] = [];
+    for (let i = 0; i < 40; i++) {
+        commits.push({
+            author: {
+                email: "ggg@example.com",
+                login: "ggg",
+                name: "e. e. cummings",
+            },
+            commit: `${i}abc123`,
+            committer: {
+                email: "ggg@example.com",
+                login: "ggg",
+                name: "e. e. cummings",
+            },
+            message: `commit ${i}`,
+            parentCount: 1,
+        });
+    }
     // GitHubGlue Responses
     const comment = {
         author: "ggg",
@@ -846,7 +862,7 @@ test("handle push/comment too many commits fails", async () => {
         baseOwner: "gitgitgadget",
         baseRepo: "git",
         body: "Never seen - too many commits.",
-        commits,
+        commits: commits.length,
         hasComments: false,
         headCommit: commitB,
         headLabel: "somebody:master",
@@ -860,7 +876,7 @@ test("handle push/comment too many commits fails", async () => {
     ci.setGHGetPRComment(comment);
     ci.setGHGetGitHubUserInfo(user);
 
-    const failMsg = `The pull request has ${commits} commits.`;
+    const failMsg = `The pull request has ${commits.length} commits.`;
     // fail for too many commits on push
     await expect(ci.handlePush("gitgitgadget", 433865360)).
         rejects.toThrow(/Failing check due/);
@@ -888,6 +904,7 @@ test("handle push/comment too many commits fails", async () => {
     ci.setGHGetPRInfo(prInfo);
     ci.setGHGetPRComment(comment);
     ci.setGHGetGitHubUserInfo(user);
+    ci.setGHGetPRCommits(commits);
 
     await expect(ci.handlePush("gitgitgadget", 433865360)).
         rejects.toThrow(/Failing check due/);


### PR DESCRIPTION
I noticed that there are a couple status updates that look uglier than necessary. See e.g. https://github.com/gitgitgadget/git/pull/923#issuecomment-816281852.

Let's avoid mentioning an "empty update", and let's include the section name in the status updates.

While at it, mock a method in the `CIHelper` tests that was previously forgotten.