### PR TITLE
Add Types to Commander Options

### DIFF
--- a/lib/delete-ci-test-branches.ts
+++ b/lib/delete-ci-test-branches.ts
@@ -60,19 +60,22 @@ export type deletionOptions = {
  * @param options deletionOptions to override default of two days
  */
 export async function deleteBranches( octocat: Octokit, owner: string,
-    repo: string, options?: deletionOptions): Promise<void> {
+    repo: string, options: deletionOptions = {}): Promise<void> {
 
     if (!owner || !repo) {
         throw new Error("Missing owner or repo name.");
     }
 
     const expires = new Date();
-    const userOptions = options || { hours: 48 };
 
-    if (userOptions.hours) {
-        expires.setUTCHours(0 - userOptions.hours, 0 ,0);
-    } else if (userOptions.minutes) {
-        expires.setUTCMinutes(expires.getUTCMinutes() - userOptions.minutes);
+    if (!options.hours && !options.minutes) {
+        options.hours = 48;
+    }
+
+    if (options.hours) {
+        expires.setUTCHours(0 - options.hours, 0 ,0);
+    } else if (options.minutes) {
+        expires.setUTCMinutes(expires.getUTCMinutes() - options.minutes);
     } else {
         throw new Error("Invalid options passed.");
     }
@@ -122,7 +125,7 @@ export async function deleteBranches( octocat: Octokit, owner: string,
                 const mutate = `mutation DeleteBranch {
                     deleteRef(input:{refId: "${br.id}"}) {
                     clientMutationId }}`;
-                if (!userOptions.dryRun) {
+                if (!options.dryRun) {
                     return octocat.graphql(mutate);
                 } else {
                     console.log(`Deletion of refId: "${br.id}" skipped`);

--- a/script/delete-test-branches.ts
+++ b/script/delete-test-branches.ts
@@ -48,21 +48,29 @@ before last midnight`,
             "do not delete the refs (useful for debugging)")
     .parse(process.argv);
 
+interface commanderOptions {
+    dryRun: boolean | undefined;
+    hours: number | undefined;
+    minutes: number | undefined;
+    owner: string;
+    repo: string;
+}
+
 if (commander.args.length > 0) {
     commander.help();
 }
 
 (async (): Promise<void> => {
     const options: deletionOptions = {};
-    const commandOptions = commander.opts();
+    const commandOptions = commander.opts<commanderOptions>();
     if (commandOptions.dryRun) {
         options.dryRun = true;
     }
 
     if (commandOptions.hours) {
-        options.hours = commandOptions.hours as number;
+        options.hours = commandOptions.hours;
     } else if (commandOptions.minutes) {
-        options.minutes = commandOptions.minutes as number;
+        options.minutes = commandOptions.minutes;
     }
 
     const github = new GitHubProxy(/* repoDir */);

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -27,11 +27,17 @@ commander.version("1.0.0")
             "Do not update the local refs (useful for debugging)")
     .parse(process.argv);
 
+interface commanderOptions {
+    gitgitgadgetWorkDir: string | undefined;
+    gitWorkDir: string | undefined;
+    skipUpdate: boolean | undefined;
+}
+
 if (commander.args.length === 0) {
     commander.help();
 }
 
-const commandOptions = commander.opts();
+const commandOptions = commander.opts<commanderOptions>();
 
 async function getGitGitWorkDir(): Promise<string> {
     if (!commandOptions.gitWorkDir) {
@@ -49,7 +55,7 @@ async function getGitGitWorkDir(): Promise<string> {
             commandOptions.gitWorkDir,
         ]);
     }
-    return commandOptions.gitWorkDir as string;
+    return commandOptions.gitWorkDir;
 }
 
 async function getCIHelper(): Promise<CIHelper> {


### PR DESCRIPTION
Make the types known before upcoming linter changes start flagging them.

Also, correct `delete-ci-test-branches.ts` to properly set a default timeout if none is specified with `--dry-run` present.
