### PR TITLE
patch-series: make stripDuplicateHeaders private

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -371,7 +371,7 @@ export class PatchSeries {
         });
     }
 
-    protected static stripDuplicateHeaders(headers: string,
+    private static stripDuplicateHeaders(headers: string,
                                            header: ISingletonHeader): string {
         const needle = "\n" + header.key + ":";
         let offset;


### PR DESCRIPTION
... otherwise ISingletonHeader would need to be exported