### PR TITLE
Reject commits expecting to be rebased out

### DIFF
--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -34,6 +34,7 @@ export class LintCommit {
 
         if (this.commitViable()) {
             this.commitMessageLength();
+            this.bangPrefix();
             this.lowerCaseAfterPrefix();
             this.signedOffBy();
             this.moreThanAHyperlink();
@@ -96,6 +97,14 @@ export class LintCommit {
         if (match) {
             this.block(`Prefixed commit message must be in lower case: ${
                        this.lines[0]}`);
+        }
+    }
+
+    // Reject commits that appear to require rebasing
+
+    private bangPrefix(): void {
+        if (this.lines[0].match(/^(squash|fixup|amend)!/)) {
+            this.block(`Rebase needed to squash commit: ${this.lines[0]}`);
         }
     }
 

--- a/tests/commit-lint.test.ts
+++ b/tests/commit-lint.test.ts
@@ -65,6 +65,46 @@ test("basic lint tests", () => {
         }
     }
 
+    commit.message = "squash! This needs rebase\n\nSigned-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/Rebase/);
+        }
+    }
+
+    commit.message = "fixup! This needs rebase\n\nSigned-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/Rebase/);
+        }
+    }
+
+    commit.message = "amend! This needs rebase\n\nSigned-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/Rebase/);
+        }
+    }
+
+    commit.message = "amend This is okay\n\nSigned-off-by: x";
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).toBeUndefined();
+    }
+
     commit.message = "tests: This should be lower case\n\nSigned-off-by: x";
     {
         const linter = new LintCommit(commit);


### PR DESCRIPTION
Commit messages starting with `squash!`, `fixup!` or `amend!` are special commits to simplify updating a previous Commit.  A rebase should be run to remove them.
