### PR TITLE
build(deps): bump @octokit/rest from 18.6.0 to 18.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "ISC",
       "dependencies": {
         "@octokit/auth-app": "^3.5.2",
-        "@octokit/rest": "^18.6.0",
+        "@octokit/rest": "^18.6.6",
         "commander": "^8.0.0",
         "dugite": "^1.103.0",
         "html-to-text": "^8.0.0",
@@ -1437,9 +1437,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.2.tgz",
-      "integrity": "sha512-oJhK/yhl9Gt430OrZOzAl2wJqR0No9445vmZ9Ey8GjUZUpwuu/vmEFP0TDhDXdpGDoxD6/EIFHJEcY8nHXpDTA=="
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.2.0.tgz",
+      "integrity": "sha512-113BfIPwDYBAUA5bDSd4q/DzRDSZlUanupjLHeRAtb3Sw99XJwiP8KHGsGoOwPtzUaszVscf3wbfaA3VCR3uHA=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "2.13.5",
@@ -1461,11 +1461,11 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.1.tgz",
-      "integrity": "sha512-3B2iguGmkh6bQQaVOtCsS0gixrz8Lg0v4JuXPqBcFqLKuJtxAUf3K88RxMEf/naDOI73spD+goJ/o7Ie7Cvdjg==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.7.tgz",
+      "integrity": "sha512-LAgTLOsJ86ig2wYSpcSx+UWt7aQYYsEZ/Tf/pksAVQWKNcGuTVCDl9OUiPhQ7DZelNozYVWTO9Iyjd/soe4tug==",
       "dependencies": {
-        "@octokit/types": "^6.16.2",
+        "@octokit/types": "^6.17.4",
         "deprecation": "^2.3.1"
       },
       "peerDependencies": {
@@ -1496,22 +1496,22 @@
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "18.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.6.0.tgz",
-      "integrity": "sha512-MdHuXHDJM7e5sUBe3K9tt7th0cs4csKU5Bb52LRi2oHAeIMrMZ4XqaTrEv660HoUPoM1iDlnj27Ab/Nh3MtwlA==",
+      "version": "18.6.6",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.6.6.tgz",
+      "integrity": "sha512-kCLvz8MSh+KToXySdqUp80caBom1ZQmsX3gbT3osfbJy6fD86QObUjzAOD3D3Awz3X7ng24+lB+imvSr5EnM7g==",
       "dependencies": {
         "@octokit/core": "^3.5.0",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.3.1"
+        "@octokit/plugin-rest-endpoint-methods": "5.3.7"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.16.4",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.4.tgz",
-      "integrity": "sha512-UxhWCdSzloULfUyamfOg4dJxV9B+XjgrIZscI0VCbp4eNrjmorGEw+4qdwcpTsu6DIrm9tQsFQS2pK5QkqQ04A==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.18.0.tgz",
+      "integrity": "sha512-H2xk9vlPWrG1oRzWkOCI/lcYUzskmnrF+suUKaCz+XylmmjyZWl0l+RIuuWX8EGW+uX15kBTRNKE/jpSmPA0IA==",
       "dependencies": {
-        "@octokit/openapi-types": "^7.3.2"
+        "@octokit/openapi-types": "^8.2.0"
       }
     },
     "node_modules/@selderee/plugin-htmlparser2": {
@@ -9642,9 +9642,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.2.tgz",
-      "integrity": "sha512-oJhK/yhl9Gt430OrZOzAl2wJqR0No9445vmZ9Ey8GjUZUpwuu/vmEFP0TDhDXdpGDoxD6/EIFHJEcY8nHXpDTA=="
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.2.0.tgz",
+      "integrity": "sha512-113BfIPwDYBAUA5bDSd4q/DzRDSZlUanupjLHeRAtb3Sw99XJwiP8KHGsGoOwPtzUaszVscf3wbfaA3VCR3uHA=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.13.5",
@@ -9661,11 +9661,11 @@
       "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.1.tgz",
-      "integrity": "sha512-3B2iguGmkh6bQQaVOtCsS0gixrz8Lg0v4JuXPqBcFqLKuJtxAUf3K88RxMEf/naDOI73spD+goJ/o7Ie7Cvdjg==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.7.tgz",
+      "integrity": "sha512-LAgTLOsJ86ig2wYSpcSx+UWt7aQYYsEZ/Tf/pksAVQWKNcGuTVCDl9OUiPhQ7DZelNozYVWTO9Iyjd/soe4tug==",
       "requires": {
-        "@octokit/types": "^6.16.2",
+        "@octokit/types": "^6.17.4",
         "deprecation": "^2.3.1"
       }
     },
@@ -9693,22 +9693,22 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.6.0.tgz",
-      "integrity": "sha512-MdHuXHDJM7e5sUBe3K9tt7th0cs4csKU5Bb52LRi2oHAeIMrMZ4XqaTrEv660HoUPoM1iDlnj27Ab/Nh3MtwlA==",
+      "version": "18.6.6",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.6.6.tgz",
+      "integrity": "sha512-kCLvz8MSh+KToXySdqUp80caBom1ZQmsX3gbT3osfbJy6fD86QObUjzAOD3D3Awz3X7ng24+lB+imvSr5EnM7g==",
       "requires": {
         "@octokit/core": "^3.5.0",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.3.1"
+        "@octokit/plugin-rest-endpoint-methods": "5.3.7"
       }
     },
     "@octokit/types": {
-      "version": "6.16.4",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.4.tgz",
-      "integrity": "sha512-UxhWCdSzloULfUyamfOg4dJxV9B+XjgrIZscI0VCbp4eNrjmorGEw+4qdwcpTsu6DIrm9tQsFQS2pK5QkqQ04A==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.18.0.tgz",
+      "integrity": "sha512-H2xk9vlPWrG1oRzWkOCI/lcYUzskmnrF+suUKaCz+XylmmjyZWl0l+RIuuWX8EGW+uX15kBTRNKE/jpSmPA0IA==",
       "requires": {
-        "@octokit/openapi-types": "^7.3.2"
+        "@octokit/openapi-types": "^8.2.0"
       }
     },
     "@selderee/plugin-htmlparser2": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@octokit/auth-app": "^3.5.2",
-    "@octokit/rest": "^18.6.0",
+    "@octokit/rest": "^18.6.6",
     "commander": "^8.0.0",
     "dugite": "^1.103.0",
     "html-to-text": "^8.0.0",

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -200,7 +200,7 @@ test("pull requests", async () => {
 
         const commitComment = "comment about commit";
         const reviewResult = await github
-            .addPRCommitComment(prData.html_url, cFile.data.commit.sha,
+            .addPRCommitComment(prData.html_url, cFile.data.commit.sha || '',
                                 repoDir, commitComment);
 
         const commentReply =


### PR DESCRIPTION
`cFile.data.commit.sha` can be undefined.  Not sure why it is now being detected as a problem. Adding code to basically ignore missing value for the test.
