### PR TITLE
lint: run all possible checks on short commit msg

### DIFF
--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -5,6 +5,10 @@ export interface ILintError {
     message: string;
 }
 
+export interface ILintOptions {
+    maxColumns?: number | undefined; // max line length
+}
+
 /*
  * Simple single use class to drive lint tests on commit messages.
  */
@@ -15,10 +19,16 @@ export class LintCommit {
     private messages: string[] = [];
     private maxColumns = 76;
 
-    public constructor(patch: IPRCommit) {
+    public constructor(patch: IPRCommit, options?: ILintOptions | undefined) {
         this.blocked = false;
         this.lines =  patch.message.split("\n");
         this.patch = patch;
+
+        if (options !== undefined) {
+            if (options.maxColumns !== undefined) {
+                this.maxColumns = options.maxColumns;
+            }
+        }
     }
 
     /**

--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -6,13 +6,14 @@ export interface ILintError {
 }
 
 /*
- * Simple class to drive lint tests on commit messages.
+ * Simple single use class to drive lint tests on commit messages.
  */
 export class LintCommit {
     private blocked: boolean;
     private lines: string[];
     private patch: IPRCommit;
     private messages: string[] = [];
+    private maxColumns = 76;
 
     public constructor(patch: IPRCommit) {
         this.blocked = false;
@@ -20,27 +21,39 @@ export class LintCommit {
         this.patch = patch;
     }
 
-    /*
+    /**
      * Linter method to run checks on the commit message.
-     * @param {IPRCommit} the patch to be checked
-     *
-     * The lints are in methods called from here.  If
-     * a lint check is too severe to continue, it will throw
-     * an error.
      */
     public lint(): ILintError | void {
 
-        // Basic test before all others
+        const phase1 = [
+            this.commitViable
+        ];
 
-        if (this.commitViable()) {
-            this.commitMessageLength();
-            this.bangPrefix();
-            this.lowerCaseAfterPrefix();
-            this.signedOffBy();
-            this.moreThanAHyperlink();
+        const phase2 = [            // checks to always run
+            this.commitMessageLength,
+            this.bangPrefix,
+            this.lowerCaseAfterPrefix,
+            this.signedOffBy
+        ];
+
+        const phase3 = [            // checks if phase1 was successful
+            this.commitTextLength,
+            this.moreThanAHyperlink
+        ];
+
+        phase1.map((linter) => { linter(); });
+
+        const phase1Okay = false === this.blocked;
+
+        phase2.map((linter) => { linter(); });
+
+        if (phase1Okay) {
+            phase3.map((linter) => { linter(); });
         }
 
         if (this.messages.length) {
+            this.messages.unshift(`\`${this.lines[0]}\``);
             return { checkFailed: this.blocked,
                      message: `There ${this.messages.length > 1 ?
                      "are issues" : "is an issue"} in commit ${
@@ -61,57 +74,65 @@ export class LintCommit {
     // Test for a minimum viable commit message.
     // - the body of the commit message should not be empty
 
-    private commitViable(): boolean {
+    private commitViable = (): void => {
         if (this.lines.length < 3) {
             this.block("Commit checks stopped - the message is too short");
-            return false;
         }
+    };
 
-        return true;
-    }
+    // The first line should not be too long
+
+    private commitMessageLength = (): void => {
+        if (this.lines[0].length > this.maxColumns) {
+            this.block(`First line of commit message is too long (> ${
+                this.maxColumns} columns)`);
+        }
+    };
 
     // More tests of the commit message structure.
-    // - the first line should not exceed 76 characters
     // - the first line should be followed by an empty line
+    // other lines should not be too long
 
-    private commitMessageLength(): void {
-        const maxColumns = 76;
-        if (this.lines[0].length > maxColumns) {
-            this.block(`First line of commit message is too long (> ${
-                maxColumns} columns): ${this.lines[0]}`);
-        }
-
-        if (this.lines[1].length) {
+    private commitTextLength = (): void => {
+        if (this.lines.length > 2 && this.lines[1].length) {
             this.block("The first line must be separated from the rest by an "
                         + "empty line");
         }
-    }
+
+        for (let i = 1; i < this.lines.length; i++) {
+            if (this.lines[i].length > this.maxColumns) {
+                this.block(`Lines in the body of the commit messages ${""
+                    }should be wrapped between 60 and ${
+                    this.maxColumns} characters.`);
+                break;
+            }
+        }
+    };
 
     // Verify if the first line starts with a prefix (e.g. tests:), it continues
     // in lower-case (except for ALLCAPS as that is likely to be a code
     // identifier)
 
-    private lowerCaseAfterPrefix(): void {
+    private lowerCaseAfterPrefix = (): void =>{
         const match = this.lines[0].match(/^\S+?:\s*?([A-Z][a-z ])/);
 
         if (match) {
-            this.block(`Prefixed commit message must be in lower case: ${
-                       this.lines[0]}`);
+            this.block("Prefixed commit message must be in lower case");
         }
-    }
+    };
 
     // Reject commits that appear to require rebasing
 
-    private bangPrefix(): void {
+    private bangPrefix = (): void =>{
         if (this.lines[0].match(/^(squash|fixup|amend)!/)) {
-            this.block(`Rebase needed to squash commit: ${this.lines[0]}`);
+            this.block("Rebase needed to squash commit");
         }
-    }
+    };
 
     // Verify there is a Signed-off-by: line - DCO check does this
     // already, but put out a message if it is indented
 
-    private signedOffBy(): void {
+    private signedOffBy = (): void =>{
         let signedFound = false;
 
         this.lines.map((line) => {
@@ -128,7 +149,7 @@ export class LintCommit {
         if (!signedFound) {
             this.block("Commit not signed off");
         }
-    }
+    };
 
     // Verify the body of the commit message does not consist of a hyperlink,
     // without any other explanation.
@@ -136,7 +157,7 @@ export class LintCommit {
     // Low hanging fruit: check the first line.
     // Hyperlink validation is NOT part of the test.
 
-    private moreThanAHyperlink(): void {
+    private moreThanAHyperlink = (): void =>{
         const line = this.lines[2];
         const match = line.match(/^(\w*)\s*https*:\/\/\S+\s*(\w*)/);
 
@@ -146,5 +167,5 @@ export class LintCommit {
                 this.block("A hyperlink requires some explanation");
             }
         }
-    }
+    };
 }

--- a/tests/commit-lint.test.ts
+++ b/tests/commit-lint.test.ts
@@ -308,3 +308,48 @@ test("combo lint tests", () => {
         }
     }
 });
+
+test("lint options tests", () => {
+    const commit = {
+        author: {
+            email: "ggg@example.com",
+            login: "ggg",
+            name: "e. e. cummings",
+        },
+        commit: "BAD1FEEDBEEF",
+        committer: {
+            email: "ggg@example.com",
+            login: "ggg",
+            name: "e. e. cummings",
+        },
+        message: `all good but too long 1234567890${
+                ""}1234578901234567890123456789012345678901234567890\n\n${
+                ""}1234578901234567890123456789012345678901234567890${
+                ""}123456789012345678901234567890\nmore bad\nSigned-off-by: x`,
+        parentCount: 1,
+    };
+
+    {
+        const linter = new LintCommit(commit, {});
+        const lintError = linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/is too long/);
+            expect(lintError.message).toMatch(/should be wrapped/);
+            expect(lintError.message).toMatch(/76/);
+        }
+    }
+
+    {
+        const linter = new LintCommit(commit, {maxColumns: 66});
+        const lintError = linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/is too long/);
+            expect(lintError.message).toMatch(/should be wrapped/);
+            expect(lintError.message).toMatch(/66/);
+        }
+    }
+});

--- a/tests/commit-lint.test.ts
+++ b/tests/commit-lint.test.ts
@@ -224,4 +224,87 @@ blah http://www.github.com\n\nSigned-off-by: x`;
         expect(lintError).toBeUndefined();
     }
 
+    commit.message = `wrapped but too long\n\n ${
+                ""}1234578901234567890123456789012345678901234567890${
+                ""}123456789012345678901234567890\nmore bad\nSigned-off-by: x`;
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/should be wrapped/);
+        }
+    }
+});
+
+test("combo lint tests", () => {
+    const commit = {
+        author: {
+            email: "ggg@example.com",
+            login: "ggg",
+            name: "e. e. cummings",
+        },
+        commit: "BAD1FEEDBEEF",
+        committer: {
+            email: "ggg@example.com",
+            login: "ggg",
+            name: "e. e. cummings",
+        },
+        message: "Message has no description",
+        parentCount: 1,
+    };
+
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/too short/);
+            expect(lintError.message).toMatch(/not signed/);
+        }
+    }
+
+    commit.message = `x: A 34578901234567890123456789012345678901234567890${
+                ""}123456789012345678901234567890`;
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/too short/);
+            expect(lintError.message).toMatch(/not signed/);
+            expect(lintError.message).toMatch(/is too long/);
+            expect(lintError.message).toMatch(/lower/);
+        }
+    }
+
+    commit.message = `1234578901234567890123456789012345678901234567890${
+                ""}123456789012345678901234567890\nmore bad\nSigned-off-by: x`;
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/is too long/);
+            expect(lintError.message).toMatch(/empty line/);
+        }
+    }
+
+    commit.message = `all good but too long\n ${
+                ""}1234578901234567890123456789012345678901234567890${
+                ""}123456789012345678901234567890\nmore bad\nSigned-off-by: x`;
+    {
+        const linter = new LintCommit(commit);
+        const lintError = linter.lint();
+        expect(lintError).not.toBeUndefined();
+        if (lintError) {
+            expect(lintError.checkFailed).toBe(true);
+            expect(lintError.message).toMatch(/should be wrapped/);
+            expect(lintError.message).toMatch(/empty line/);
+        }
+    }
 });


### PR DESCRIPTION
Actually two changes here.

### lint: run all possible checks on short commit msg

- Refactor linting into 3 phases where phase 3 only runs if phase 1 succeeds.
- The commit message will be shown before any linting messages to make it easier to identify.  
- Added check on long Lines in commit description.
- Cleaned up some dead comments.

### linting: add options interface for customization
The initial option allows setting of the max line length in the commit message.  This will help position for when some method of customizing is selected.