### PR TITLE
tslint: don't require parameter and argument alignment

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -3,8 +3,6 @@
     "rules": {
         "align": [
             true,
-            "parameters",
-            "arguments",
             "members",
             "elements",
             "statements"


### PR DESCRIPTION
The current code doesn't adhere to this and this also contradicts
with max-line-length: aligning parameters or argument often
requires to indent subsequent lines so far that the line
length requirement would need to be violated