### PR TITLE
Add one bit of defensive programming

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,31 @@
             "outFiles": [
                 "${workspaceRoot}/build/**/*.js"
             ]
+        },
+        {
+            "name": "Debug update-open-prs",
+            "type": "node",
+            "request": "launch",
+            "runtimeArgs": [
+                "--inspect-brk",
+                // "--nolazy",
+            ],
+            "args": [
+                "${workspaceRoot}/build/script/misc-helper.js",
+                "update-open-prs",
+            ],
+            "stopOnEntry": false,
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": null,
+            "runtimeExecutable": null,
+            "env": {
+                "NODE_ENV": "development"
+            },
+            "console": "integratedTerminal",
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceRoot}/build/**/*.js"
+            ]
         }
     ]
 }


### PR DESCRIPTION
This just came up, where GitGitGadget (for an unknown reason) failed not only to send [`[PATCH v2 4/4]`](https://lore.kernel.org/git/7bacb3760f3d8d55b9a8d370642b093e9c60e9a6.1639149490.git.gitgitgadget@gmail.com/) of https://github.com/gitgitgadget/git/pull/1069 (see the [thread](https://lore.kernel.org/git/pull.1069.v2.git.1639149490.gitgitgadget@gmail.com/#r)), but also failed to record the Message-ID of that patch.

While it is unclear why it failed (the [log](https://dev.azure.com/gitgitgadget/git/_build/results?buildId=121013&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=28e14b79-1d95-5195-ee03-3a68ac48a418) is not illuminating), GitGitGadget should handle this more gracefully than to stop processing _all_ PRs.