### PR TITLE
test: use internal SMTP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "commander": "^8.3.0",
         "dugite": "^1.104.0",
         "html-to-text": "^8.1.0",
-        "imap-simple": "^5.1.0",
         "json-stable-stringify": "^1.0.1",
         "jsonwebtoken": "^8.5.1",
         "libqp": "^1.1.0",
@@ -39,6 +38,7 @@
         "eslint-plugin-jsdoc": "^37.0.3",
         "jest": "^27.3.1",
         "jest-junit": "^13.0.0",
+        "test-smtp-server": "0.9.1",
         "ts-jest": "^27.0.7",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4"
@@ -1523,10 +1523,32 @@
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
       "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
+    "node_modules/@types/mailparser": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/mailparser/-/mailparser-3.4.0.tgz",
+      "integrity": "sha512-MotFinA1sT2nPFtQw1WpaF3X6I1OdbEloaixMmk924BOYqwHmlZkoi7XcVUXHI+7i0to8JguHqYj5k/E6c9Chw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "iconv-lite": "^0.6.3"
+      }
+    },
+    "node_modules/@types/mailparser/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@types/marked": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-3.0.2.tgz",
-      "integrity": "sha512-mGYI9qFs+i5eYaytWKBbtEMbIkrXGKuhsDpDcj70ogKS2gk1NmgEy9Z3VEKz922Lfms6eITXXqv5idlX7C/irw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-3.0.3.tgz",
+      "integrity": "sha512-ZgAr847Wl68W+B0sWH7F4fDPxTzerLnRuUXjUpp1n4NjGSs8hgPAjAp7NQIXblG34MXTrf5wWkAK8PVJ2LIlVg==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2215,6 +2237,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
@@ -2529,11 +2560,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -2846,6 +2872,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/encoding-japanese": {
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-1.0.30.tgz",
+      "integrity": "sha512-bd/DFLAoJetvv7ar/KIpE3CNO8wEuyrt9Xuw6nSMiZ+Vrz/Q21BPsMHvARL2Wz6IKHKXgb+DWZqtRg1vql9cBg==",
       "dev": true
     },
     "node_modules/end-of-stream": {
@@ -3526,20 +3558,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3821,6 +3839,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -3835,34 +3854,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/imap": {
-      "version": "0.8.19",
-      "resolved": "https://registry.npmjs.org/imap/-/imap-0.8.19.tgz",
-      "integrity": "sha1-NniHOTSrCc6mukh0HyhNoq9Z2NU=",
-      "dependencies": {
-        "readable-stream": "1.1.x",
-        "utf7": ">=1.0.2"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/imap-simple": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/imap-simple/-/imap-simple-5.1.0.tgz",
-      "integrity": "sha512-FLZm1v38C5ekN46l/9X5gBRNMQNVc5TSLYQ3Hsq3xBLvKwt1i5fcuShyth8MYMPuvId1R46oaPNrH92hFGHr/g==",
-      "dependencies": {
-        "iconv-lite": "~0.4.13",
-        "imap": "^0.8.18",
-        "nodeify": "^1.0.0",
-        "quoted-printable": "^1.0.0",
-        "utf8": "^2.1.1",
-        "uuencode": "0.0.4"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/import-fresh": {
@@ -3919,6 +3910,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ipv6-normalize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ipv6-normalize/-/ipv6-normalize-1.0.1.tgz",
+      "integrity": "sha1-GzJYKQ02X6gyOeiZB93kWS52IKg=",
+      "dev": true
     },
     "node_modules/is-core-module": {
       "version": "2.8.0",
@@ -3994,11 +3991,6 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
-    "node_modules/is-promise": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
-      "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU="
-    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4016,11 +4008,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4992,10 +4979,49 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libbase64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.2.1.tgz",
+      "integrity": "sha512-l+nePcPbIG1fNlqMzrh68MLkX/gTxk/+vdvAb388Ssi7UuUN31MI44w4Yf33mM3Cm4xDfw48mdf3rkdHszLNew==",
+      "dev": true
+    },
+    "node_modules/libmime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.0.0.tgz",
+      "integrity": "sha512-2Bm96d5ktnE217Ib1FldvUaPAaOst6GtZrsxJCwnJgi9lnsoAKIHyU0sae8rNx6DNYbjdqqh8lv5/b9poD8qOg==",
+      "dev": true,
+      "dependencies": {
+        "encoding-japanese": "1.0.30",
+        "iconv-lite": "0.6.2",
+        "libbase64": "1.2.1",
+        "libqp": "1.1.0"
+      }
+    },
+    "node_modules/libmime/node_modules/iconv-lite": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/libqp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
+    },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5079,6 +5105,66 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mailparser": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.4.0.tgz",
+      "integrity": "sha512-u2pfpLg+xr7m2FKDl+ohQhy2gMok1QZ+S9E5umS9ez5DSJWttrqSmBGswyj9F68pZMVTwbhLpBt7Kd04q/W4Vw==",
+      "dev": true,
+      "dependencies": {
+        "encoding-japanese": "1.0.30",
+        "he": "1.2.0",
+        "html-to-text": "8.0.0",
+        "iconv-lite": "0.6.3",
+        "libmime": "5.0.0",
+        "linkify-it": "3.0.3",
+        "mailsplit": "5.3.1",
+        "nodemailer": "6.7.0",
+        "tlds": "1.224.0"
+      }
+    },
+    "node_modules/mailparser/node_modules/html-to-text": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.0.0.tgz",
+      "integrity": "sha512-fEtul1OerF2aMEV+Wpy+Ue20tug134jOY1GIudtdqZi7D0uTudB2tVJBKfVhTL03dtqeJoF8gk8EPX9SyMEvLg==",
+      "dev": true,
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.6.0",
+        "deepmerge": "^4.2.2",
+        "he": "^1.2.0",
+        "htmlparser2": "^6.1.0",
+        "minimist": "^1.2.5",
+        "selderee": "^0.6.0"
+      },
+      "bin": {
+        "html-to-text": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.23.2"
+      }
+    },
+    "node_modules/mailparser/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mailsplit": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/mailsplit/-/mailsplit-5.3.1.tgz",
+      "integrity": "sha512-o6R6HCzqWYmI2/IYlB+v2IMPgYqC2EynmagZQICAhR7zAq0CO6fPcsO6CrYmVuYT+SSwvLAEZR5WniohBELcAA==",
+      "dev": true,
+      "dependencies": {
+        "libbase64": "1.2.1",
+        "libmime": "5.0.0",
+        "libqp": "1.1.0"
       }
     },
     "node_modules/make-dir": {
@@ -5316,15 +5402,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
       "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
       "dev": true
-    },
-    "node_modules/nodeify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
-      "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
-      "dependencies": {
-        "is-promise": "~1.0.0",
-        "promise": "~1.3.0"
-      }
     },
     "node_modules/nodemailer": {
       "version": "6.7.0",
@@ -5620,14 +5697,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
-      "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
-      "dependencies": {
-        "is-promise": "~1"
-      }
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5685,17 +5754,6 @@
         }
       ]
     },
