### PR TITLE
sendMail: change parseMBox to use simpleParser

### DIFF
--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -168,7 +168,7 @@ export class GitGitGadget {
         const email = userInfo.email;
 
         const send = async (mail: string): Promise<string> => {
-            const mbox = parseMBox(mail);
+            const mbox = await parseMBox(mail);
             mbox.cc = [];
             mbox.to = email;
             console.log(mbox);

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -1,5 +1,4 @@
 import { createHash } from "crypto";
-import * as libqp from "libqp";
 import { git, revParse } from "./git";
 import { GitNotes } from "./git-notes";
 import { IGitGitGadgetOptions } from "./gitgitgadget";
@@ -43,20 +42,7 @@ export class MailArchiveGitHelper {
     }
 
     public static mbox2markdown(mbox: IParsedMBox): string {
-        let body = mbox.body;
-
-        const headers = mbox.headers || [];
-        for (const header of headers) {
-            if (header.key === "Content-Transfer-Encoding") {
-                const value = header.value.toLowerCase();
-                if (value === "base64") {
-                    body = Buffer.from(body, "base64").toString();
-                } else if (value === "quoted-printable") {
-                    const buffer = libqp.decode(body);
-                    body = buffer.toString("utf-8");
-                }
-            }
-        }
+        const body = mbox.body;
 
         if (!body.length) {
             return "";
@@ -156,7 +142,7 @@ export class MailArchiveGitHelper {
         };
 
         const mboxHandler = async (mbox: string): Promise<void> => {
-                const parsedMbox = parseMBox(mbox, true);
+                const parsedMbox = await parseMBox(mbox, true);
                 if (!parsedMbox.headers) {
                     throw new Error(`Could not parse ${mbox}`);
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "html-to-text": "^8.1.0",
         "json-stable-stringify": "^1.0.1",
         "jsonwebtoken": "^8.5.1",
-        "libqp": "^1.1.0",
         "marked": "^4.0.12",
         "nodemailer": "^6.7.2",
         "rfc2047": "^3.0.1"
@@ -27,7 +26,6 @@
         "@types/jest": "^27.4.0",
         "@types/json-stable-stringify": "^1.0.33",
         "@types/jsonwebtoken": "^8.5.8",
-        "@types/libqp": "^1.1.1",
         "@types/marked": "^4.0.2",
         "@types/nodemailer": "^6.4.4",
         "@types/rfc2047": "^2.0.1",
@@ -1483,15 +1481,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
       "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/libqp": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/libqp/-/libqp-1.1.1.tgz",
-      "integrity": "sha512-pdSohjXQ5SxvWAXa+yv1Jrqm3izxfFHDdIybs6vYdtLWIHUxE75ftnSnA8bZQgQE3oP1RFk4kHkclLg7yD9i2A==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5308,7 +5297,8 @@
     "node_modules/libqp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
-      "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
+      "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
+      "dev": true
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -8716,15 +8706,6 @@
         "@types/node": "*"
       }
     },
-    "@types/libqp": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/libqp/-/libqp-1.1.1.tgz",
-      "integrity": "sha512-pdSohjXQ5SxvWAXa+yv1Jrqm3izxfFHDdIybs6vYdtLWIHUxE75ftnSnA8bZQgQE3oP1RFk4kHkclLg7yD9i2A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/lru-cache": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
@@ -11561,7 +11542,8 @@
     "libqp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
-      "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
+      "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
+      "dev": true
     },
     "lines-and-columns": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/jest": "^27.4.0",
     "@types/json-stable-stringify": "^1.0.33",
     "@types/jsonwebtoken": "^8.5.8",
-    "@types/libqp": "^1.1.1",
     "@types/marked": "^4.0.2",
     "@types/nodemailer": "^6.4.4",
     "@types/rfc2047": "^2.0.1",
@@ -65,7 +64,6 @@
     "html-to-text": "^8.1.0",
     "json-stable-stringify": "^1.0.1",
     "jsonwebtoken": "^8.5.1",
-    "libqp": "^1.1.0",
     "marked": "^4.0.12",
     "nodemailer": "^6.7.2",
     "rfc2047": "^3.0.1"


### PR DESCRIPTION
simpleParser handles base-64 and quoted-printable as well as specializing in email parsing.

The cc test is expanded and the to test now includes multiple recipients.

The tests using mbox2markdown for base-64 and quoted-printable just use the parser now.