### PR TITLE
Update commander usage for new version

### DIFF
--- a/script/delete-test-branches.ts
+++ b/script/delete-test-branches.ts
@@ -1,5 +1,5 @@
 import { Octokit } from "@octokit/rest";
-import commander = require("commander");
+import { Command } from "commander";
 import { deleteBranches,
     deletionOptions } from "../lib/delete-ci-test-branches";
 import { GitHubGlue } from "../lib/github-glue";
@@ -27,6 +27,8 @@ class GitHubProxy extends GitHubGlue {
         this.octo = this.client;
     }
 }
+
+const commander = new Command();
 
 commander.version("1.0.0")
     .usage("[options]")

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -1,12 +1,14 @@
 import { createAppAuth } from "@octokit/auth-app";
 import { Octokit } from "@octokit/rest";
-import commander = require("commander");
+import { Command } from "commander";
 import { CIHelper } from "../lib/ci-helper";
 import { isDirectory } from "../lib/fs-util";
 import { git, gitConfig } from "../lib/git";
 import { GitHubGlue } from "../lib/github-glue";
 import { toPrettyJSON } from "../lib/json-util";
 import { IPatchSeriesMetadata } from "../lib/patch-series-metadata";
+
+const commander = new Command();
 
 commander.version("1.0.0")
     .usage("[options] ( update-open-prs | lookup-upstream-commit | "


### PR DESCRIPTION
Use typescript typings and `new` object.  The global `commander` is deprecated and removed in v8.0.0.

This can be implemented before and will correct #611 build failure.
