### PR TITLE
markdown-renderer update to html-to-text v8

### DIFF
--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -5,57 +5,74 @@ import marked from "marked";
 
 export function md2text(markdown: string, columns = 76): string {
 
-    const headerOptions =  {
-                options: {
-                    uppercase: false
-                },
-                format: "headerFormatter",
-            };
-
     let quoteDepth = 0;
     const formatOptions: HtmlToTextOptions = {
         wordwrap: columns,
         formatters: {
             headerFormatter: (elem, walk, builder, options) => {
-                builder.openBlock(options.leadingLineBreaks || 2);
+                builder.openBlock({
+                    leadingLineBreaks: options.leadingLineBreaks || 2});
                 walk(elem.children, builder);
-                builder.closeBlock(options.trailingLineBreaks || 2,
-                    str => {
+                builder.closeBlock({
+                    trailingLineBreaks: options.trailingLineBreaks || 2,
+                    blockTransform: str => {
                         const underline = str.substr(str.lastIndexOf("\n") + 1)
                             .replace(/./g, "=");
                         return `${str}\n${underline}`;
-                    });
+                    }});
             },
             blockFormatter: (elem, walk, builder, options) => {
-                builder.openBlock(options.leadingLineBreaks || 2,
-                    quoteDepth? 1 : 2);
+                builder.openBlock({
+                    leadingLineBreaks: options.leadingLineBreaks || 2,
+                    reservedLineLength: quoteDepth? 1 : 2});
                 quoteDepth++;
                 walk(elem.children, builder);
                 quoteDepth--;
-                builder.closeBlock(options.trailingLineBreaks || 2,
-                    str => { return str
+                builder.closeBlock({ trailingLineBreaks:
+                    options.trailingLineBreaks || 2,
+                    blockTransform: str => { return str
                         .replace(/^>/mg, ">>") // add to quote
                         .replace(/^(?!>|$)/mg, "> ")   // new quote
                         .replace(/(^|\n)(\n)(?!$)/g, "$1>$2") // quote empty
-                    });
+                    }});
             },
         },
-        tags: {
-            a: {
+        selectors: [
+            {
+                selector: "a",
                 options: {
                     hideLinkHrefIfSameAsText: true,
                 },
             },
-            h1: headerOptions,
-            h2: headerOptions,
-            h3: headerOptions,
-            blockquote: {
+            {
+                selector: "h1",
+                options: {
+                    uppercase: false
+                },
+                format: "headerFormatter",
+            },
+            {
+                selector: "h2",
+                options: {
+                    uppercase: false
+                },
+                format: "headerFormatter",
+            },
+            {
+                selector: "h3",
+                options: {
+                    uppercase: false
+                },
+                format: "headerFormatter",
+            },
+            {
+                selector: "blockquote",
                 options: {
                     trimEmptyLines: false
                 },
-                format: "blockFormatter",
+                format: "blockFormatter"
             },
-        },
+        ],
     };
 
     return htmlToText(marked(markdown), formatOptions);


### PR DESCRIPTION
Change to use the new API.  A number of things have been deprecated.

The big change was to use selectors instead of tags.