### PR TITLE
ci: auto-approve Dependabot PRs

### DIFF
--- a/.github/workflows/auto-approve-dependabot-prs.yml
+++ b/.github/workflows/auto-approve-dependabot-prs.yml
@@ -1,0 +1,19 @@
+name: Auto-approve Dependabot Pull Requests
+
+on: [pull_request_target]
+
+jobs:
+  auto-approve:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          await github.pulls.createReview({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+            event: "APPROVE",
+          });


### PR DESCRIPTION
We trust Dependabot and therefore it is not _really_ necessary to ask for a thorough review by a human being. Therefore, let's just auto-approve Dependabot's Pull Requests.

Example run demonstrating that this works: https://github.com/dscho/gitgitgadget/pull/211#pullrequestreview-694436263