### PR TITLE
Point new users to Libera Chat instead of Freenode

### DIFF
--- a/res/WELCOME.md
+++ b/res/WELCOME.md
@@ -21,7 +21,7 @@ Before you can contribute the patches, your GitHub username needs to be added to
 
 Both the person who commented `/allow` and the PR author are able to `/allow` you.
 
-An alternative is the channel [`#git-devel`](https://webchat.freenode.net/#git-devel) on the FreeNode IRC network:
+An alternative is the channel [`#git-devel`](https://web.libera.chat/#git-devel) on the Libera Chat IRC network:
 
     <newcontributor> I've just created my first PR, could someone please /allow me? https://github.com/gitgitgadget/git/pull/12345
     <veteran> newcontributor: it is done
@@ -55,4 +55,4 @@ To send a new iteration, just add another PR comment with the contents: `/submit
 
 New contributors who want advice are encouraged to join [git-mentoring@googlegroups.com](https://groups.google.com/forum/#!forum/git-mentoring), where volunteers who regularly contribute to Git are willing to answer newbie questions, give advice, or otherwise provide mentoring to interested contributors. You must join in order to post or view messages, but anyone can join.
 
-You may also be able to find help in real time in the developer IRC channel, [`#git-devel`](https://webchat.freenode.net/#git-devel) on Freenode. Remember that IRC does not support offline messaging, so if you send someone a private message and log out, they cannot respond to you. The scrollback of `#git-devel` is [archived](https://colabti.org/irclogger//irclogger_logs/git-devel), though.
+You may also be able to find help in real time in the developer IRC channel, [`#git-devel`](https://web.libera.chat/#git-devel) on Libera Chat. Remember that IRC does not support offline messaging, so if you send someone a private message and log out, they cannot respond to you. The scrollback of `#git-devel` is [archived](https://colabti.org/irclogger//irclogger_logs/git-devel), though.


### PR DESCRIPTION
The `#git-devel` channel has been moved to Libera Chat.

[Logs from 2021-05-25](https://colabti.org/irclogger/irclogger_log/git-devel?date=2021-05-25;raw=on):
> [14:52] *** ChanServ changes topic to: Development channel for Git: https://git-scm.com | Questions about using git? Please go to #git | Channel log: https://j.mp/gitdevlog | In the process of moving to libera.chat |  reduce spam, talking in this channel requires a NickServ account.
>
> [14:53] *** ChanServ changes topic to: Channel log: https://j.mp/gitdevlog | In the process of moving to libera.chat | To reduce spam, talking in this channel requires a NickServ account.
>
> [14:55] *** ChanServ changes topic to: Channel log: https://j.mp/gitdevlog | In the process of moving to libera.chat; mind the dust as we move! | To reduce spam, talking in this channel requires a NickServ account.

And from [the next day](https://colabti.org/irclogger/irclogger_log/git-devel?date=2021-05-26;raw=on):

>[02:09] *** ChanServ changes topic to: Moved to libera.chat | Channel log: https://j.mp/gitdevlog. In the process of being turned down on the freenode side.

[...]

> [03:04] *** freenodecom joined
[03:04] *** freenodecom sets mode: +o freenodecom
>
> [03:04] *** freenodecom changes topic to: This channel has moved to ##git-devel. The topic is in violation of freenode policy: https://freenode.net/policies
>
> [03:04] <freenodecom> This channel has been reopened with respect to the communities and new users. The topic is in violation of freenode policy: https://freenode.net/policies
>
> [03:04] *** OperServ sets mode: +o freenodecom
>
> [03:04] *** ChanServ sets mode: +c
>
> [03:04] *** ChanServ sets mode: -b failo!*@*
>
> [03:04] *** freenodecom sets mode: -ov ikke ikke
>
> [03:04] <freenodecom> The new channel is ##git-devel
>
> [03:04] *** freenodecom sets mode: +spimf ##git-devel
>
> [03:04] *** freenodecom sets mode: +f ##git-devel
>
> [03:04] *** freenodecom left