### PR TITLE
lookup-commit.sh: we entered the next epoch on lore.kernel.org/git

### DIFF
--- a/script/lookup-commit.sh
+++ b/script/lookup-commit.sh
@@ -30,7 +30,7 @@ update_mail_archive_dir () {
 	git clone --bare https://dev.azure.com/gitgitgadget/git/_git/lore-git "$LORE_GIT_DIR" ||
 	die "Could not clone lore.kernel/git to $LORE_GIT_DIR"
 
-	git -C "$LORE_GIT_DIR" fetch https://lore.kernel.org/git/0 master:master ||
+	git -C "$LORE_GIT_DIR" fetch https://lore.kernel.org/git/1 master:master ||
 	die "Could not update $LORE_GIT_DIR to remote's master"
 
 	head="$(git -C "$LORE_GIT_DIR" rev-parse --verify master)" ||


### PR DESCRIPTION
Let's follow suite so that we do not fall behind in GitGitGadget.

This PR is needed to fix the failures of the "Update GitGitGadget's commit to mail notes" builds, e.g. [this one](https://dev.azure.com/gitgitgadget/git/_build/results?buildId=124673&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=33e5d3ec-87e7-5f80-0281-074c6962cb44&l=36)