### PR TITLE
Do not prevent the built-in FSMonitor patch series from being sent

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -32,6 +32,7 @@ export class CIHelper {
     protected testing: boolean;
     private gggNotesUpdated: boolean;
     private mail2CommitMapUpdated: boolean;
+    protected maxCommitsExceptions = new Set();
 
     public constructor(workDir?: string, skipUpdate?: boolean,
                        gggConfigDir = ".") {
@@ -698,7 +699,8 @@ export class CIHelper {
         Promise<boolean> {
         let result = true;
         const maxCommits = 30;
-        if (pr.commits && pr.commits > maxCommits) {
+        if (!this.maxCommitsExceptions.has(pr.pullRequestURL) &&
+            pr.commits && pr.commits > maxCommits) {
             await addComment(`The pull request has ${pr.commits
                              } commits.  The max allowed is ${maxCommits
                              }.  Please split the patch series into ${

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -32,7 +32,9 @@ export class CIHelper {
     protected testing: boolean;
     private gggNotesUpdated: boolean;
     private mail2CommitMapUpdated: boolean;
-    protected maxCommitsExceptions = new Set();
+    protected maxCommitsExceptions = new Set([
+        "https://github.com/gitgitgadget/git/pull/923"
+    ]);
 
     public constructor(workDir?: string, skipUpdate?: boolean,
                        gggConfigDir = ".") {

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -95,6 +95,14 @@ class TestCIHelper extends CIHelper {
             // eslint-disable-next-line @typescript-eslint/require-await
             Promise<IGitHubUser> => o );
     }
+
+    public addMaxCommitsException(pullRequestURL: string): void {
+        this.maxCommitsExceptions.add(pullRequestURL);
+    }
+
+    public removeMaxCommitsException(pullRequestURL: string): void {
+        this.maxCommitsExceptions.delete(pullRequestURL);
+    }
 }
 
 // Create three repos.
@@ -887,6 +895,14 @@ test("handle push/comment too many commits fails", async () => {
     // fail for too many commits on submit
     await ci.handleComment("gitgitgadget", 433865360);
     expect(ci.addPRCommentCalls[0][1]).toMatch(failMsg);
+    ci.addPRCommentCalls.length = 0;
+
+    ci.addMaxCommitsException(prInfo.pullRequestURL);
+    await ci.handleComment("gitgitgadget", 433865360);
+    // There will still be a comment, but about upper-case after prefix
+    expect(ci.addPRCommentCalls).toHaveLength(1);
+    expect(ci.addPRCommentCalls[0][1]).not.toMatch(failMsg);
+    ci.removeMaxCommitsException(prInfo.pullRequestURL);
     ci.addPRCommentCalls.length = 0;
 
     // fail for too many commits on preview


### PR DESCRIPTION
Currently, https://github.com/gitgitgadget/git/pull/923 is blocked because it has more commits than the (hard-coded) limit. Let's lift this limit for this PR specifically, and set an example how the same can be done in the future for other PRs.