### PR TITLE
ci(approve): add the required permissions

### DIFF
--- a/.github/workflows/auto-approve-dependabot-prs.yml
+++ b/.github/workflows/auto-approve-dependabot-prs.yml
@@ -2,6 +2,9 @@ name: Auto-approve Dependabot Pull Requests
 
 on: [pull_request_target]
 
+permissions:
+  pull-requests: write
+
 jobs:
   auto-approve:
     if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'


### PR DESCRIPTION
This fixes the permissions of the Dependabot PR auto-approver, so that we can re-enable it again.