### PR TITLE
dry part 2: expand use of `pullRequestKey` over URL string

### DIFF
--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -75,17 +75,6 @@ export class GitGitGadget {
                                 publishTagsAndNotesToRemote);
     }
 
-    public static parsePullRequestURL(pullRequestURL: string):
-        [string, string, number] {
-        const match = pullRequestURL
-            .match(/^https:\/\/github.com\/(.*)\/(.*)\/pull\/(\d+)$/);
-        if (!match) {
-            throw new Error(`Unrecognized PR URL: "${pullRequestURL}`);
-        }
-        const [, owner, repo, prNo] = match;
-        return [owner, repo, parseInt(prNo, 10)];
-    }
-
     protected static async readOptions(notes: GitNotes):
         Promise<[IGitGitGadgetOptions, Set<string>]> {
 

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -95,7 +95,7 @@ export class GitHubGlue {
     /**
      * Add a cc to a Pull Request
      *
-     * @param {string} pullRequestURL the Pull Request to comment on
+     * @param {pullRequestKeyInfo} pullRequest - the Pull Request to comment on
      * @param {string} cc to add
      * @returns the comment ID and the URL to the comment
      */
@@ -160,7 +160,7 @@ export class GitHubGlue {
     /**
      * Add a Pull Request comment
      *
-     * @param {string} pullRequestURL the Pull Request to comment on
+     * @param {pullRequestKeyInfo} pullRequest - the Pull Request to comment on
      * @param {string} comment the comment
      * @returns the comment ID and the URL to the comment
      */
@@ -184,7 +184,7 @@ export class GitHubGlue {
     /**
      * Add a Pull Request comment on a specific commit
      *
-     * @param {string} pullRequestURL the Pull Request to comment on
+     * @param {pullRequestKeyInfo} pullRequest - the Pull Request to comment on
      * @param {string} commit the hash of the commit to comment on
      * @param {string} comment the comment
      * @returns the comment ID and the URL to the comment
@@ -219,7 +219,7 @@ export class GitHubGlue {
     /**
      * Add a Pull Request comment as reply to a specific comment
      *
-     * @param {string} pullRequestURL the Pull Request to comment on
+     * @param {pullRequestKeyInfo} pullRequest - the Pull Request to comment on
      * @param {number} id the ID of the comment to which to reply
      * @param {string} comment the comment to add
      * @returns the comment ID and the URL to the added comment
@@ -246,7 +246,7 @@ export class GitHubGlue {
     /**
      * Update a Pull Request body or title
      *
-     * @param {string} pullRequestURL the Pull Request to comment on
+     * @param {pullRequestKeyInfo} pullRequest - the Pull Request to update
      * @param {string} body the updated body
      * @param {string} title the updated title
      * @returns the PR number

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -246,17 +246,14 @@ export class GitHubGlue {
     /**
      * Update a Pull Request body or title
      *
-     * @param {pullRequestKeyInfo} pullRequest - the Pull Request to update
+     * @param {pullRequestKey} prKey - the Pull Request to update
      * @param {string} body the updated body
      * @param {string} title the updated title
      * @returns the PR number
      */
-    public async updatePR(pullRequest: pullRequestKeyInfo,
-                          body?: string | undefined, title?: string):
-        Promise<number> {
-        const prKey = getPullRequestKey(pullRequest);
-
+    public async updatePR(prKey: pullRequestKey, body?: string | undefined, title?: string): Promise<number> {
         await this.ensureAuthenticated(prKey.owner);
+
         const result = await this.client.rest.pulls.update({
             "body": body || undefined,
             "title": title || undefined,

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -5,12 +5,13 @@ import {
     commitExists, git, gitCommandExists, gitConfig, revListCount, revParse,
 } from "./git";
 import { GitNotes } from "./git-notes";
-import { GitGitGadget, IGitGitGadgetOptions } from "./gitgitgadget";
+import { IGitGitGadgetOptions } from "./gitgitgadget";
 import { IMailMetadata } from "./mail-metadata";
 import { md2text } from "./markdown-renderer";
 import { IPatchSeriesMetadata } from "./patch-series-metadata";
 import { PatchSeriesOptions } from "./patch-series-options";
 import { ProjectOptions } from "./project-options";
+import { getPullRequestKeyFromURL } from "./pullRequestKey";
 
 export interface ILogger {
     log(message: string): void;
@@ -751,11 +752,10 @@ export class PatchSeries {
         if (!this.metadata.pullRequestURL) {
             tagName = `${this.project.branchName}-v${this.metadata.iteration}`;
         } else {
-            const [owner, , prNumber] =
-                GitGitGadget.parsePullRequestURL(this.metadata.pullRequestURL);
+            const prKey = getPullRequestKeyFromURL(this.metadata.pullRequestURL);
             const branch = this.metadata.headLabel.replace(/:/g, "/");
-            const tagPrefix = owner === "gitgitgadget" ? "pr-" : `pr-${owner}-`;
-            tagName = `${tagPrefix}${prNumber}/${branch}-v${
+            const tagPrefix = prKey.owner === "gitgitgadget" ? "pr-" : `pr-${prKey.owner}-`;
+            tagName = `${tagPrefix}${prKey.pull_number}/${branch}-v${
                 this.metadata.iteration}`;
         }
 


### PR DESCRIPTION
Warning: many continued lines have been joined using new longer line length.

### doc: correct jsdoc for parameter type changes

###  GitHubGlue: reduce updatePR parameter typings

Currently only used internally with `pullRequestKey`.

### CIHelper: more pullRequestKey use and longer lines

More changes to use `pullRequestKey` and rely less on reparsing URL.

A number of multi-line statements were re-wrapped to one line,  making the code a little more obvious.

### GitGitGadget: remove parsePullRequestURL

Convert last user to new function.