### PR TITLE
dry part 4a: more code reduction

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,11 +13,11 @@
                 // "--nolazy",
             ],
             "args": [
-                "${workspaceRoot}/node_modules/jest/bin/jest.js",
+                "${workspaceFolder}/node_modules/jest/bin/jest.js",
                 "--runInBand",
             ],
             "stopOnEntry": false,
-            "cwd": "${workspaceRoot}",
+            "cwd": "${workspaceFolder}",
             "preLaunchTask": null,
             "runtimeExecutable": null,
             "env": {
@@ -26,8 +26,32 @@
             "console": "integratedTerminal",
             "sourceMaps": true,
             "outFiles": [
-                "${workspaceRoot}/build/**/*.js"
+                "${workspaceFolder}/build/**/*.js",
+                "${workspaceFolder}/tests/*.js"
             ]
+        },
+        {
+            "name": "Jest Debug Current File",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+            "args": [
+                "--runInBand",
+                "--cache",
+                "${fileBasename}",
+            ],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "NODE_ENV": "development"
+            },
+            "console": "integratedTerminal",
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/build/**/*.js",
+                "${workspaceFolder}/lib/**/*.js",
+                "${workspaceFolder}/tests/*.js"
+            ],
         }
+
     ]
 }

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -139,9 +139,6 @@ export class CIHelper {
         }
 
         const options = await this.getGitGitGadgetOptions();
-        if (!options) {
-            throw new Error("There were no GitGitGadget options to be found?");
-        }
         if (!options.openPRs) {
             return false;
         }
