### PR TITLE
scripts: make shell scripts generic with new vars

### DIFF
--- a/script/lookup-commit.sh
+++ b/script/lookup-commit.sh
@@ -25,12 +25,17 @@ LORE_GIT_DIR="$(dirname "$0")/../.git/lore.kernel-git"
 test -n "$GITGIT_DIR" ||
 GITGIT_DIR="$(dirname "$0")/../.git/git-worktree"
 
+mail_repo="${GITGIT_MAIL_REPO:-https://dev.azure.com/gitgitgadget/git/_git/lore-git}"
+mail_remote="${GITGIT_MAIL_REMOTE:-https://lore.kernel.org/git}"
+mail_epoch="${GITGIT_MAIL_EPOCH:-/1}"
+git_remote="${GITGIT_GIT_REMOTE:-https://github.com/gitgitgadget/git}"
+
 update_mail_archive_dir () {
 	test -d "$LORE_GIT_DIR" ||
-	git clone --bare https://dev.azure.com/gitgitgadget/git/_git/lore-git "$LORE_GIT_DIR" ||
-	die "Could not clone lore.kernel/git to $LORE_GIT_DIR"
+	git clone --bare $mail_repo "$LORE_GIT_DIR" ||
+	die "Could not clone $mail_repo to $LORE_GIT_DIR"
 
-	git -C "$LORE_GIT_DIR" fetch https://lore.kernel.org/git/1 master:master ||
+	git -C "$LORE_GIT_DIR" fetch $mail_remote$mail_epoch master:master ||
 	die "Could not update $LORE_GIT_DIR to remote's master"
 
 	head="$(git -C "$LORE_GIT_DIR" rev-parse --verify master)" ||
@@ -57,10 +62,10 @@ update_mail_archive_dir () {
 
 update_gitgit_dir () {
 	test -d "$GITGIT_DIR" ||
-	git clone https://github.com/gitgitgadget/git "$GITGIT_DIR" ||
-	die "Could not clone gitgitgadget/git to $GITGIT_DIR"
+	git clone $git_remote "$GITGIT_DIR" ||
+	die "Could not clone $git_remote to $GITGIT_DIR"
 
-	git -C "$GITGIT_DIR" fetch https://github.com/gitgitgadget/git refs/notes/commit-to-mail:refs/notes/commit-to-mail ||
+	git -C "$GITGIT_DIR" fetch $git_remote refs/notes/commit-to-mail:refs/notes/commit-to-mail ||
 	die "Could not update refs/notes/commit-to-mail"
 
 	if git -C "$GITGIT_DIR" rev-parse --verify refs/remotes/gitster/seen >/dev/null 2>&1
@@ -417,7 +422,7 @@ die "Failed to identify Message-Id for $1: $messageid"
 case $mode in
 print) echo $messageid;;
 open)
-	url=https://lore.kernel.org/git/$messageid
+	url=$mail_remote/$messageid
 	case "$(uname -s)" in
 	Linux) xdg-open "$url";;
 	MINGW*|MSYS*) start "$url";;

--- a/script/search-commit-on-mail-archive.sh
+++ b/script/search-commit-on-mail-archive.sh
@@ -1,26 +1,27 @@
 #!/bin/sh
+mail_remote="${GITGIT_MAIL_REMOTE:-https://lore.kernel.org/git}"
 
 for c in "$@"
 do
-	m="$(curl -s https://lore.kernel.org/git/?q="$(git show --format=%aI\ %s -s $c |
+	m="$(curl -s $mail_remote/?q="$(git show --format=%aI\ %s -s $c |
 		sed -e 's/^\(....\)-\(..\)-\(..\)[^ ]* \(.*\)/d%3A\1\2\3..\1\2\3+s%3A%22\4%22/' -e 'y/ /+/')" |
 		grep -v '\[PATCH 0*/' |
 		sed -n '/Search results/,/^Archives are clon/s/^href="\([^"?][^"]*\)\/">\([^<]*\).*/\1 \2/p')"
 
 	test -n "$m" ||
