### PR TITLE
github-glue/patch-series: avoid parameterless catch clauses

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -137,11 +137,11 @@ export class GitHubGlue {
                             throw new Error("Found");
                         }
                     });
-                } catch {
+                } catch (_) {
                     // quick exit for cc matched (comment to quiet linter)
                 }
             });
-        } catch {
+        } catch (_) {
             found = false;          // ensure it was not a cc: false positive
             footerSeparator = "\r\n"; // reset
         }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -252,7 +252,7 @@ export class PatchSeries {
             // \r\n line endings.
             prTemplate = prTemplate.replace(/\r\n/g, "\n");
             prBody = prBody.replace(prTemplate, "");
-        } catch {
+        } catch (_) {
             // Just ignore it
         }
 


### PR DESCRIPTION
It's allowed since ECMA2019. 
I'm not sure whether typescript allows it, but VS doesn't like it and fails to parse the whole files when catch parameters are omitted