### PR TITLE
dry part 3: more prep for using generic config

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -121,7 +121,7 @@ export class CIHelper {
         await this.notes.set(messageID, mailMeta, true);
 
         if (!this.testing && mailMeta.pullRequestURL && mailMeta.pullRequestURL.startsWith(this.urlBase) ) {
-            await this.github.annotateCommit(mailMeta.originalCommit, upstreamCommit, "gitgitgadget");
+            await this.github.annotateCommit(mailMeta.originalCommit, upstreamCommit, "gitgitgadget", "git");
         }
 
         return true;

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -757,6 +757,11 @@ export class CIHelper {
     private async getPRInfo(prKey: pullRequestKey): Promise<IPullRequestInfo> {
         const pr = await this.github.getPRInfo(prKey);
 
+        if (!new Set(["gitgitgadget", "dscho", "git"]).has(pr.baseOwner) ||
+            pr.baseRepo !== "git") {
+            throw new Error(`Unsupported repository: ${pr.pullRequestURL}`);
+        }
+
         if (!pr.baseLabel || !pr.baseCommit || !pr.headLabel || !pr.headCommit) {
             throw new Error(`Could not determine PR details for ${pr.pullRequestURL}`);
         }

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -45,7 +45,7 @@ export class CIHelper {
         this.gggNotesUpdated = !!skipUpdate;
         this.mail2commit = new MailCommitMapping(this.notes.workDir);
         this.mail2CommitMapUpdated = !!skipUpdate;
-        this.github = new GitHubGlue(workDir);
+        this.github = new GitHubGlue(workDir, "git");
         this.testing = false;
         this.urlBase = `https://github.com/gitgitgadget/`;
         this.urlRepo = `${this.urlBase}git/`;

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -252,11 +252,6 @@ export class GitGitGadget {
                                send: SendFunction):
         Promise<IPatchSeriesMetadata | undefined> {
 
-        if (!new Set(["gitgitgadget", "dscho", "git"]).has(pr.baseOwner) ||
-            pr.baseRepo !== "git") {
-            throw new Error(`Unsupported repository: ${pr.pullRequestURL}`);
-        }
-
         // get metadata in work repo
         const metadata =
             await this.notes.get<IPatchSeriesMetadata>(pr.pullRequestURL);

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -61,7 +61,7 @@ export class GitHubGlue {
     }
 
     public async annotateCommit(originalCommit: string, gitGitCommit: string,
-                                repositoryOwner: string): Promise<number> {
+                                repositoryOwner: string, baseOwner: string): Promise<number> {
         const output =
             await git(["show", "-s", "--format=%h %cI", gitGitCommit],
                       { workDir: this.workDir });
@@ -70,7 +70,7 @@ export class GitHubGlue {
             throw new Error(`Could not find ${gitGitCommit}: '${output}'`);
         }
         const [, short, completedAt] = match;
-        const url = `https://github.com/git/git/commit/${gitGitCommit}`;
+        const url = `https://github.com/${baseOwner}/${this.repo}/commit/${gitGitCommit}`;
 
         await this.ensureAuthenticated(repositoryOwner);
         const checks = await this.client.rest.checks.create({
@@ -80,9 +80,8 @@ export class GitHubGlue {
             head_sha: originalCommit,
             name: "upstream commit",
             output: {
-                summary: `Integrated into git.git as [${
-                    short}](${url}).`,
-                title: `In git.git: ${short}`,
+                summary: `Integrated into ${baseOwner}.${this.repo} as [${short}](${url}).`,
+                title: `In ${baseOwner}.${this.repo}: ${short}`,
             },
             owner: repositoryOwner,
             repo: this.repo,

--- a/lib/patch-series-metadata.ts
+++ b/lib/patch-series-metadata.ts
@@ -1,6 +1,3 @@
-export type GitGitIntegrationBranch =
-    "maint" | "master" | "next" | "seen" | "pu";
-
 export interface IPatchSeriesMetadata {
     readonly pullRequestURL?: string;
     baseCommit: string;

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -245,8 +245,7 @@ async function getCIHelper(): Promise<CIHelper> {
         const gitGitCommit = commander.args[2];
 
         const glue = new GitHubGlue(ci.workDir);
-        const id = await glue.annotateCommit(originalCommit, gitGitCommit,
-                                             "gitgitgadget");
+        const id = await glue.annotateCommit(originalCommit, gitGitCommit, "gitgitgadget", "git");
         console.log(`Created check with id ${id}`);
     } else if (command === "identify-merge-commit") {
         if (commander.args.length !== 3) {

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -72,7 +72,7 @@ async function getCIHelper(): Promise<CIHelper> {
             process.exit(1);
         }
 
-        const gitHub = new GitHubGlue(ci.workDir);
+        const gitHub = new GitHubGlue(ci.workDir, "git");
 
         const options = await ci.getGitGitGadgetOptions();
         let optionsChanged = false;
@@ -244,7 +244,7 @@ async function getCIHelper(): Promise<CIHelper> {
         const originalCommit = commander.args[1];
         const gitGitCommit = commander.args[2];
 
-        const glue = new GitHubGlue(ci.workDir);
+        const glue = new GitHubGlue(ci.workDir, "git");
         const id = await glue.annotateCommit(originalCommit, gitGitCommit, "gitgitgadget", "git");
         console.log(`Created check with id ${id}`);
     } else if (command === "identify-merge-commit") {


### PR DESCRIPTION
### cihelper: validate owner/repo before submission

Moving from GitGitGadget::genAndSend.  It is more consistent with other checks being done at that layer.

### patch-series-meta-data: remove unused type

The type will resurface as part of configuration.

### githubglue::constructor - pass repo name as needed

While the default would be okay in these cases, specifying the name makes it clear this will need to specify a custom name to support other projects.

### githubglue::annotateCommit: add baseOwner parm

This additional parm (combined with changes to always specify the repo on the constructor) makes GitHubGlue generic.

### code compaction: remove many remaining line wraps

An initial cleanup of ci-helper.