@@ -237,9 +234,6 @@ export class CIHelper {
      */
     public async handleOpenPRs(): Promise<boolean> {
         const options = await this.getGitGitGadgetOptions();
-        if (!options) {
-            throw new Error("There were no GitGitGadget options to be found?");
-        }
         if (!options.openPRs) {
             return false;
         }
@@ -292,9 +286,6 @@ export class CIHelper {
             updateOptionsInRef = false;
         } else {
             options = await this.getGitGitGadgetOptions();
-            if (!options) {
-                throw new Error("GitGitGadgetOptions not set?!?!?");
-            }
             updateOptionsInRef = true;
         }
 

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -1,13 +1,10 @@
-import {
-    commitExists, git, gitConfig, gitConfigForEach, revParse,
-} from "./git";
+import { commitExists, git, gitConfig, gitConfigForEach, revParse } from "./git";
 
 // For now, only the Git, Cygwin and BusyBox projects are supported
 export class ProjectOptions {
     public static async getBranchName(workDir: string): Promise<string> {
         // Get the current branch name
-        const ref = await git(["rev-parse", "--symbolic-full-name", "HEAD"],
-                              { workDir });
+        const ref = await git(["rev-parse", "--symbolic-full-name", "HEAD"], { workDir });
         const match = ref.match(/^refs\/heads\/(.*)/);
         if (!match) {
             throw new Error("Not on a branch (" + ref + ")?");
@@ -15,26 +12,17 @@ export class ProjectOptions {
         return match[1];
     }
 
-    public static async getLocal(workDir?: string): Promise<ProjectOptions> {
-        if (!workDir) {
-            workDir = ".";
-        }
+    public static async getLocal(workDir = "."): Promise<ProjectOptions> {
         const branchName = await ProjectOptions.getBranchName(workDir);
         const cc = await ProjectOptions.getCc(branchName, workDir);
-        const publishToRemote =
-            await gitConfig("mail.publishtoremote", workDir);
-        const baseBranch =
-            await ProjectOptions.determineBaseBranch(workDir, branchName,
-                                                     publishToRemote);
+        const publishToRemote = await gitConfig("mail.publishtoremote", workDir);
+        const baseBranch = await ProjectOptions.determineBaseBranch(workDir, branchName, publishToRemote);
 
-        return await ProjectOptions.get(workDir, branchName, cc, baseBranch,
-                                        publishToRemote);
+        return await ProjectOptions.get(workDir, branchName, cc, baseBranch, publishToRemote);
     }
 
-    public static async get(workDir: string, branchName: string,
-                            cc: string[], basedOn?: string,
-                            publishToRemote?: string, baseCommit?: string):
-        Promise<ProjectOptions> {
+    public static async get(workDir: string, branchName: string, cc: string[], basedOn?: string,
+                            publishToRemote?: string, baseCommit?: string): Promise<ProjectOptions> {
         let upstreamBranch: string;
         let to: string;
         let midUrlPrefix = " Message-ID: ";
@@ -50,12 +38,10 @@ export class ProjectOptions {
             to = "--to=git@vger.kernel.org";
             // Do *not* Cc: Junio Hamano by default
             upstreamBranch = "upstream/seen";
-            if (await git(["rev-list", branchName + ".." + upstreamBranch],
-                          { workDir })) {
+            if (await git(["rev-list", branchName + ".." + upstreamBranch], { workDir })) {
                 upstreamBranch = "upstream/next";
             }
-            if (await git(["rev-list", branchName + ".." + upstreamBranch],
-                          { workDir })) {
+            if (await git(["rev-list", branchName + ".." + upstreamBranch], { workDir })) {
                 upstreamBranch = "upstream/master";
             }
             midUrlPrefix = "https://lore.kernel.org/git/";
@@ -63,14 +49,12 @@ export class ProjectOptions {
             // Cygwin
             to = "--to=cygwin-patches@cygwin.com";
             upstreamBranch = "cygwin/master";
-            midUrlPrefix = "https://www.mail-archive.com/search?"
-                + "l=cygwin-patches@cygwin.com&q=";
+            midUrlPrefix = "https://www.mail-archive.com/search?l=cygwin-patches@cygwin.com&q=";
         } else if (await commitExists("cc8ed39b240180b5881", workDir)) {
             // BusyBox
             to = "--to=busybox@busybox.net";
             upstreamBranch = "busybox/master";
-            midUrlPrefix = "https://www.mail-archive.com/search?"
-                + "l=busybox@busybox.net&q=";
+            midUrlPrefix = "https://www.mail-archive.com/search?l=busybox@busybox.net&q=";
         } else if (await commitExists("7ccd18012de2e6c47e5", workDir)) {
             // We're running in the test suite!
             to = "--to=reviewer@example.com";
@@ -85,23 +69,17 @@ export class ProjectOptions {
         }
 
         if (!baseCommit &&
-            await git(["rev-list", branchName + ".." + upstreamBranch],
-                      { workDir })) {
-            throw new Error(`Branch ${branchName} is not rebased to ${
-                upstreamBranch}`);
+            await git(["rev-list", branchName + ".." + upstreamBranch], { workDir })) {
+            throw new Error(`Branch ${branchName} is not rebased to ${upstreamBranch}`);
         }
 
-        return new ProjectOptions(branchName, upstreamBranch, basedOn,
-                                  publishToRemote, to, cc, midUrlPrefix,
+        return new ProjectOptions(branchName, upstreamBranch, basedOn, publishToRemote, to, cc, midUrlPrefix,
                                   workDir, baseCommit);
     }
 
-    protected static async determineBaseBranch(workDir: string,
-                                               branchName: string,
-                                               publishToRemote?: string):
+    protected static async determineBaseBranch(workDir: string, branchName: string, publishToRemote?: string):
         Promise<string | undefined> {
-        const basedOn =
-            await gitConfig(`branch.${branchName}.basedon`, workDir);
+        const basedOn = await gitConfig(`branch.${branchName}.basedon`, workDir);
         if (!basedOn || !await commitExists(basedOn, workDir)) {
             return undefined;
         }
@@ -115,18 +93,15 @@ export class ProjectOptions {
             throw new Error(`${basedOn} not pushed to ${publishToRemote}`);
         }
 
-        const commit = await git(["rev-parse", "-q", "--verify", remoteRef],
-                                 { workDir });
+        const commit = await git(["rev-parse", "-q", "--verify", remoteRef], { workDir });
         if (await git(["rev-parse", basedOn]) !== commit) {
-            throw new Error(`${basedOn} on ${publishToRemote
-                } disagrees with local branch`);
+            throw new Error(`${basedOn} on ${publishToRemote} disagrees with local branch`);
         }
 
         return basedOn;
     }
 
-    protected static async getCc(branchName: string, workDir: string):
-        Promise<string[]> {
+    protected static async getCc(branchName: string, workDir: string): Promise<string[]> {
         // Cc: from config
         const cc: string[] = [];
         const forEach = (email: string): void => {
@@ -149,10 +124,8 @@ export class ProjectOptions {
     public readonly cc: string[];
     public readonly midUrlPrefix: string;
 
-    protected constructor(branchName: string, upstreamBranch: string,
-                          basedOn: string | undefined,
-                          publishToRemote: string | undefined,
-                          to: string, cc: string[], midUrlPrefix: string,
+    protected constructor(branchName: string, upstreamBranch: string, basedOn: string | undefined,
+                          publishToRemote: string | undefined, to: string, cc: string[], midUrlPrefix: string,
                           workDir: string, baseCommit?: string) {
         this.branchName = branchName;
         this.upstreamBranch = upstreamBranch;


### PR DESCRIPTION
### code compaction: remove line wraps

Cleanup of project-options.

###  ci-helper: remove redundant check for options

`getGitGitGadgetOptions()` will throw an error if there are no     options so no need to check on the return.

### debug: add config to jest debug current file 

Provide ability to set breakpoint in current test file and start debugging using a test run on that file.

Added source directories to search because ts-jest appears to build there.

Renamed workspaceRoot to workspaceFolder (deprecated).