### PR TITLE
generalize: enable gitgitgadget use in other projects

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -754,7 +754,8 @@ export class CIHelper {
                 return !match ? false : onlyPRs.has(parseInt(match[1], 10));
             };
         await this.maybeUpdateGGGNotes();
-        const mailArchiveGit = await MailArchiveGitHelper.get(this.notes, mailArchiveGitDir, this.github);
+        const mailArchiveGit = await MailArchiveGitHelper.get(this.notes, mailArchiveGitDir, this.github,
+            this.config.mailrepo.branch);
         return await mailArchiveGit.processMails(prFilter);
     }
 

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -10,6 +10,7 @@ import { MailArchiveGitHelper } from "./mail-archive-helper";
 import { MailCommitMapping } from "./mail-commit-mapping";
 import { IMailMetadata } from "./mail-metadata";
 import { IPatchSeriesMetadata } from "./patch-series-metadata";
+import { IConfig, getConfig } from "./project-config";
 import { getPullRequestKeyFromURL, pullRequestKey } from "./pullRequestKey";
 
 const readFile = util.promisify(fs.readFile);
@@ -23,6 +24,7 @@ type CommentFunction = (comment: string) => Promise<void>;
  * commit.
  */
 export class CIHelper {
+    public readonly config: IConfig = getConfig();
     public readonly workDir?: string;
     public readonly notes: GitNotes;
     public readonly urlBase: string;
@@ -34,9 +36,7 @@ export class CIHelper {
     protected testing: boolean;
     private gggNotesUpdated: boolean;
     private mail2CommitMapUpdated: boolean;
-    protected maxCommitsExceptions = new Set([
-        "https://github.com/gitgitgadget/git/pull/923"
-    ]);
+    protected maxCommitsExceptions: string[];
 
     public constructor(workDir?: string, skipUpdate?: boolean, gggConfigDir = ".") {
         this.gggConfigDir = gggConfigDir;
@@ -47,8 +47,9 @@ export class CIHelper {
         this.mail2CommitMapUpdated = !!skipUpdate;
         this.github = new GitHubGlue(workDir, "git");
         this.testing = false;
-        this.urlBase = `https://github.com/gitgitgadget/`;
-        this.urlRepo = `${this.urlBase}git/`;
+        this.maxCommitsExceptions = this.config.lint?.maxCommitsIgnore || [];
+        this.urlBase = `https://github.com/${this.config.repo.owner}/`;
+        this.urlRepo = `${this.urlBase}${this.config.repo.name}/`;
     }
 
     /*
@@ -95,7 +96,7 @@ export class CIHelper {
      * is one, and if it was not yet recorded in GitGitGadget's metadata, record
      * it and create a GitHub Commit Status.
      *
-     * @returns `true` iff the metadata had to be updated
+     * @returns `true` if the metadata had to be updated
      */
     public async updateCommitMapping(messageID: string, upstreamCommit?: string): Promise<boolean> {
         await this.maybeUpdateGGGNotes();
@@ -121,7 +122,8 @@ export class CIHelper {
         await this.notes.set(messageID, mailMeta, true);
 
         if (!this.testing && mailMeta.pullRequestURL && mailMeta.pullRequestURL.startsWith(this.urlBase) ) {
-            await this.github.annotateCommit(mailMeta.originalCommit, upstreamCommit, "gitgitgadget", "git");
+            await this.github.annotateCommit(mailMeta.originalCommit, upstreamCommit,
+                this.config.repo.owner, this.config.repo.baseOwner);
         }
 
         return true;
@@ -129,11 +131,15 @@ export class CIHelper {
 
     public async updateCommitMappings(): Promise<boolean> {
         if (!this.gggNotesUpdated) {
-            await git(["fetch", this.urlRepo,
-                       "--tags",
+            const args = [];
+
+            for (const branch of this.config.repo.branches) {
+                args.push(`refs/heads/${branch}:refs/remotes/upstream/${branch}`);
+            }
+
+            await git(["fetch", this.urlRepo, "--tags",
                        "+refs/notes/gitgitgadget:refs/notes/gitgitgadget",
-                       "+refs/heads/maint:refs/remotes/upstream/maint",
-                       "+refs/heads/seen:refs/remotes/upstream/seen"],
+                       ...args],
                       { workDir: this.workDir });
             this.gggNotesUpdated = true;
         }
@@ -309,24 +315,28 @@ export class CIHelper {
 
         const prKey = getPullRequestKeyFromURL(pullRequestURL);
 
-        // Identify branch in gitster/git
+        // Identify branch in maintainer repo
+        const maintainerBranch = `refs/remotes/${this.config.repo.maintainerBranch}/`;
+        const maintainerRepo = `${this.config.repo.maintainerBranch}.${this.config.repo.name}`;
+
         let gitsterBranch: string | undefined =
             await git(["for-each-ref", `--points-at=${tipCommitInGitGit}`,
-                       "--format=%(refname)", "refs/remotes/gitster/"],
+                       "--format=%(refname)", maintainerBranch],
                       { workDir: this.workDir });
         if (gitsterBranch) {
             const newline = gitsterBranch.indexOf("\n");
             if (newline > 0) {
-                const comment2 = `Found multiple candidates in gitster/git:\n${gitsterBranch};\n\nUsing the first one.`;
+                const comment2 = `Found multiple candidates in ${maintainerRepo}:\n${
+                    gitsterBranch};\n\nUsing the first one.`;
                 const url2 = await this.github.addPRComment(prKey, comment2);
                 console.log(`Added comment about ${gitsterBranch}: ${url2}`);
 
-                gitsterBranch = gitsterBranch.substr(0, newline);
+                gitsterBranch = gitsterBranch.substring(0, newline);
             }
-            gitsterBranch = gitsterBranch.replace(/^refs\/remotes\/gitster\//, "");
+            gitsterBranch = gitsterBranch.substring(maintainerBranch.length);
 
             const comment = `This branch is now known as [\`${gitsterBranch
-                }\`](https://github.com/gitster/git/commits/${gitsterBranch}).`;
+                }\`](https://github.com/${maintainerRepo}/commits/${gitsterBranch}).`;
             if (prMeta.branchNameInGitsterGit !== gitsterBranch) {
                 prMeta.branchNameInGitsterGit = gitsterBranch;
                 notesUpdated = true;
@@ -338,13 +348,13 @@ export class CIHelper {
 
         let closePR: string | undefined;
         const prLabelsToAdd: string[] = [];
-        for (const branch of ["seen", "next", "master", "maint"]) {
+        for (const branch of this.config.repo.trackingBranches) {
             const mergeCommit = await this.identifyMergeCommit(branch, tipCommitInGitGit);
             if (!mergeCommit) {
                 continue;
             }
 
-            if (branch === "master" || branch === "maint") {
+            if (this.config.repo.closingBranches.includes(branch)) {
                 closePR = mergeCommit;
             }
 
@@ -359,8 +369,8 @@ export class CIHelper {
                 prLabelsToAdd.push(branch);
 
                 // Add comment on GitHub
-                const comment = `This patch series was integrated into ${branch
-                    } via https://github.com/git/git/commit/${mergeCommit}.`;
+                const comment = `This patch series was integrated into ${branch} via https://github.com/${
+                    this.config.repo.baseOwner}/${this.config.repo.name}/commit/${mergeCommit}.`;
                 const url = await this.github.addPRComment(prKey, comment);
                 console.log(`Added comment about ${branch}: ${url}`);
             }
@@ -514,11 +524,12 @@ export class CIHelper {
         const argument = match[3];
         const prKey = {
             owner: repositoryOwner,
-            repo: "git",
+            repo: this.config.repo.name,
             pull_number: comment.prNumber
         };
 
-        const pullRequestURL = `https://github.com/${repositoryOwner}/git/pull/${comment.prNumber}`;
+        const pullRequestURL = `https://github.com/${repositoryOwner}/${this.config.repo.name
+            }/pull/${comment.prNumber}`;
         console.log(`Handling command ${command} with argument ${argument} at ${
             pullRequestURL}#issuecomment-${commentID}`);
 
@@ -531,7 +542,7 @@ export class CIHelper {
         try {
             const gitGitGadget = await GitGitGadget.get(this.gggConfigDir, this.workDir);
             if (!gitGitGadget.isUserAllowed(comment.author)) {
-                throw new Error(`User ${comment.author} is not yet permitted to use GitGitGadget`);
+                throw new Error(`User ${comment.author} is not yet permitted to use ${this.config.app.displayName}`);
             }
 
             const getPRAuthor = async (): Promise<string> => {
@@ -560,7 +571,7 @@ export class CIHelper {
                     const metadata = await gitGitGadget.submit(pr, userInfo);
                     const code = "\n```";
                     await addComment(`Submitted as [${metadata?.coverLetterMessageId
-                            }](https://lore.kernel.org/git/${
+                            }](https://${this.config.mailrepo.host}/${this.config.mailrepo.name}/${
                             metadata?.coverLetterMessageId})\n\nTo fetch this version into \`FETCH_HEAD\`:${
                             code}\ngit fetch ${this.urlRepo} ${metadata?.latestTag}${code
                             }\n\nTo fetch this version to local tag \`${metadata?.latestTag}\`:${
@@ -600,17 +611,18 @@ export class CIHelper {
                 }
 
                 if (await gitGitGadget.allowUser(comment.author, accountName)) {
-                    await addComment(`User ${accountName} is now allowed to use GitGitGadget.${extraComment}`);
+                    await addComment(`User ${accountName} is now allowed to use ${this.config.app.displayName}.${
+                        extraComment}`);
                 } else {
-                    await addComment(`User ${accountName} already allowed to use GitGitGadget.`);
+                    await addComment(`User ${accountName} already allowed to use ${this.config.app.displayName}.`);
                 }
             } else if (command === "/disallow") {
                 const accountName = argument || await getPRAuthor();
 
                 if (await gitGitGadget.denyUser(comment.author, accountName)) {
-                    await addComment(`User ${accountName} is no longer allowed to use GitGitGadget.`);
+                    await addComment(`User ${accountName} is no longer allowed to use ${this.config.app.displayName}.`);
                 } else {
-                    await addComment(`User ${accountName} already not allowed to use GitGitGadget.`);
+                    await addComment(`User ${accountName} already not allowed to use ${this.config.app.displayName}.`);
                 }
             } else if (command === "/cc") {
                 await this.handleCC(argument, prKey);
@@ -628,8 +640,9 @@ export class CIHelper {
     public async checkCommits(pr: IPullRequestInfo, addComment: CommentFunction, userInfo?: IGitHubUser):
         Promise<boolean> {
         let result = true;
-        const maxCommits = 30;
-        if (!this.maxCommitsExceptions.has(pr.pullRequestURL) &&
+        const maxCommits = this.config.lint.maxCommits;
+
+        if (!this.maxCommitsExceptions.includes(pr.pullRequestURL) &&
             pr.commits && pr.commits > maxCommits) {
             await addComment(`The pull request has ${pr.commits} commits.  The max allowed is ${maxCommits
                              }.  Please split the patch series into multiple pull requests. Also consider ${
@@ -748,8 +761,8 @@ export class CIHelper {
     private async getPRInfo(prKey: pullRequestKey): Promise<IPullRequestInfo> {
         const pr = await this.github.getPRInfo(prKey);
 
-        if (!new Set(["gitgitgadget", "dscho", "git"]).has(pr.baseOwner) ||
-            pr.baseRepo !== "git") {
+        if (!this.config.repo.owners.includes(pr.baseOwner) ||
+            pr.baseRepo !== this.config.repo.name) {
             throw new Error(`Unsupported repository: ${pr.pullRequestURL}`);
         }
 
@@ -771,6 +784,11 @@ export class CIHelper {
     private async getUserInfo(author: string): Promise<IGitHubUser> {
         const userInfo = await this.github.getGitHubUserInfo(author);
         if (!userInfo.name) {
+            if (this.config.user.allowUserAsLogin) {
+                userInfo.name = userInfo.login;
+            } else {
+                throw new Error(`Could not determine full name of ${author}`);
+            }
             throw new Error(`Could not determine full name of ${author}`);
         }
 

--- a/lib/gitgitgadget-config.ts
+++ b/lib/gitgitgadget-config.ts
@@ -15,6 +15,7 @@ const defaultConfig: IConfig = {
     mailrepo: {
         name: "git",
         owner: "gitgitgadget",
+        branch: "master",
         host: "lore.kernel.org",
     },
     mail: {

--- a/lib/gitgitgadget-config.ts
+++ b/lib/gitgitgadget-config.ts
@@ -1,0 +1,48 @@
+import { IConfig, setConfig } from "./project-config";
+
+const defaultConfig: IConfig = {
+    repo: {
+        name: "git",
+        owner: "gitgitgadget",
+        baseOwner: "git",
+        owners: ["gitgitgadget", "git", "dscho"],
+        branches: ["maint", "seen"],
+        closingBranches: ["maint", "master"],
+        trackingBranches: ["maint", "seen", "master", "next"],
+        maintainerBranch: "gitster",
+        host: "github.com",
+    },
+    mailrepo: {
+        name: "git",
+        owner: "gitgitgadget",
+        host: "lore.kernel.org",
+    },
+    mail: {
+        author: "GitGitGadget",
+        sender: "GitGitGadget"
+    },
+    app: {
+        appID: 12836,
+        installationID: 195971,
+        name: "gitgitgadget",
+        displayName: "GitGitGadget",
+        altname: "gitgitgadget-git"
+    },
+    lint: {
+        maxCommitsIgnore: [
+            "https://github.com/gitgitgadget/git/pull/923"
+        ],
+        maxCommits: 30,
+    },
+    user: {
+        allowUserAsLogin: false,
+    }
+};
+
+export default defaultConfig;
+
+setConfig(defaultConfig);
+
+export function getConfig(): IConfig {
+    return setConfig(defaultConfig);
+}

--- a/lib/mail-commit-mapping.ts
+++ b/lib/mail-commit-mapping.ts
@@ -1,7 +1,9 @@
 import { git } from "./git";
 import { GitNotes } from "./git-notes";
+import { IConfig, getConfig } from "./project-config";
 
 export class MailCommitMapping {
+    public readonly config: IConfig = getConfig();
     public readonly workDir?: string;
     public readonly mail2CommitNotes: GitNotes;
 
@@ -32,16 +34,16 @@ export class MailCommitMapping {
             refs.push("refs/notes/mail-to-commit:refs/notes/mail-to-commit");
         }
         if (includeUpstreamBranches) {
-            for (const ref of ["seen", "next", "master", "maint"]) {
+            for (const ref of this.config.repo.trackingBranches) {
                 refs.push(`+refs/heads/${ref}:refs/remotes/upstream/${ref}`);
             }
         }
-        if (includeGitsterBranches) {
-            refs.push("+refs/heads/*:refs/remotes/gitster/*");
+        if (includeGitsterBranches && this.config.repo.maintainerBranch) {
+            refs.push(`+refs/heads/*:refs/remotes/${this.config.repo.maintainerBranch}/*`);
         }
         if (refs.length) {
-            await git(["fetch", "https://github.com/gitgitgadget/git", ...refs],
-                      { workDir: this.workDir });
+            await git(["fetch", `https://github.com/${this.config.repo.owner}/${this.config.repo.name}`, ...refs],
+                { workDir: this.workDir });
         }
     }
 }

--- a/lib/project-config.ts
+++ b/lib/project-config.ts
@@ -23,6 +23,7 @@ export interface IConfig {
     mailrepo: {
         name: string;
         owner: string;
+        branch: string;
         host: string;
     },
     mail: {

--- a/lib/project-config.ts
+++ b/lib/project-config.ts
@@ -1,0 +1,100 @@
+import * as fs from "fs";
+import path from "path";
+
+export type projectInfo = {
+    to: string;                     // email to send patches to
+    branch: string;                 // upstream branch a PR must be based on
+    cc: string[];                   // emails to always be copied on patches
+    urlPrefix: string;              // url to 'listserv' of mail (should it be in mailrepo?)
+};
+
+export interface IConfig {
+    repo: {
+        name: string;               // name of the repo
+        owner: string;              // owner of repo holding the notes (tracking data)
+        baseOwner: string;          // owner of base repo
+        owners: string[];           // owners of clones being monitored (PR checking)
+        branches: string[];         // remote branches to fetch - just use trackingBranches?
+        closingBranches: string[];  // close if the pr is added to this branch
+        trackingBranches: string[]; // comment if the pr is added to this branch
+        maintainerBranch?: string;  // branch/owner manually implementing changes
+        host: string;
+    },
+    mailrepo: {
+        name: string;
+        owner: string;
+        host: string;
+    },
+    mail: {
+        author: string;
+        sender: string;
+    },
+    project?: projectInfo | undefined, // project-options values
+    app: {
+        appID: number;
+        installationID: number;
+         name: string;
+         displayName: string;           // name to use in comments to identify app
+         altname: string | undefined;   // is this even needed?
+    },
+    lint: {
+        maxCommitsIgnore?: string[];    // array of pull request urls to skip check
+        maxCommits: number;             // limit on number of commits in a pull request
+    },
+    user: {
+        allowUserAsLogin: boolean;      // use GitHub login as name if name is private
+    }
+};
+
+let config: IConfig;                // singleton
+
+/**
+ * Query to get the current configuration.
+ *
+ * @returns IConfig interface
+ */
+export function getConfig(): IConfig {
+    if (config === undefined) {
+        throw new Error("project-config not set");
+    }
+
+    return config;
+}
+
+type importedConfig = { default: IConfig; }
+
+/**
+ * Load a config.  The config may be a javascript file (plain or generated
+ * from typescript) or a json file (with a .json extension).
+ *
+ * @param file fully qualified filename and path
+ * @returns IConfig interface
+ */
+export async function loadConfig(file: string): Promise<IConfig> {
+    let loadedConfig: IConfig;
+
+    if (path.extname(file) === ".js") {
+        const { default: newConfig } = (await import(file)) as importedConfig;
+        loadedConfig = newConfig;
+    } else {
+        const fileText = fs.readFileSync(file, {encoding: "utf-8"});
+        loadedConfig = JSON.parse(fileText) as IConfig;
+    }
+
+    if (loadedConfig === undefined) {
+        throw new Error("project-config not set");
+    }
+
+    return loadedConfig;
+}
+
+/**
+ * Set/update the configuration.
+ *
+ * @param newConfig configuration to be set
+ * @returns current IConfig interface
+ */
+export function setConfig(newConfig: IConfig): IConfig {
+    config = newConfig;
+    return config;
+}

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -1,4 +1,5 @@
 import { commitExists, git, gitConfig, gitConfigForEach, revParse } from "./git";
+import { IConfig, getConfig, projectInfo } from "./project-config";
 
 // For now, only the Git, Cygwin and BusyBox projects are supported
 export class ProjectOptions {
@@ -23,11 +24,20 @@ export class ProjectOptions {
 
     public static async get(workDir: string, branchName: string, cc: string[], basedOn?: string,
                             publishToRemote?: string, baseCommit?: string): Promise<ProjectOptions> {
+        const config: IConfig = getConfig();
         let upstreamBranch: string;
         let to: string;
         let midUrlPrefix = " Message-ID: ";
 
-        if (await commitExists("cb07fc2a29c86d1bc11", workDir) &&
+        if (config.hasOwnProperty("project")) {
+            const project = config.project as projectInfo;
+            to = `--to=${project.to}`;
+            upstreamBranch = project.branch;
+            midUrlPrefix = project.urlPrefix;
+            for (const user of project.cc) {
+                cc.push(user);
+            }
+        } else if (await commitExists("cb07fc2a29c86d1bc11", workDir) &&
             await revParse(`${baseCommit}:git-gui.sh`, workDir) !== undefined) {
             // Git GUI
             to = "--to=git@vger.kernel.org";

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   "scripts": {
     "build": "tsc",
     "cleanbranch": "node ./build/script/delete-test-branches.js",
-    "lint": "eslint -c .eslintrc.js --ext .ts,.js \"{lib,script,tests}/**/*.{ts,tsx,js}\"",
+    "lint": "eslint -c .eslintrc.js --ext .ts,.js \"{lib,script,tests,tests-config}/**/*.{ts,tsx,js}\"",
     "start": "node server.js",
     "test": "jest --env=node",
+    "test:config": "jest --env=node --testRegex=/tests-config/.*\\.test\\.ts",
     "test:watch": "jest --watch --notify --notifyMode=change --coverage",
     "ci": "npm run lint && jest --env=node --ci --reporters=default --reporters=jest-junit"
   },

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -4,9 +4,12 @@ import { Command } from "commander";
 import { CIHelper } from "../lib/ci-helper";
 import { isDirectory } from "../lib/fs-util";
 import { git, gitConfig } from "../lib/git";
+import { getConfig } from "../lib/gitgitgadget-config";
 import { GitHubGlue } from "../lib/github-glue";
 import { toPrettyJSON } from "../lib/json-util";
 import { IPatchSeriesMetadata } from "../lib/patch-series-metadata";
+import { IConfig, loadConfig, setConfig } from "../lib/project-config";
+import path from "path";
 
 const commander = new Command();
 
@@ -23,11 +26,14 @@ commander.version("1.0.0")
             + "current working directory to access the Git config e.g. for "
             + "`gitgitgadget.workDir`",
             ".")
+    .option("-c, --config <string>",
+            "Use this configuration when using gitgitgadget with a project other than git", "")
     .option("-s, --skip-update",
             "Do not update the local refs (useful for debugging)")
     .parse(process.argv);
 
 interface ICommanderOptions {
+    config: string | undefined;
     gitgitgadgetWorkDir: string | undefined;
     gitWorkDir: string | undefined;
     skipUpdate: boolean | undefined;
@@ -38,6 +44,7 @@ if (commander.args.length === 0) {
 }
 
 const commandOptions = commander.opts<ICommanderOptions>();
+let config: IConfig = getConfig();
 
 async function getGitGitWorkDir(): Promise<string> {
     if (!commandOptions.gitWorkDir) {
@@ -51,7 +58,7 @@ async function getGitGitWorkDir(): Promise<string> {
         console.log(`Cloning git into ${commandOptions.gitWorkDir}`);
         await git([
             "clone",
-            "https://github.com/gitgitgadget/git",
+            `https://github.com/${config.repo.owner}/${config.repo.name}`,
             commandOptions.gitWorkDir,
         ]);
     }
@@ -64,6 +71,11 @@ async function getCIHelper(): Promise<CIHelper> {
 }
 
 (async (): Promise<void> => {
+    if (commandOptions.config) {
+        const newConfig = await loadConfig(path.resolve(commandOptions.config));
+        config = setConfig(newConfig);
+    }
+
     const ci = await getCIHelper();
     const command = commander.args[0];
     if (command === "update-open-prs") {
@@ -87,7 +99,7 @@ async function getCIHelper(): Promise<CIHelper> {
 
         const handledPRs = new Set<string>();
         const handledMessageIDs = new Set<string>();
-        for (const repositoryOwner of ["gitgitgadget", "git", "dscho"]) {
+        for (const repositoryOwner of config.repo.owners) {
             const pullRequests = await gitHub.getOpenPRs(repositoryOwner);
             for (const pr of pullRequests) {
                 const meta = await ci.getPRMetadata(pr.pullRequestURL);
@@ -178,7 +190,7 @@ async function getCIHelper(): Promise<CIHelper> {
     } else if (command === "set-tip-commit-in-git.git") {
         if (commander.args.length !== 3) {
             process.stderr.write(`${command}: needs 2 parameters:${
-                "\n"}PR URL and tip commit in git.git`);
+                "\n"}PR URL and tip commit in ${config.repo.baseOwner}.${config.repo.name}`);
             process.exit(1);
         }
         const pullRequestURL = commander.args[1];
@@ -236,8 +248,8 @@ async function getCIHelper(): Promise<CIHelper> {
         console.log(`Result: ${result}`);
     } else if (command === "annotate-commit") {
         if (commander.args.length !== 3) {
-            process.stderr.write(`${command}: needs 2 parameters: ${
-                ""}original and git.git commit\n`);
+            process.stderr.write(`${command}: needs 2 parameters: original and ${
+                config.repo.baseOwner}.${config.repo.name} commit\n`);
             process.exit(1);
         }
 
@@ -245,7 +257,7 @@ async function getCIHelper(): Promise<CIHelper> {
         const gitGitCommit = commander.args[2];
 
         const glue = new GitHubGlue(ci.workDir, "git");
-        const id = await glue.annotateCommit(originalCommit, gitGitCommit, "gitgitgadget", "git");
+        const id = await glue.annotateCommit(originalCommit, gitGitCommit, config.repo.owner, config.repo.baseOwner);
         console.log(`Created check with id ${id}`);
     } else if (command === "identify-merge-commit") {
         if (commander.args.length !== 3) {
@@ -275,29 +287,24 @@ async function getCIHelper(): Promise<CIHelper> {
         console.log(toPrettyJSON(await ci.getMailMetadata(messageID)));
     } else if (command === "get-pr-meta") {
         if (commander.args.length !== 2 && commander.args.length !== 3) {
-            process.stderr.write(`${command}: need a repository owner and ${
-                                 ""}a Pull Request number\n`);
+            process.stderr.write(`${command}: need a repository owner and a Pull Request number\n`);
             process.exit(1);
         }
-        const repositoryOwner = commander.args.length === 3 ?
-            commander.args[1] : "gitgitgadget";
+        const repositoryOwner = commander.args.length === 3 ? commander.args[1] : config.repo.owner;
         const prNumber = commander.args[commander.args.length === 3 ? 2 : 1];
 
         const pullRequestURL = prNumber.match(/^http/) ? prNumber :
-            `https://github.com/${repositoryOwner}/git/pull/${prNumber}`;
+            `https://github.com/${repositoryOwner}/${config.repo.name}/pull/${prNumber}`;
         console.log(toPrettyJSON(await ci.getPRMetadata(pullRequestURL)));
     } else if (command === "get-pr-commits") {
         if (commander.args.length !== 2 && commander.args.length !== 3) {
-            process.stderr.write(`${command}: need a repository owner and ${
-                                 ""}a Pull Request number\n`);
+            process.stderr.write(`${command}: need a repository owner and a Pull Request number\n`);
             process.exit(1);
         }
-        const repositoryOwner = commander.args.length === 3 ?
-            commander.args[1] : "gitgitgadget";
+        const repositoryOwner = commander.args.length === 3 ? commander.args[1] : config.repo.owner;
         const prNumber = commander.args[commander.args.length === 3 ? 2 : 1];
 
-        const pullRequestURL =
-            `https://github.com/${repositoryOwner}/git/pull/${prNumber}`;
+        const pullRequestURL = `https://github.com/${repositoryOwner}/${config.repo.name}/pull/${prNumber}`;
         const prMeta = await ci.getPRMetadata(pullRequestURL);
         if (!prMeta) {
             throw new Error(`No metadata found for ${pullRequestURL}`);
@@ -305,16 +312,13 @@ async function getCIHelper(): Promise<CIHelper> {
         console.log(toPrettyJSON(await ci.getOriginalCommitsForPR(prMeta)));
     } else if (command === "handle-pr") {
         if (commander.args.length !== 2 && commander.args.length !== 3) {
-            process.stderr.write(`${command}: need a repository owner and ${
-                                 ""}a Pull Request number\n`);
+            process.stderr.write(`${command}: need a repository owner and a Pull Request number\n`);
             process.exit(1);
         }
-        const repositoryOwner = commander.args.length === 3 ?
-            commander.args[1] : "gitgitgadget";
+        const repositoryOwner = commander.args.length === 3 ? commander.args[1] : config.repo.owner;
         const prNumber = commander.args[commander.args.length === 3 ? 2 : 1];
 
-        const pullRequestURL =
-            `https://github.com/${repositoryOwner}/git/pull/${prNumber}`;
+        const pullRequestURL = `https://github.com/${repositoryOwner}/${config.repo.name}/pull/${prNumber}`;
 
         const meta = await ci.getPRMetadata(pullRequestURL);
         if (!meta) {
@@ -370,7 +374,7 @@ async function getCIHelper(): Promise<CIHelper> {
             process.exit(1);
         }
         const pullRequestURL = commander.args[1].match(/^[0-9]+$/) ?
-            `https://github.com/gitgitgadget/git/pull/${commander.args[1]}` :
+            `https://github.com/gitgitgadget/${config.repo.name}/pull/${commander.args[1]}` :
             commander.args[1];
         const comment = commander.args[2];
 
@@ -382,8 +386,7 @@ async function getCIHelper(): Promise<CIHelper> {
              installationID?: number;
              name: string;
         }): Promise<void> => {
-            const appName = options.name === "gitgitgadget" ?
-                "gitgitgadget" : "gitgitgadget-git";
+            const appName = options.name === config.app.name ? config.app.name : config.app.altname;
             const key = await gitConfig(`${appName}.privateKey`);
             if (!key) {
                 throw new Error(`Need the ${appName} App's private key`);
@@ -401,50 +404,42 @@ async function getCIHelper(): Promise<CIHelper> {
                 options.installationID =
                     (await client.rest.apps.getRepoInstallation({
                         owner: options.name,
-                        repo: "git",
+                        repo: config.repo.name,
                 })).data.id;
             }
             const result = await client.rest.apps.createInstallationAccessToken(
                 {
                     installation_id: options.installationID,
                 });
-            const configKey = options.name === "gitgitgadget" ?
-                "gitgitgadget.githubToken" :
-                `gitgitgadget.${options.name}.githubToken`;
+            const configKey = options.name === config.app.name ?
+                `${config.app.name}.githubToken` : `gitgitgadget.${options.name}.githubToken`;
             await git(["config", configKey, result.data.token]);
         };
 
-        await set({appID: 12836, installationID: 195971, name: "gitgitgadget"});
+        await set(config.app);
         for (const org of commander.args.slice(1)) {
             await set({ appID: 46807, name: org});
         }
     } else if (command === "handle-pr-comment") {
         if (commander.args.length !== 2 && commander.args.length !== 3) {
-            process.stderr.write(`${command}: optionally takes  a ${
-                                 ""}repository owner and one comment ID\n`);
+            process.stderr.write(`${command}: optionally takes a repository owner and one comment ID\n`);
             process.exit(1);
         }
-        const repositoryOwner = commander.args.length === 3 ?
-            commander.args[1] : "gitgitgadget";
-        const commentID =
-            parseInt(commander.args[commander.args.length === 3 ? 2 : 1], 10);
+        const repositoryOwner = commander.args.length === 3 ? commander.args[1] : config.repo.owner;
+        const commentID = parseInt(commander.args[commander.args.length === 3 ? 2 : 1], 10);
 
         await ci.handleComment(repositoryOwner, commentID);
     } else if (command === "handle-pr-push") {
         if (commander.args.length !== 2 && commander.args.length !== 3) {
-            process.stderr.write(`${command}: optionally takes a repository ${
-                                 ""}owner and a Pull Request number\n`);
+            process.stderr.write(`${command}: optionally takes a repository owner and a Pull Request number\n`);
             process.exit(1);
         }
-        const repositoryOwner = commander.args.length === 3 ?
-            commander.args[1] : "gitgitgadget";
-        const prNumber =
-            parseInt(commander.args[commander.args.length === 3 ? 2 : 1], 10);
+        const repositoryOwner = commander.args.length === 3 ? commander.args[1] : config.repo.owner;
+        const prNumber = parseInt(commander.args[commander.args.length === 3 ? 2 : 1], 10);
 
         await ci.handlePush(repositoryOwner, prNumber);
     } else if (command === "handle-new-mails") {
-        const mailArchiveGitDir =
-            await gitConfig("gitgitgadget.loreGitDir");
+        const mailArchiveGitDir = await gitConfig("gitgitgadget.loreGitDir");
         if (!mailArchiveGitDir) {
             process.stderr.write("Need a lore.kernel/git worktree");
             process.exit(1);
@@ -453,8 +448,7 @@ async function getCIHelper(): Promise<CIHelper> {
         for (const arg of commander.args.slice(1)) {
             onlyPRs.add(parseInt(arg, 10));
         }
-        await ci.handleNewMails(mailArchiveGitDir,
-                                onlyPRs.size ? onlyPRs : undefined);
+        await ci.handleNewMails(mailArchiveGitDir, onlyPRs.size ? onlyPRs : undefined);
     } else {
         process.stderr.write(`${command}: unhandled sub-command\n`);
         process.exit(1);

--- a/tests-config/ci-helper.test.ts
+++ b/tests-config/ci-helper.test.ts
@@ -26,6 +26,7 @@ const testConfig: IConfig = {
     mailrepo: {
         name: "git",
         owner: "gitgitgadget",
+        branch: "main",
         host: "lore.kernel.org",
     },
     mail: {

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -2,12 +2,15 @@ import { expect, jest, test } from "@jest/globals";
 import { git, gitCommandExists } from "../lib/git";
 import { GitNotes } from "../lib/git-notes";
 import { GitGitGadget, IGitGitGadgetOptions } from "../lib/gitgitgadget";
+import { getConfig } from "../lib/gitgitgadget-config";
 import { PatchSeries } from "../lib/patch-series";
 import { IPatchSeriesMetadata } from "../lib/patch-series-metadata";
 import { testCreateRepo } from "./test-lib";
 
 // This test script might take quite a while to run
 jest.setTimeout(60000);
+
+getConfig();
 
 const expectedMails = [
     `From 91fba7811291c1064b2603765a2297c34fc843c0 Mon Sep 17 00:00:00 2001

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -1,9 +1,15 @@
+/* eslint-disable max-classes-per-file */
 import { expect, jest, test } from "@jest/globals";
+import { getConfig } from "../lib/gitgitgadget-config";
 import { git } from "../lib/git";
+import { GitNotes } from "../lib/git-notes";
 import { PatchSeries } from "../lib/patch-series";
+import { ProjectOptions } from "../lib/project-options";
 import { testCreateRepo } from "./test-lib";
 
 jest.setTimeout(60000);
+
+getConfig();
 
 const mbox1 =
     `From 38d1082511bb02a709f203481c2787adc6e67c02 Mon Sep 17 00:00:00 2001
@@ -86,7 +92,23 @@ class PatchSeriesTest extends PatchSeries {
 
         const thisAuthor = "GitGitGadget <gitgitgadget@gmail.com>";
         const senderName = "Nguyễn Thái Ngọc Duy";
-        PatchSeries.insertCcAndFromLines(mails, thisAuthor, senderName);
+        const prMeta = {
+            baseCommit: "",
+            baseLabel: "",
+            headCommit: "",
+            headLabel: "",
+            iteration: 1,
+        };
+        class ProjectOptionsTest extends ProjectOptions {
+            public constructor() {
+                super("", "","","","",[],"","");
+            }
+        }
+
+        const x = new PatchSeriesTest(new GitNotes(), {},
+                new ProjectOptionsTest(), prMeta, "", 1);
+
+        x.insertCcAndFromLines(mails, thisAuthor, senderName);
 
         test("non-ASCII characters are encoded correctly", () => {
             const needle = "\"=?UTF-8?Q?Nguy=E1=BB=85n_Th=C3=A1i_Ng=E1=BB=8Dc?="

--- a/tests/project-options.test.ts
+++ b/tests/project-options.test.ts
@@ -1,12 +1,15 @@
 import { expect, jest, test } from "@jest/globals";
 import { isDirectory } from "../lib/fs-util";
 import { GitNotes } from "../lib/git-notes";
+import { getConfig } from "../lib/gitgitgadget-config";
 import { PatchSeries } from "../lib/patch-series";
 import { ProjectOptions } from "../lib/project-options";
 import { testCreateRepo } from "./test-lib";
 
 // This test script might take quite a while to run
 jest.setTimeout(20000);
+
+getConfig();
 
 test("project options", async () => {
     const repo = await testCreateRepo(__filename);

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,6 +4,7 @@
     "lib/**/*.ts",
     "script/**/*.ts",
     "tests/**/*.ts",
+    "tests-config/**/*.ts",
     "./.eslintrc.js",
   ]
 }


### PR DESCRIPTION
### New config feature
This enables gitgitgadget to work with other projects through a config file.  While the patches affect many files, there is little logic change.  The last couple of commits came about while testing. 

Looking for agreement on method and suggestions on names used.  There are other issues to be addressed.  Many are mentioned in my disorganized [ggguser/readme](https://github.com/webstech/ggguser#readme).

### Related

Note, there is basic testing with an alternate config with `npm run test:config`.

A POC is in progress using three repos.  
- [ggguser](https://github.com/webstech/ggguser) represents a gitgitgadget user project - a project using ggg with some customizations.
- [gggmonitored](https://github.com/webstech/gggmonitored) is the equivalent of `gitgitgadget/git`
- [gggmail](https://github.com/webstech/gggmail) is the equivalent of a mail repo like lore.git.

`ggguser` has an expanding workflow(s) to create a usable model.  It can generate configurations and run misc-helper commands.

## Commits
### MailArchiveGitHelper - add branch name to config

The default branch on the mail repo needs to be configurable.

###    Add init-gitgitgadget-options to misc-helper

Allow easy setup for new projects.  The passed user name will be set in the `allowedUsers`.

`gitgitgadget.publishremote` must be set in the git config.
###  extensible: introduce product-config feature

Change most git specific references to use a configuration that can be loaded at run-time.  The configuration may be javascript (native or ts generated) or json.  It can be specified using `--config=` parameter to `misc-helper` script.