### PR TITLE
Update `marked` and `@types/marked` to v4.0.0+

### DIFF
--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -1,5 +1,5 @@
 import { htmlToText, HtmlToTextOptions } from "html-to-text";
-import marked from "marked";
+import { marked } from "marked";
 
 // Provide our own renderings of headings and block quotes.
 
@@ -75,5 +75,5 @@ export function md2text(markdown: string, columns = 76): string {
         ],
     };
 
-    return htmlToText(marked(markdown), formatOptions);
+    return htmlToText(marked.parse(markdown), formatOptions);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "json-stable-stringify": "^1.0.1",
         "jsonwebtoken": "^8.5.1",
         "libqp": "^1.1.0",
-        "marked": "^3.0.8",
+        "marked": "^4.0.1",
         "nodemailer": "^6.7.0",
         "rfc2047": "^3.0.1"
       },
@@ -27,7 +27,7 @@
         "@types/json-stable-stringify": "^1.0.33",
         "@types/jsonwebtoken": "^8.5.5",
         "@types/libqp": "^1.1.1",
-        "@types/marked": "^3.0.2",
+        "@types/marked": "^4.0.0",
         "@types/nodemailer": "^6.4.4",
         "@types/rfc2047": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
@@ -1546,9 +1546,9 @@
       }
     },
     "node_modules/@types/marked": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-3.0.3.tgz",
-      "integrity": "sha512-ZgAr847Wl68W+B0sWH7F4fDPxTzerLnRuUXjUpp1n4NjGSs8hgPAjAp7NQIXblG34MXTrf5wWkAK8PVJ2LIlVg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.0.tgz",
+      "integrity": "sha512-Zuz0vlQDfPuop4aFFWFdFTTpVmFqkwAQJ4Onxmgc2ZMxhgaO0UxEwWpz23uHXd9QhwsFB1BJBmWNjheZmqdBuQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -5207,11 +5207,11 @@
       }
     },
     "node_modules/marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.1.tgz",
+      "integrity": "sha512-L90F6VQdYJSL1WVaIGCbNASAWnPCyB/jGmvQ/KIk0ThYq0XuzRrWxhwjcHoYvIZlQHKD/C/2i7DAADFPgxV7Tw==",
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 12"
@@ -8116,9 +8116,9 @@
       }
     },
     "@types/marked": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-3.0.3.tgz",
-      "integrity": "sha512-ZgAr847Wl68W+B0sWH7F4fDPxTzerLnRuUXjUpp1n4NjGSs8hgPAjAp7NQIXblG34MXTrf5wWkAK8PVJ2LIlVg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.0.tgz",
+      "integrity": "sha512-Zuz0vlQDfPuop4aFFWFdFTTpVmFqkwAQJ4Onxmgc2ZMxhgaO0UxEwWpz23uHXd9QhwsFB1BJBmWNjheZmqdBuQ==",
       "dev": true
     },
     "@types/node": {
@@ -10891,9 +10891,9 @@
       }
     },
     "marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.1.tgz",
+      "integrity": "sha512-L90F6VQdYJSL1WVaIGCbNASAWnPCyB/jGmvQ/KIk0ThYq0XuzRrWxhwjcHoYvIZlQHKD/C/2i7DAADFPgxV7Tw=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/json-stable-stringify": "^1.0.33",
     "@types/jsonwebtoken": "^8.5.5",
     "@types/libqp": "^1.1.1",
-    "@types/marked": "^3.0.2",
+    "@types/marked": "^4.0.0",
     "@types/nodemailer": "^6.4.4",
     "@types/rfc2047": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.3.0",
@@ -65,7 +65,7 @@
     "json-stable-stringify": "^1.0.1",
     "jsonwebtoken": "^8.5.1",
     "libqp": "^1.1.0",
-    "marked": "^3.0.8",
+    "marked": "^4.0.1",
     "nodemailer": "^6.7.0",
     "rfc2047": "^3.0.1"
   },


### PR DESCRIPTION
Source is updated to handle breaking changes.

marked had a second update to handle a problem that showed up with jest but not regular builds.