-    "node_modules/quoted-printable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/quoted-printable/-/quoted-printable-1.0.1.tgz",
-      "integrity": "sha1-nuv16z0R7vAismT9LStrK7O4TMM=",
-      "dependencies": {
-        "utf8": "^2.1.0"
-      },
-      "bin": {
-        "quoted-printable": "bin/quoted-printable"
-      }
-    },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
@@ -5718,17 +5776,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -5896,7 +5943,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -5978,6 +6026,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/smtp-server": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/smtp-server/-/smtp-server-3.9.0.tgz",
+      "integrity": "sha512-CHws5GkHjfIikue6vSdp3uRnmW85l0JJQibVwDs7S5aIUppXJA9Y60XcdxcaCLXmAnd8V8wbtav5KY92nCZeag==",
+      "dev": true,
+      "dependencies": {
+        "base32.js": "0.1.0",
+        "ipv6-normalize": "1.0.1",
+        "nodemailer": "6.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/smtp-server/node_modules/nodemailer": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.1.tgz",
+      "integrity": "sha512-1xzFN3gqv+/qJ6YRyxBxfTYstLNt0FCtZaFRvf4Sg9wxNGWbwFmGXVpfSi6ThGK6aRxAo+KjHtYSW8NvCsNSAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6045,11 +6116,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -6222,6 +6288,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-smtp-server": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/test-smtp-server/-/test-smtp-server-0.9.1.tgz",
+      "integrity": "sha512-iSO+80dBOhxumHZQ5Ty6kJ8f4rmvs80MVRltSOWtfxLos4rcV3Ef9zjrPcDDNggZ76YyABLgawVbSvQiwwe3ig==",
+      "dev": true,
+      "dependencies": {
+        "@types/mailparser": "^3.4.0",
+        "mailparser": "^3.4.0",
+        "smtp-server": "^3.9.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -6233,6 +6313,15 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "node_modules/tlds": {
+      "version": "1.224.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.224.0.tgz",
+      "integrity": "sha512-Jgdc8SEijbDFUsmCn6Wk/f7E6jBLFZOG3U1xK0amGSfEH55Xx97ItUS/d2NngsuApjn11UeWCWj8Um3VRhseZQ==",
+      "dev": true,
+      "bin": {
+        "tlds": "bin.js"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -6473,6 +6562,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
     "node_modules/universal-github-app-jwt": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz",
@@ -6515,32 +6610,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/utf7": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utf7/-/utf7-1.0.2.tgz",
-      "integrity": "sha1-lV9JCq5lO6IguUVqCod2wZk2CZE=",
-      "dependencies": {
-        "semver": "~5.3.0"
-      }
-    },
-    "node_modules/utf7/node_modules/semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/utf8": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
-    },
-    "node_modules/uuencode": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/uuencode/-/uuencode-0.0.4.tgz",
-      "integrity": "sha1-yNUDcIhWY4eThas34zPH6OOwIYw="
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -8025,10 +8094,31 @@
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
       "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
+    "@types/mailparser": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/mailparser/-/mailparser-3.4.0.tgz",
+      "integrity": "sha512-MotFinA1sT2nPFtQw1WpaF3X6I1OdbEloaixMmk924BOYqwHmlZkoi7XcVUXHI+7i0to8JguHqYj5k/E6c9Chw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "iconv-lite": "^0.6.3"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "@types/marked": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-3.0.2.tgz",
-      "integrity": "sha512-mGYI9qFs+i5eYaytWKBbtEMbIkrXGKuhsDpDcj70ogKS2gk1NmgEy9Z3VEKz922Lfms6eITXXqv5idlX7C/irw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-3.0.3.tgz",
+      "integrity": "sha512-ZgAr847Wl68W+B0sWH7F4fDPxTzerLnRuUXjUpp1n4NjGSs8hgPAjAp7NQIXblG34MXTrf5wWkAK8PVJ2LIlVg==",
       "dev": true
     },
     "@types/node": {
@@ -8494,6 +8584,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=",
+      "dev": true
+    },
     "before-after-hook": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