-	m="$(curl -s https://lore.kernel.org/git/?q="$(git show --format=%aI\ %s -s $c |
+	m="$(curl -s $mail_remote/?q="$(git show --format=%aI\ %s -s $c |
 		sed -e 's/^[^ ]* \(.*\)/s%3A%22\1%22/' -e 'y/ /+/')" |
 		grep -v '\[PATCH 0*/' |
 		sed -n '/Search results/,/^Archives are clon/s/^href="\([^"?][^"]*\)\/">\([^<]*\).*/\1 \2/p')"
 
 	test -n "$m" ||
-	m="$(curl -s https://lore.kernel.org/git/?q="$(git show --format=%aI\ %s -s $c |
+	m="$(curl -s $mail_remote/?q="$(git show --format=%aI\ %s -s $c |
 		sed -e 's/^\(....\)-\(..\)-\(..\)[^ ]* \(.*\)/d%3A\1\2\3..\1\2\3+\4/' -e 'y/ /+/')" |
 		grep -v '\[PATCH 0*/' |
 		sed -n '/Search results/,/^Archives are clon/s/^href="\([^"?][^"]*\)\/">\([^<]*\).*/\1 \2/p')"
 
 	test -n "$m" ||
-	m="$(curl -s https://lore.kernel.org/git/?q="$(git show --format=%aI\ %s -s $c |
+	m="$(curl -s $mail_remote/?q="$(git show --format=%aI\ %s -s $c |
 		sed -e 's/^[^ ]* //' -e 'y/ /+/')" |
 		grep -v '\[PATCH 0*/' |
 		sed -n '/Search results/,/^Archives are clon/s/^href="\([^"?][^"]*\)\/">\([^<]*\).*/\1 \2/p')"
@@ -51,6 +52,6 @@ do
 		printf '\t\t%s) echo %s; continue;;\n' "$c" "${m2%% *}"
 	else
 		echo "Multiple candidates for $c ($(git show -s --format=%an:\ %s $c)):"
-		echo "$m" | sed 's|^|https://lore.kernel.org/git/|'
+		echo "$m" | sed 's|^|$mail_remote/|'
 	fi
 done

--- a/script/update-mail-to-commit-notes.sh
+++ b/script/update-mail-to-commit-notes.sh
@@ -16,13 +16,14 @@ die () {
 
 test -n "$GITGIT_DIR" ||
 GITGIT_DIR="$(dirname "$0")/../.git/git-worktree"
+git_remote="${GITGIT_GIT_REMOTE:-https://github.com/gitgitgadget/git}"
 
 update_gitgit_dir () {
 	test -d "$GITGIT_DIR" ||
-	git clone https://github.com/gitgitgadget/git "$GITGIT_DIR" ||
-	die "Could not clone gitgitgadget/git to $GITGIT_DIR"
+	git clone $git_remote "$GITGIT_DIR" ||
+	die "Could not clone $gitremote to $GITGIT_DIR"
 
-	git -C "$GITGIT_DIR" fetch https://github.com/gitgitgadget/git \
+	git -C "$GITGIT_DIR" fetch $git_remote \
 		refs/notes/mail-to-commit:refs/notes/mail-to-commit ||
 	die "Could not update notes"
 }


### PR DESCRIPTION
Added:
GITGIT_MAIL_REPO used for bare clone
GITGIT_MAIL_REMOTE used for fetching mail
GITGIT_MAIL_EPOCH epoch for fetching mail (if applicable)
GITGIT_GIT_REMOTE remote for fetching notes

This does not address numerous git specific commits in `lookup-commit`.

All the scripts were run.  `lookup-commit` and `search-commit-on-mail-archive`  seemed to work consistently (once I figured out parms and setup).  A second run of `update-mail-to-commit-notes` dies with `Could not determine range start` after
```
fatal: ambiguous argument 'refs/notes/commit-to-mail^{/Update from commit range "6b313e3fe06fe34b62217a848a58fb0e5b7bab80..9e835a8bdafce2aaeb6df5f57f11014051bbfdca"}': unknown revision or path not in the working tree.
```
Not sure what is supposed to happen here.
