### PR TITLE
use explicit and compiler-friendly type conversions

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -119,11 +119,12 @@ export class CIHelper {
         }
         mailMeta.commitInGitGit = upstreamCommit;
         if (!mailMeta.originalCommit) {
-            mailMeta.originalCommit =
-                await this.getOriginalCommitForMessageId(messageID);
-            if (!mailMeta.originalCommit) {
+            const originalCommit
+                = await this.getOriginalCommitForMessageId(messageID);
+            if (!originalCommit) {
                 throw new Error(`No original commit found for ${messageID}`);
             }
+            mailMeta.originalCommit = originalCommit;
         }
         await this.notes.set(messageID, mailMeta, true);
 
@@ -389,7 +390,7 @@ export class CIHelper {
                 prMeta.mergedIntoUpstream = {};
             }
             if (prMeta.mergedIntoUpstream[branch] !== mergeCommit) {
-                prMeta.mergedIntoUpstream[branch] = mergeCommit;
+                prMeta.mergedIntoUpstream[branch] = mergeCommit as string;
                 notesUpdated = true;
 
                 // Add label on GitHub

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -88,12 +88,12 @@ export class GitGitGadget {
 
     protected static async readOptions(notes: GitNotes):
         Promise<[IGitGitGadgetOptions, Set<string>]> {
-        let options = await notes.get<IGitGitGadgetOptions>("");
-        if (options === undefined) {
-            options = {
-                allowedUsers: [],
-            };
-        }
+
+        const defaultOptions: IGitGitGadgetOptions = { allowedUsers: [], };
+
+        const options: IGitGitGadgetOptions
+            = await notes.get<IGitGitGadgetOptions>("") ?? defaultOptions;
+
         const allowedUsers = new Set<string>(options.allowedUsers);
 
         return [options, allowedUsers];

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -119,7 +119,8 @@ export class MailArchiveGitHelper {
             }
             console.log(`Handling "${sousChef.subject}"`);
             const whatsCookingBaseURL = "https://lore.kernel.org/git/";
-            for (const branchName of sousChef.branches.keys()) {
+            for (const key of sousChef.branches.keys()) {
+                const branchName: string = key as any as string;
                 const pullRequestURL = branchNameMap.get(branchName);
                 if (pullRequestURL) {
                     const branchBaseURL


### PR DESCRIPTION
In all of those cases, I'm seeing type conversion errors from static analysis. The "extra-tours" in this PR are clearing up typing and type conversions for the compiler