### PR TITLE
Make `/preview` safer

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -850,6 +850,8 @@ export class PatchSeries {
             await this.sendMBox(mails.join("\n"));
         }
 
+        if (this.options.noUpdate) return this.metadata;
+
         logger.log("Updating the mail metadata");
         let isCoverLetter: boolean = mails.length > 1;
         for (const mail of mails) {
@@ -904,7 +906,7 @@ export class PatchSeries {
             await this.notes.set(key, this.metadata, true);
         }
 
-        if (!this.options.noUpdate && publishTagsAndNotesToRemote) {
+        if (publishTagsAndNotesToRemote) {
             await git(["push", publishTagsAndNotesToRemote, this.notes.notesRef,
                        `refs/tags/${tagName}`],
                       { workDir: this.notes.workDir });


### PR DESCRIPTION
As reported by @ldennington, [one instance of a `/preview` command](https://github.com/gitgitgadget/git/pull/1050#issuecomment-985770245) updated GitGitGadget's notes ref in such a way that it thought it had sent a new iteration, and then failed to find the corresponding tag in gitgitgadget/git.

My best guess is that the notes ref (which was updated locally by that `/preview` command, but never pushed) actually _did_ get pushed by _another_ run (which shares a persistent clone of gitgitgadget/git, to avoid cloning/updating unnecessarily). Granted, this other run should have force-fetched the notes ref first, overwriting any local changes. But it did not.

To avoid that situation, let's prevent `/preview` runs from even modifying that notes ref.