### PR TITLE
Capture PR footer from last linefeed pair

### DIFF
--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -1264,7 +1264,7 @@ test("Handle comment cc", async () => {
     ci.updatePRCalls.length = 0;
 
     // email will not be re-added to list
-    prInfo.body = "changes\n\ncc: <abody@example.com>";
+    prInfo.body = "changes\r\n\r\ncc: <abody@example.com>";
 
     await ci.handleComment("gitgitgadget", prNumber);
 

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -309,6 +309,12 @@ test("add PR cc requests", async () => {
     expect(updatePR.mock.calls).toHaveLength(2);
     updatePR.mock.calls.length = 0;
 
+    // Test with 3 linefeeds present
+    prInfo.body = `Test\r\n\r\n\r\ncc: ${prCc}`;
+    await github.addPRCc(prInfo.pullRequestURL, prCc);
+    expect(updatePR.mock.calls).toHaveLength(0);
+    updatePR.mock.calls.length = 0;
+
     // Test with linefeeds and unknown footers
     prInfo.body = `Test\r\n \t\r\nbb: x\r\ncc: ${prCc}`;
     await github.addPRCc(prInfo.pullRequestURL, prCc);


### PR DESCRIPTION
User edited PR descriptions may have an odd number of linefeeds separating the body from the footer.  The footer is now extracted from the last linefeed pair.

Additionally, the trimmed PR body will be used for updating to ensure there is no single trailing linefeed.

This corrects the problem observed in a recent [PR](https://github.com/gitgitgadget/gitgitgadget/pull/777#issuecomment-978889386).