### PR TITLE
dry part 1: GitHubGlue support for keys or url as parm

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -25,6 +25,8 @@ type CommentFunction = (comment: string) => Promise<void>;
 export class CIHelper {
     public readonly workDir?: string;
     public readonly notes: GitNotes;
+    public readonly urlBase: string;
+    public readonly urlRepo: string;
     protected readonly mail2commit: MailCommitMapping;
     protected readonly github: GitHubGlue;
     protected readonly gggConfigDir: string;
@@ -46,6 +48,8 @@ export class CIHelper {
         this.mail2CommitMapUpdated = !!skipUpdate;
         this.github = new GitHubGlue(workDir);
         this.testing = false;
+        this.urlBase = `https://github.com/gitgitgadget/`;
+        this.urlRepo = `${this.urlBase}git/`;
     }
 
     /*
@@ -81,7 +85,7 @@ export class CIHelper {
         if (!this.commit2mailNotes) {
             this.commit2mailNotes = new GitNotes(this.mail2commit.workDir,
                                                  "refs/notes/commit-to-mail");
-            await this.commit2mailNotes.update();
+            await this.commit2mailNotes.update(this.urlRepo);
         }
         const messageId = await
             this.getMessageIdForOriginalCommit(originalCommit);
@@ -865,7 +869,7 @@ export class CIHelper {
 
     private async maybeUpdateGGGNotes(): Promise<void> {
         if (!this.gggNotesUpdated) {
-            await this.notes.update();
+            await this.notes.update(this.urlRepo);
             this.gggNotesUpdated = true;
         }
     }

--- a/lib/git-notes.ts
+++ b/lib/git-notes.ts
@@ -75,11 +75,11 @@ export class GitNotes {
         return notes.replace(/^[^]*\n\n/, "");
     }
 
-    public async update(): Promise<void> {
+    public async update(url: string): Promise<void> {
         if (this.notesRef === "refs/notes/gitgitgadget" ||
             this.notesRef === "refs/notes/commit-to-mail" ||
             this.notesRef === "refs/notes/mail-to-commit") {
-            await git(["fetch", "https://github.com/gitgitgadget/git",
+            await git(["fetch", url,
                        `+${this.notesRef}:${this.notesRef}`],
                       { workDir: this.workDir });
         } else {

--- a/lib/pullRequestKey.ts
+++ b/lib/pullRequestKey.ts
@@ -1,0 +1,26 @@
+/**
+ * Helper types to identify key fields of pull request related APIs.
+ *
+ * Two functions are provided to extract the key fields from a formatted URL.
+ */
+export type pullRequestKey = {
+    owner: string;
+    repo: string;
+    pull_number: number;
+}
+
+export type pullRequestKeyInfo = string | pullRequestKey;
+
+export function getPullRequestKey(pullRequest: pullRequestKeyInfo): pullRequestKey {
+    return typeof(pullRequest) === "string" ? getPullRequestKeyFromURL(pullRequest) : pullRequest;
+}
+
+export function getPullRequestKeyFromURL(pullRequestURL: string): pullRequestKey {
+    const match = pullRequestURL.match(/^https:\/\/github.com\/(.*)\/(.*)\/pull\/(\d+)$/);
+    if (!match) {
+        throw new Error(`Unrecognized PR URL: "${pullRequestURL}`);
+    }
+
+    return {owner: match[1], repo: match[2], pull_number: parseInt(match[3], 10)};
+}
+

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -1251,7 +1251,7 @@ test("Handle comment cc", async () => {
 
     await ci.handleComment("gitgitgadget", prNumber);
 
-    expect(ci.updatePRCalls[0][2]).toMatch(/Some Body/);
+    expect(ci.updatePRCalls[0][ci.updatePRCalls[0].length-1]).toMatch(/Some Body/);
     ci.updatePRCalls.length = 0;
 
     comment.body = "/cc \"A Body\" <abody@example.com>, "
@@ -1259,8 +1259,8 @@ test("Handle comment cc", async () => {
 
     await ci.handleComment("gitgitgadget", prNumber);
 
-    expect(ci.updatePRCalls[0][2]).toMatch(/A Body/);
-    expect(ci.updatePRCalls[1][2]).toMatch(/S Body/);
+    expect(ci.updatePRCalls[0][ci.updatePRCalls[0].length-1]).toMatch(/A Body/);
+    expect(ci.updatePRCalls[1][ci.updatePRCalls[0].length-1]).toMatch(/S Body/);
     ci.updatePRCalls.length = 0;
 
     // email will not be re-added to list
@@ -1268,6 +1268,6 @@ test("Handle comment cc", async () => {
 
     await ci.handleComment("gitgitgadget", prNumber);
 
-    expect(ci.updatePRCalls[0][2]).toMatch(/S Body/);
+    expect(ci.updatePRCalls[0][ci.updatePRCalls[0].length-1]).toMatch(/S Body/);
     expect(ci.updatePRCalls).toHaveLength(1);
 });


### PR DESCRIPTION
This is part of a series to make GitGitGadget more generic for use with other repos.  As part of this it also starts to address issue #150.  

The `pullRequestKey` may not be the best name or object but it is also not the first name or iteration.  Suggestions are welcome.  The existing `parsePullRequestURL` should be able to go away with the next iteration.

A next step would be to update the `azure` function to add the repo name to the trigger parms.  This can then be handled in the pipeline to set a third parm of the repo.  A full key would then be available for PR processing.  

### test: ci-helper check last parm for value

The number of parms to GitHubGlue::updatePR could change.  This
removes a dependency on the number of call parameters.

### dependency: remove repo url from notes

Part of a set of changes to make GitGitGadget more supportive of    other projects.

### regex reduction: introduce PR keys object

First phase in removing reparsing of pull request URL.  This positions   `GitHubGlue` to accept a URL string or object for most methods.