@@ -8744,11 +8840,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -8989,6 +9080,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "encoding-japanese": {
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-1.0.30.tgz",
+      "integrity": "sha512-bd/DFLAoJetvv7ar/KIpE3CNO8wEuyrt9Xuw6nSMiZ+Vrz/Q21BPsMHvARL2Wz6IKHKXgb+DWZqtRg1vql9cBg==",
       "dev": true
     },
     "end-of-stream": {
@@ -9496,13 +9593,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -9713,6 +9803,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -9722,28 +9813,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
-    },
-    "imap": {
-      "version": "0.8.19",
-      "resolved": "https://registry.npmjs.org/imap/-/imap-0.8.19.tgz",
-      "integrity": "sha1-NniHOTSrCc6mukh0HyhNoq9Z2NU=",
-      "requires": {
-        "readable-stream": "1.1.x",
-        "utf7": ">=1.0.2"
-      }
-    },
-    "imap-simple": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/imap-simple/-/imap-simple-5.1.0.tgz",
-      "integrity": "sha512-FLZm1v38C5ekN46l/9X5gBRNMQNVc5TSLYQ3Hsq3xBLvKwt1i5fcuShyth8MYMPuvId1R46oaPNrH92hFGHr/g==",
-      "requires": {
-        "iconv-lite": "~0.4.13",
-        "imap": "^0.8.18",
-        "nodeify": "^1.0.0",
-        "quoted-printable": "^1.0.0",
-        "utf8": "^2.1.1",
-        "uuencode": "0.0.4"
-      }
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -9784,6 +9853,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ipv6-normalize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ipv6-normalize/-/ipv6-normalize-1.0.1.tgz",
+      "integrity": "sha1-GzJYKQ02X6gyOeiZB93kWS52IKg=",
+      "dev": true
     },
     "is-core-module": {
       "version": "2.8.0",
@@ -9838,11 +9913,6 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
-    "is-promise": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
-      "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU="
-    },
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -9854,11 +9924,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -10622,10 +10687,48 @@
         "type-check": "~0.4.0"
       }
     },
