### PR TITLE
GitHubGlue::getGitHubUserInfo check reply status

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -465,13 +465,16 @@ export class GitHubGlue {
             username: login,
         });
 
-
-        return {
-            email: response.data.email,
-            login: response.data.login,
-            name: response.data.name || "",
-            type: response.data.type,
-        };
+        if (response.status === 200 ) {
+            return {
+                email: response.data.email,
+                login: response.data.login,
+                name: response.data.name || "",
+                type: response.data.type,
+            };
+        } else {
+            throw new Error(`GitHub unresponsive for getByUsername`);
+        }
     }
 
     protected async ensureAuthenticated(repositoryOwner: string):


### PR DESCRIPTION
The octokit api was updated to allow a `202` status on the request.  This does not make sense but it causes an eslint error.  This change  adds a response status check so eslint is able to determine the type of `response.data`.  This change may be removed in the future if the 202 status is removed.