### PR TITLE
CIHelper::identifyMergeCommit - update refs

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -457,6 +457,8 @@ export class CIHelper {
     public async identifyMergeCommit(upstreamBranch: string,
                                      integratedCommit: string):
         Promise<string | undefined> {
+        await this.maybeUpdateMail2CommitMap();
+
         const revs =
             await git(["rev-list", "--ancestry-path", "--parents",
                        `${integratedCommit}..upstream/${upstreamBranch}`],

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -271,7 +271,7 @@ test("identify merge that integrated some commit", async () => {
     const commitD = await repo.merge("d", commitF);
     await repo.git(["update-ref", "refs/remotes/upstream/seen", commitD]);
 
-    const ci = new CIHelper(repo.workDir);
+    const ci = new CIHelper(repo.workDir, true);
     expect(commitB).not.toBeUndefined();
     expect(await ci.identifyMergeCommit("seen", commitG)).toEqual(commitD);
     expect(await ci.identifyMergeCommit("seen", commitE)).toEqual(commitC);


### PR DESCRIPTION
The method can be called directly so it needs to update the refs.

Running the command 
```
ts-node script/misc-helper.ts identify-merge-commit maint 4589bca829a2ace58bc98876cccd7dbd2e89f732 -g ..\some_new_git_repo
```

where `some_new_git_repo` does not exist or is an outdated github fork will fail with errors like:

```
Caught error Error: git rev-list --ancestry-path --parents 4589bca829a2ace58bc98876cccd7dbd2e89f732..upstream/maint failed: 128,
fatal: ambiguous argument '4589bca829a2ace58bc98876cccd7dbd2e89f732..upstream/maint': unknown revision or path not in the working tree.
```

The error can happen with an outdated github repo but will always happen when a new repo is specified on the command line (a clone is done).

The fix is the simplest fix.  Alternatives are to make `CIHelper::maybeUpdateMail2CommitMap` public or to provide a wrapper function to do the update before calling identifyMergeCommit.