+    "libbase64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.2.1.tgz",
+      "integrity": "sha512-l+nePcPbIG1fNlqMzrh68MLkX/gTxk/+vdvAb388Ssi7UuUN31MI44w4Yf33mM3Cm4xDfw48mdf3rkdHszLNew==",
+      "dev": true
+    },
+    "libmime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.0.0.tgz",
+      "integrity": "sha512-2Bm96d5ktnE217Ib1FldvUaPAaOst6GtZrsxJCwnJgi9lnsoAKIHyU0sae8rNx6DNYbjdqqh8lv5/b9poD8qOg==",
+      "dev": true,
+      "requires": {
+        "encoding-japanese": "1.0.30",
+        "iconv-lite": "0.6.2",
+        "libbase64": "1.2.1",
+        "libqp": "1.1.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "libqp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
+    },
+    "linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
     },
     "locate-path": {
       "version": "5.0.0",
@@ -10700,6 +10803,59 @@
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "mailparser": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.4.0.tgz",
+      "integrity": "sha512-u2pfpLg+xr7m2FKDl+ohQhy2gMok1QZ+S9E5umS9ez5DSJWttrqSmBGswyj9F68pZMVTwbhLpBt7Kd04q/W4Vw==",
+      "dev": true,
+      "requires": {
+        "encoding-japanese": "1.0.30",
+        "he": "1.2.0",
+        "html-to-text": "8.0.0",
+        "iconv-lite": "0.6.3",
+        "libmime": "5.0.0",
+        "linkify-it": "3.0.3",
+        "mailsplit": "5.3.1",
+        "nodemailer": "6.7.0",
+        "tlds": "1.224.0"
+      },
+      "dependencies": {
+        "html-to-text": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.0.0.tgz",
+          "integrity": "sha512-fEtul1OerF2aMEV+Wpy+Ue20tug134jOY1GIudtdqZi7D0uTudB2tVJBKfVhTL03dtqeJoF8gk8EPX9SyMEvLg==",
+          "dev": true,
+          "requires": {
+            "@selderee/plugin-htmlparser2": "^0.6.0",
+            "deepmerge": "^4.2.2",
+            "he": "^1.2.0",
+            "htmlparser2": "^6.1.0",
+            "minimist": "^1.2.5",
+            "selderee": "^0.6.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
+    "mailsplit": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/mailsplit/-/mailsplit-5.3.1.tgz",
+      "integrity": "sha512-o6R6HCzqWYmI2/IYlB+v2IMPgYqC2EynmagZQICAhR7zAq0CO6fPcsO6CrYmVuYT+SSwvLAEZR5WniohBELcAA==",
+      "dev": true,
+      "requires": {
+        "libbase64": "1.2.1",
+        "libmime": "5.0.0",
+        "libqp": "1.1.0"
       }
     },
     "make-dir": {
@@ -10888,15 +11044,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
       "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
       "dev": true
-    },
-    "nodeify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
-      "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
-      "requires": {
-        "is-promise": "~1.0.0",
-        "promise": "~1.3.0"
-      }
     },
     "nodemailer": {
       "version": "6.7.0",
@@ -11110,14 +11257,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
-    "promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
-      "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
-      "requires": {
-        "is-promise": "~1"
-      }
-    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -11155,14 +11294,6 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "quoted-printable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/quoted-printable/-/quoted-printable-1.0.1.tgz",
-      "integrity": "sha1-nuv16z0R7vAismT9LStrK7O4TMM=",
-      "requires": {
-        "utf8": "^2.1.0"
-      }
-    },
     "railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
@@ -11182,17 +11313,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
     },
     "regexpp": {
       "version": "3.2.0",
@@ -11310,7 +11430,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "saxes": {
       "version": "5.0.1",
@@ -11370,6 +11491,25 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "smtp-server": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/smtp-server/-/smtp-server-3.9.0.tgz",
+      "integrity": "sha512-CHws5GkHjfIikue6vSdp3uRnmW85l0JJQibVwDs7S5aIUppXJA9Y60XcdxcaCLXmAnd8V8wbtav5KY92nCZeag==",
+      "dev": true,
+      "requires": {
+        "base32.js": "0.1.0",
+        "ipv6-normalize": "1.0.1",
+        "nodemailer": "6.6.1"
+      },
+      "dependencies": {
+        "nodemailer": {
+          "version": "6.6.1",
+          "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.1.tgz",
+          "integrity": "sha512-1xzFN3gqv+/qJ6YRyxBxfTYstLNt0FCtZaFRvf4Sg9wxNGWbwFmGXVpfSi6ThGK6aRxAo+KjHtYSW8NvCsNSAg==",
+          "dev": true
+        }
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -11431,11 +11571,6 @@
           "dev": true
         }
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "string-length": {
       "version": "4.0.2",
@@ -11557,6 +11692,17 @@
         "minimatch": "^3.0.4"
       }
     },
+    "test-smtp-server": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/test-smtp-server/-/test-smtp-server-0.9.1.tgz",
+      "integrity": "sha512-iSO+80dBOhxumHZQ5Ty6kJ8f4rmvs80MVRltSOWtfxLos4rcV3Ef9zjrPcDDNggZ76YyABLgawVbSvQiwwe3ig==",
+      "dev": true,
+      "requires": {
+        "@types/mailparser": "^3.4.0",
+        "mailparser": "^3.4.0",
+        "smtp-server": "^3.9.0"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -11567,6 +11713,12 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
+      "dev": true
+    },
+    "tlds": {
+      "version": "1.224.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.224.0.tgz",
+      "integrity": "sha512-Jgdc8SEijbDFUsmCn6Wk/f7E6jBLFZOG3U1xK0amGSfEH55Xx97ItUS/d2NngsuApjn11UeWCWj8Um3VRhseZQ==",
       "dev": true
     },
     "tmpl": {
@@ -11716,6 +11868,12 @@
       "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true
     },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
     "universal-github-app-jwt": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz",
@@ -11752,31 +11910,6 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
-    },
-    "utf7": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utf7/-/utf7-1.0.2.tgz",
-      "integrity": "sha1-lV9JCq5lO6IguUVqCod2wZk2CZE=",
-      "requires": {
-        "semver": "~5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-        }
-      }
-    },
-    "utf8": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
-    },
-    "uuencode": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/uuencode/-/uuencode-0.0.4.tgz",
-      "integrity": "sha1-yNUDcIhWY4eThas34zPH6OOwIYw="
     },
     "uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-jsdoc": "^37.0.3",
     "jest": "^27.3.1",
     "jest-junit": "^13.0.0",
