### PR TITLE
Allow some long lines in commit lint

### DIFF
--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -110,7 +110,11 @@ export class LintCommit {
         }
 
         for (let i = 1; i < this.lines.length; i++) {
-            if (this.lines[i].length > this.maxColumns) {
+            if (this.lines[i].length > this.maxColumns &&
+                // Allow long lines if they cannot be wrapped at some
+                // white-space character, e.g. URLs. To allow ` [1] <URL>`
+                // lines, we skip the first 10 characters.
+                this.lines[i].slice(10).match(/\s/)) {
                 this.block(`Lines in the body of the commit messages ${""
                     }should be wrapped between 60 and ${
                     this.maxColumns} characters.`);

--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -120,7 +120,7 @@ export class LintCommit {
     };
 
     // Verify if the first line starts with a prefix (e.g. tests:), it continues
-    // in lower-case (except for ALLCAPS as that is likely to be a code
+    // in lower-case (except for ALL_CAPS as that is likely to be a code
     // identifier)
 
     private lowerCaseAfterPrefix = (): void =>{

--- a/tests/commit-lint.test.ts
+++ b/tests/commit-lint.test.ts
@@ -159,7 +159,7 @@ blah http://www.github.com\n\nSigned-off-by: x`;
 
     commit.message = `wrapped but too long\n\n ${
                 ""}1234578901234567890123456789012345678901234567890${
-                ""}123456789012345678901234567890\nmore bad\nSigned-off-by: x`;
+                ""} 23456789012345678901234567890\nmore bad\nSigned-off-by: x`;
     lintCheck(commit, (lintError) => {
         expect(lintError.checkFailed).toBe(true);
         expect(lintError.message).toMatch(/should be wrapped/);
@@ -209,7 +209,7 @@ test("combo lint tests", () => {
 
     commit.message = `all good but too long\n ${
                 ""}1234578901234567890123456789012345678901234567890${
-                ""}123456789012345678901234567890\nmore bad\nSigned-off-by: x`;
+                ""} 23456789012345678901234567890\nmore bad\nSigned-off-by: x`;
     lintCheck(commit, (lintError) => {
         expect(lintError.checkFailed).toBe(true);
         expect(lintError.message).toMatch(/should be wrapped/);
@@ -231,9 +231,9 @@ test("lint options tests", () => {
             name: "e. e. cummings",
         },
         message: `all good but too long 1234567890${
-                ""}1234578901234567890123456789012345678901234567890\n\n${
+                ""} 234578901234567890123456789012345678901234567890\n\n${
                 ""}1234578901234567890123456789012345678901234567890${
-                ""}123456789012345678901234567890\nmore bad\nSigned-off-by: x`,
+                ""} 23456789012345678901234567890\nmore bad\nSigned-off-by: x`,
         parentCount: 1,
     };
 

--- a/tests/commit-lint.test.ts
+++ b/tests/commit-lint.test.ts
@@ -128,7 +128,7 @@ Signed-off-by: x`;
         }
     }
 
-    commit.message = "tests: THIS can be allcaps\n\nSigned-off-by: x";
+    commit.message = "tests: THIS can be all-caps\n\nSigned-off-by: x";
     {
         const linter = new LintCommit(commit);
         const lintError = linter.lint();

--- a/tests/commit-lint.test.ts
+++ b/tests/commit-lint.test.ts
@@ -164,6 +164,12 @@ blah http://www.github.com\n\nSigned-off-by: x`;
         expect(lintError.checkFailed).toBe(true);
         expect(lintError.message).toMatch(/should be wrapped/);
     });
+
+    commit.message = `contains a long URL that cannot be wrapped\n\n ${
+                ""}[2] https://lore.kernel.org/git/CABPp-BH9tju7WVm=${
+                ""}QZDOvaMDdZbpNXrVWQdN-jmfN8wC6YVhmw@mail.gmail.com/\n\n${
+                ""}Signed-off-by: x}`;
+    lintCheck(commit);
 });
 
 test("combo lint tests", () => {


### PR DESCRIPTION
When a line simply cannot be wrapped (because there is no white-space where we could wrap the line), we should exempt the line from the too-long-line check.

Requested by @newren in https://github.com/gitgitgadget/git/pull/1113#issuecomment-1008229286.