+    "test-smtp-server": "0.9.1",
     "ts-jest": "^27.0.7",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4"
@@ -61,7 +62,6 @@
     "commander": "^8.3.0",
     "dugite": "^1.104.0",
     "html-to-text": "^8.1.0",
-    "imap-simple": "^5.1.0",
     "json-stable-stringify": "^1.0.1",
     "jsonwebtoken": "^8.5.1",
     "libqp": "^1.1.0",

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -1,40 +1,30 @@
-import { expect, jest, test } from "@jest/globals";
+import { afterAll, beforeAll, expect, jest, test } from "@jest/globals";
 import { CIHelper } from "../lib/ci-helper";
-import { gitConfig } from "../lib/git";
 import { GitNotes } from "../lib/git-notes";
 import {
      GitHubGlue, IGitHubUser, IPRComment, IPRCommit, IPullRequestInfo,
 } from "../lib/github-glue";
 import { IMailMetadata } from "../lib/mail-metadata";
-import { connect, ImapSimple } from "imap-simple";
+import { testSmtpServer } from "test-smtp-server";
 import { testCreateRepo, TestRepo } from "./test-lib";
-import { promisify } from "util";
-const sleep = promisify(setTimeout);
 
 jest.setTimeout(180000);
 
-// smtp testing support.  NodeMailer suggests using ethereal.email.
-// The config must be set for the submit/preview tests to work.  They
-// are skipped if the config is not set.
-//
-// Sample config settings:
-// [gitgitgadget]
-//  CIimapHost = imap.ethereal.email
-//  CIsmtpUser = first.last@ethereal.email
-//  CIsmtphost = smtp.ethereal.email
-//  CIsmtppass = feedeadbeeffeeddeadbeef
-//  CIsmtpopts = {port: 587, secure: false, tls: {rejectUnauthorized: false}}
+const eMailOptions = {
+    smtpserver: new testSmtpServer(),
+    smtpOpts: ""
+};
 
-async function getEmailInfo():
-    Promise <{ smtpUser: string; smtpHost: string; imapHost: string;
-               smtpPass: string; smtpOpts: string; }> {
-    const smtpUser = await gitConfig("gitgitgadget.CIsmtpUser") || "";
-    const smtpHost = await gitConfig("gitgitgadget.CIsmtpHost") || "";
-    const smtpPass = await gitConfig("gitgitgadget.CIsmtpPass") || "";
-    const smtpOpts = await gitConfig("gitgitgadget.CIsmtpOpts") || "";
-    const imapHost = await gitConfig("gitgitgadget.CIimapHost") || "";
-    return { smtpUser, smtpHost, imapHost, smtpPass, smtpOpts };
-}
+beforeAll((): void => {
+    eMailOptions.smtpserver.startServer(); // start listening
+    eMailOptions.smtpOpts =
+        `{port: ${eMailOptions.smtpserver.getPort()
+        }, secure: true, tls: {rejectUnauthorized: false}}`;
+});
+
+afterAll((): void => {
+    eMailOptions.smtpserver.stopServer(); // terminate server
+});
 
 // Mocking class to replace GithubGlue with mock of GitHubGlue
 
@@ -139,29 +129,21 @@ async function setupRepos(instance: string):
         "https://github.com/gitgitgadget/git",
     ]);
 
-    const { smtpUser, smtpHost, smtpPass, smtpOpts } =
-        await getEmailInfo();
-
     await worktree.git([
-        "config", "--add", "gitgitgadget.smtpUser",
-        smtpUser ? smtpUser : "test",
+        "config", "--add", "gitgitgadget.smtpUser", "joe_user@example.com",
     ]);
 
     await worktree.git([
-        "config", "--add", "gitgitgadget.smtpHost",
-        smtpHost ? smtpHost : "test",
+        "config", "--add", "gitgitgadget.smtpHost", "localhost",
     ]);
 
     await worktree.git([
-        "config", "--add", "gitgitgadget.smtpPass",
-        smtpPass ? smtpPass : "test",
+        "config", "--add", "gitgitgadget.smtpPass", "secret",
     ]);
 
-    if (smtpOpts) {
-        await worktree.git([
-            "config", "--add", "gitgitgadget.smtpOpts", smtpOpts,
-        ]);
-    }
+    await worktree.git([
+        "config", "--add", "gitgitgadget.smtpOpts", eMailOptions.smtpOpts,
+    ]);
 
     const notes = new GitNotes(gggRemote.workDir);
     await notes.set("", {allowedUsers: ["ggg", "user1"]}, true);
@@ -179,72 +161,21 @@ async function setupRepos(instance: string):
 }
 
 /**
- * Connect to imap mail server.  Opens the INBOX as the current folder.
+ * Check the mail server for an email.
+ *
+ * @param messageId string to search for
  */
-async function imapConnect(): Promise <ImapSimple> {
-    const { smtpUser, smtpPass, imapHost } = await getEmailInfo();
+async function checkMsgId(messageId: string): Promise<boolean> {
+    const mails = eMailOptions.smtpserver.getEmails();
 
-    const config = {
-        imap: {
-            user: smtpUser,
-            password: smtpPass,
-            host: imapHost,
-            port: 993,
-            tls: true,
-            authTimeout: 3000
+    for (const mail of mails) {
+        const parsed = await mail.getParsed();
+        if (parsed.messageId?.match(messageId)) {
+            return true;
         }
-    };
+    }
 
-    const connection = await connect(config);
-    await connection.openBox("INBOX");
-
-    return connection;
-}
-
-/**
- * Terminate the imap mail server connection.
- *
- * @param connection
- */
-async function imapDisconnect(connection: ImapSimple): Promise <void> {
-    await connection.closeBox(false);
-    connection.end();
-}
-
-/**
- * Check the inbox to see if an email has arrived after 1 second.
- *
- * @param messageId string to search for in inbox
- */
-async function checkMsgId(messageId: string): Promise <boolean> {
-    await sleep(1000);
-    const connection = await imapConnect();
-
-    const searchCriteria = [
-        "UNSEEN"
-    ];
-
-    const fetchOptions = {
-        bodies: ["HEADER"],
-        markSeen: false
-    };
-
-    const results = await connection.search(searchCriteria, fetchOptions);
-
-    type bodyObject = {
-        "message-id": string;
-    };
-
-    const ids = results.map(res => {
-        const body = res.parts[0].body as bodyObject;
-        const id = body["message-id"][0];
-        const baseId = id.match(/\<(.*)\>/);
-        return (baseId && baseId[1]) ? baseId[1] : null ;
-    });
-
-    await imapDisconnect(connection);
-
-    return ids.includes(messageId);
+    return false;
 }
 
 test("identify merge that integrated some commit", async () => {
@@ -682,23 +613,19 @@ test("handle comment submit email success", async () => {
         title: "Submit a fun fix",
     };
 
-    const { smtpUser, imapHost } = await getEmailInfo();
+    ci.setGHGetPRInfo(prInfo);
+    ci.setGHGetPRComment(comment);
+    ci.setGHGetPRCommits(commits);
+    ci.setGHGetGitHubUserInfo(user);
 
-    if (smtpUser) {                 // if configured for this test
-        ci.setGHGetPRInfo(prInfo);
-        ci.setGHGetPRComment(comment);
-        ci.setGHGetPRCommits(commits);
-        ci.setGHGetGitHubUserInfo(user);
+    await ci.handleComment("gitgitgadget", 433865360);
+    expect(ci.addPRCommentCalls[0][1]).toMatch(/Submitted as/);
 
-        await ci.handleComment("gitgitgadget", 433865360);
-        expect(ci.addPRCommentCalls[0][1]).toMatch(/Submitted as/);
-
-        const msgId = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
-        expect(msgId).not.toBeUndefined();
-        if (msgId && msgId[1] && imapHost) {
-            const msgFound = await checkMsgId(msgId[1]);
-            expect(msgFound).toBeTruthy();
-        }
+    const msgId = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
+    expect(msgId).not.toBeUndefined();
+    if (msgId && msgId[1]) {
+        const msgFound = await checkMsgId(msgId[1]);
+        expect(msgFound).toBeTruthy();
     }
 });
 
@@ -769,45 +696,41 @@ test("handle comment preview email success", async () => {
         title: "Preview a fun fix",
     };
 
-    const { smtpUser, imapHost } = await getEmailInfo();
+    ci.setGHGetPRInfo(prInfo);
+    ci.setGHGetPRComment(comment);
+    ci.setGHGetPRCommits(commits);
+    ci.setGHGetGitHubUserInfo(user);
 
-    if (smtpUser) {                 // if configured for this test
-        ci.setGHGetPRInfo(prInfo);
-        ci.setGHGetPRComment(comment);
-        ci.setGHGetPRCommits(commits);
-        ci.setGHGetGitHubUserInfo(user);
+    await ci.handleComment("gitgitgadget", 433865360);
+    expect(ci.addPRCommentCalls[0][1]).toMatch(/Submitted as/);
 
-        await ci.handleComment("gitgitgadget", 433865360);
-        expect(ci.addPRCommentCalls[0][1]).toMatch(/Submitted as/);
+    const msgId1 = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
+    expect(msgId1).not.toBeUndefined();
+    if (msgId1 && msgId1[1]) {
+        const msgFound1 = await checkMsgId(msgId1[1]);
+        expect(msgFound1).toBeTruthy();
+    }
 
-        const msgId1 = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
-        expect(msgId1).not.toBeUndefined();
-        if (msgId1 && msgId1[1] && imapHost) {
-            const msgFound1 = await checkMsgId(msgId1[1]);
-            expect(msgFound1).toBeTruthy();
-        }
+    comment.body = " /preview";
+    ci.setGHGetPRComment(comment);
+    await ci.handleComment("gitgitgadget", 433865360); // do it again
+    expect(ci.addPRCommentCalls[1][1])
+        .toMatch(/Preview email sent as/);
 
-        comment.body = " /preview";
-        ci.setGHGetPRComment(comment);
-        await ci.handleComment("gitgitgadget", 433865360); // do it again
-        expect(ci.addPRCommentCalls[1][1])
-            .toMatch(/Preview email sent as/);
+    const msgId2 = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
+    expect(msgId2).not.toBeUndefined();
+    if (msgId2 && msgId2[1]) {
+        const msgFound2 = await checkMsgId(msgId2[1]);
+        expect(msgFound2).toBeTruthy();
+    }
 
-        const msgId2 = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
-        expect(msgId2).not.toBeUndefined();
-        if (msgId2 && msgId2[1] && imapHost) {
-            const msgFound2 = await checkMsgId(msgId2[1]);
-            expect(msgFound2).toBeTruthy();
-        }
+    await ci.handleComment("gitgitgadget", 433865360); // should still be v2
 
-        await ci.handleComment("gitgitgadget", 433865360); // should still be v2
-
-        const msgId3 = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
-        expect(msgId3).not.toBeUndefined();
-        if (msgId3 && msgId3[1] && imapHost) {
-            const msgFound3 = await checkMsgId(msgId3[1]);
-            expect(msgFound3).toBeTruthy();
-        }
+    const msgId3 = ci.addPRCommentCalls[0][1].match(/\[(.*)\]/);
+    expect(msgId3).not.toBeUndefined();
+    if (msgId3 && msgId3[1]) {
+        const msgFound3 = await checkMsgId(msgId3[1]);
+        expect(msgFound3).toBeTruthy();
     }
 });
 


### PR DESCRIPTION
Use package [`test-smtp-server`](https://github.com/webstech/test-smtp-server#readme) to run an internal SMTP server.  This will remove the dependency on a third party and may be a little faster.

This is an attempt to resolve the `ConnectionTimeoutError: connection timed out. timeout = 3000 ms` errors.  These errors occur randomly and break tests.  Recently, a popular fake SMTP server had a full day outage.

There is no external configuration for this.  The server will always run as part of the test.

The changes in `ci-helper.test.ts` in the actual tests are undenting the code after removing the check to do the test.  The changes up top are mostly removal of the imap related code.