### PR TITLE
Feature (and fixes): add init-email-commit-tip command to misc-helper

### DIFF
--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -201,9 +201,10 @@ export class GitGitGadget {
             "--",
             `+${this.notes.notesRef}:${this.notes.notesRef}`
         ];
-        for (const branch of this.config.repo.trackingBranches) {
-            args.push(`+refs/heads/${branch}:refs/remotes/upstream/${branch}`);
-        }
+
+        args.push(...this.config.repo.trackingBranches.map(branch =>
+            `+refs/heads/${branch}:refs/remotes/upstream/${branch}`));
+
         const prArgs = [
             `+${pullRequestRef}:${pullRequestRef}`,
             `+${pullRequestMerge}:${pullRequestMerge}`,

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -9,7 +9,7 @@ import { IParsedMBox, parseMBox,
     parseMBoxMessageIDAndReferences } from "./send-mail";
 import { SousChef } from "./sous-chef";
 
-const stateKey = "git@vger.kernel.org <-> GitGitGadget";
+export const stateKey = "git@vger.kernel.org <-> GitGitGadget";
 const replyToThisURL =
     "https://github.com/gitgitgadget/gitgitgadget/wiki/ReplyToThis";
 
@@ -261,49 +261,8 @@ export class MailArchiveGitHelper {
         };
 
         if (!this.state.latestRevision) {
-            /*
-             * No longer - this is the ref of an empty repo
-             * This is the commit in lore.kernel/git that is *just* before the
-             * first ever GitGitGadget mail sent to the Git mailing list.
-             */
-            this.state.latestRevision = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
-        } else if (this.state.latestRevision === "205655703b0501ef14e0f0dddf8e57bb726fae97") {
-            this.state.latestRevision = "26674e9a36ae1871f69197798d30f6d3d2af7a56";
-        } else if (await revParse(this.state.latestRevision,  this.mailArchiveGitDir) === undefined) {
-            const publicInboxGitDir = process.env.PUBLIC_INBOX_DIR;
-            if (publicInboxGitDir === undefined) {
-                throw new Error(`Commit ${this.state.latestRevision} not found; need PUBLIC_INBOX_DIR`);
-            }
-
-            let commitDiff = await git(["show", this.state.latestRevision, "--"], { workDir: publicInboxGitDir });
-
-            if (!commitDiff) {
-                throw new Error(`Could not find ${this.state.latestRevision} in ${publicInboxGitDir}`);
-            }
-
-            const match = commitDiff.match(/\n\+(Message-ID: [^\n]*)/);
-
-            if (!match) {
-                throw new Error(`Could not find Message-ID in ${commitDiff}`);
-            }
-
-            let commit = "HEAD";
-            for (;;) {
-                commit = await git(["log", "-1", "--format=%H", `-S${match[1]}`,
-                                    commit, "--"],
-                                   { workDir: this.mailArchiveGitDir});
-                if (!commit) {
-                    throw new Error(`Could not find ${this.state.latestRevision
-                                }'s equivalent in ${this.mailArchiveGitDir}`);
-                }
-                commitDiff = await git(["show", commit, "--"],
-                                       {workDir: this.mailArchiveGitDir});
-                if (commitDiff.indexOf(`\n+${match[1]}\n`) >= 0) {
-                    break;
-                }
-                commit += "^"; /* continue search with the parent commit */
-            }
-            this.state.latestRevision = commit;
+            throw new Error(`Mail archive email commit tip not set.  Please run \`misc-helper init-email-commit-tip\` ${
+                ""}to set the value.`);
         }
 
         const head = await revParse(this.branch, this.mailArchiveGitDir);

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -286,7 +286,7 @@ async function getCIHelper(): Promise<CIHelper> {
 
         try {
             await ci.getGitGitGadgetOptions();
-            process.stderr.write(`${command}: ${config.repo.baseOwner}/${config.repo.name} already initialized\n`);
+            process.stderr.write(`${command}: ${config.repo.owner}/${config.repo.name} already initialized\n`);
             process.exit(1);
         } catch (error) {
             const options: IGitGitGadgetOptions = { allowedUsers: [ commander.args[1] ] };

--- a/tests-config/ci-helper.test.ts
+++ b/tests-config/ci-helper.test.ts
@@ -163,16 +163,18 @@ async function setupRepos(instance: string):
     const gggRemote = await testCreateRepo(__filename, `-git-rmt${instance}`);
 
     // re-route the URLs
-    await worktree.git(["config", `url.${gggRemote.workDir}.insteadOf`,
-                        `https://github.com/${config.repo.baseOwner}/${config.repo.name}`]);
+    const url = `https://github.com/${config.repo.owner}/${config.repo.name}`;
 
-    await gggLocal.git(["config", `url.${gggRemote.workDir}.insteadOf`,
-                        `https://github.com/${config.repo.baseOwner}/${config.repo.name}`]);
+    await worktree.git([ "config", `url.${gggRemote.workDir}.insteadOf`, url ]);
+    await gggLocal.git([ "config", `url.${gggRemote.workDir}.insteadOf`, url ]);
+    // pretend there are two remotes
+    await gggLocal.git([ "config", `url.${gggRemote.workDir}.insteadOf`,
+        `https://github.com/${config.repo.baseOwner}/${config.repo.name}` ]);
 
     // set needed config
     await worktree.git([ "config", "--add", "gitgitgadget.workDir", gggLocal.workDir, ]);
-    await worktree.git([ "config", "--add", "gitgitgadget.publishRemote",
-        `https://github.com/${config.repo.baseOwner}/${config.repo.name}`, ]);
+    // misc-helper and gitgitgadget use this and ci-helper relies on insteadOf above
+    await worktree.git(["config", "--add", "gitgitgadget.publishRemote", gggRemote.workDir]);
     await worktree.git([ "config", "--add", "gitgitgadget.smtpUser", "joe_user@example.com", ]);
     await worktree.git([ "config", "--add", "gitgitgadget.smtpHost", "localhost", ]);
     await worktree.git([ "config", "--add", "gitgitgadget.smtpPass", "secret", ]);
@@ -418,7 +420,7 @@ test("handle comment allow no name specified (with trailing white space)",
         author: "ggg",
         baseCommit: "A",
         baseLabel: "gitgitgadget:next",
-        baseOwner: config.repo.baseOwner,
+        baseOwner: config.repo.owner,
         baseRepo: config.repo.name,
         body: "Super body",
         hasComments: true,
@@ -505,7 +507,7 @@ test("handle comment submit not author", async () => {
         author: "ggNOTg",
         baseCommit: "A",
         baseLabel: "gitgitgadget:next",
-        baseOwner: config.repo.baseOwner,
+        baseOwner: config.repo.owner,
         baseRepo: config.repo.name,
         body: "Super body",
         hasComments: true,
@@ -547,7 +549,7 @@ test("handle comment submit not mergeable", async () => {
         author: "ggg",
         baseCommit: "A",
         baseLabel: "gitgitgadget:next",
-        baseOwner: config.repo.baseOwner,
+        baseOwner: config.repo.owner,
         baseRepo: config.repo.name,
         body: "Super body",
         hasComments: true,
@@ -622,7 +624,7 @@ test("handle comment submit email success", async () => {
         author: "ggg",
         baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
-        baseOwner: config.repo.baseOwner,
+        baseOwner: config.repo.owner,
         baseRepo: config.repo.name,
         body: `Super body\r\n${template}\r\nCc: Copy One <copy@cat.com>\r\n`
             + "Cc: Copy Two <copycat@cat.com>",
@@ -706,7 +708,7 @@ test("handle comment preview email success", async () => {
         author: "ggg",
         baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
-        baseOwner: config.repo.baseOwner,
+        baseOwner: config.repo.owner,
         baseRepo: config.repo.name,
         body: "There will be a submit email and a preview email.",
         hasComments: true,
@@ -811,7 +813,7 @@ test("handle push/comment too many commits fails", async () => {
         author: "ggg",
         baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
-        baseOwner: config.repo.baseOwner,
+        baseOwner: config.repo.owner,
         baseRepo: config.repo.name,
         body: "Never seen - too many commits.",
         commits: commits.length,
@@ -929,7 +931,7 @@ test("handle push/comment merge commits fails", async () => {
         author: "ggg",
         baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
-        baseOwner: config.repo.baseOwner,
+        baseOwner: config.repo.owner,
         baseRepo: config.repo.name,
         body: "Never seen - merge commits.",
         commits: commits.length,
@@ -1073,7 +1075,7 @@ test("disallow no-reply emails", async () => {
         author: "ggg",
         baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
-        baseOwner: config.repo.baseOwner,
+        baseOwner: config.repo.owner,
         baseRepo: config.repo.name,
         body: "Never seen - merge commits.",
         commits: commits.length,
@@ -1198,7 +1200,7 @@ test("basic lint tests", async () => {
         author: "ggg",
         baseCommit: commitA,
         baseLabel: "gitgitgadget:next",
-        baseOwner: config.repo.baseOwner,
+        baseOwner: config.repo.owner,
         baseRepo: config.repo.name,
         body: "Never seen - merge commits.",
         commits: commits.length,
@@ -1250,7 +1252,7 @@ test("Handle comment cc", async () => {
         author: "ggg",
         baseCommit: "foo",
         baseLabel: "gitgitgadget:next",
-        baseOwner: config.repo.baseOwner,
+        baseOwner: config.repo.owner,
         baseRepo: config.repo.name,
         body: "Never seen - no cc.",
         commits: 1,

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -115,36 +115,19 @@ async function setupRepos(instance: string):
     const gggRemote = await testCreateRepo(__filename, `-git-rmt${instance}`);
 
     // re-route the URLs
-    await worktree.git(["config", `url.${gggRemote.workDir}.insteadOf`,
-                        "https://github.com/gitgitgadget/git"]);
+    const url = `https://github.com/gitgitgadget/git`;
 
-    await gggLocal.git(["config", `url.${gggRemote.workDir}.insteadOf`,
-                        "https://github.com/gitgitgadget/git"]);
+    await worktree.git([ "config", `url.${gggRemote.workDir}.insteadOf`, url ]);
+    await gggLocal.git([ "config", `url.${gggRemote.workDir}.insteadOf`, url ]);
 
     // set needed config
-    await worktree.git([
-        "config", "--add", "gitgitgadget.workDir", gggLocal.workDir,
-    ]);
-    await worktree.git([
-        "config", "--add", "gitgitgadget.publishRemote",
-        "https://github.com/gitgitgadget/git",
-    ]);
-
-    await worktree.git([
-        "config", "--add", "gitgitgadget.smtpUser", "joe_user@example.com",
-    ]);
-
-    await worktree.git([
-        "config", "--add", "gitgitgadget.smtpHost", "localhost",
-    ]);
-
-    await worktree.git([
-        "config", "--add", "gitgitgadget.smtpPass", "secret",
-    ]);
-
-    await worktree.git([
-        "config", "--add", "gitgitgadget.smtpOpts", eMailOptions.smtpOpts,
-    ]);
+    await worktree.git([ "config", "--add", "gitgitgadget.workDir", gggLocal.workDir, ]);
+    // misc-helper and gitgitgadget use this and ci-helper relies on insteadOf above
+    await worktree.git(["config", "--add", "gitgitgadget.publishRemote", gggRemote.workDir]);
+    await worktree.git([ "config", "--add", "gitgitgadget.smtpUser", "joe_user@example.com", ]);
+    await worktree.git([ "config", "--add", "gitgitgadget.smtpHost", "localhost", ]);
+    await worktree.git([ "config", "--add", "gitgitgadget.smtpPass", "secret", ]);
+    await worktree.git([ "config", "--add", "gitgitgadget.smtpOpts", eMailOptions.smtpOpts, ]);
 
     const notes = new GitNotes(gggRemote.workDir);
     await notes.set("", {allowedUsers: ["ggg", "user1"]}, true);

--- a/tests/misc-helper.test.ts
+++ b/tests/misc-helper.test.ts
@@ -1,0 +1,142 @@
+import { expect, jest, test } from "@jest/globals";
+import { git } from "../lib/git";
+import { getConfig } from "../lib/gitgitgadget-config";
+import { testCreateRepo, TestRepo } from "./test-lib";
+import { execFile } from "child_process";
+import * as util from "util";
+
+const execChild = util.promisify(execFile);
+
+jest.setTimeout(180000);
+
+const config = getConfig();
+
+// Create three repos.
+// worktree is a local copy for doing updates and has the config
+// info that would normally be in the gitgitgadget repo.  To ensure
+// testing isolation, worktree is NOT the repo used for git clone
+// tests.  That work is done in gggLocal.
+
+// gggRemote represents the master on github.
+
+// gggLocal represents the empty repo to be used by gitgitgadget.  It
+// is empty to ensure nothing needs to be present (worktree would
+// have objects present).
+
+async function setupRepos(instance: string): Promise<{ worktree: TestRepo; gggLocal: TestRepo; gggRemote: TestRepo }> {
+    const worktree = await testCreateRepo(__filename, `-work-cmt${instance}`);
+    const gggLocal = await testCreateRepo(__filename, `-git-lcl${instance}`);
+    const gggRemote = await testCreateRepo(__filename, `-git-rmt${instance}`);
+
+    // re-route the URLs
+    const url = `https://github.com/${config.repo.owner}/${config.repo.name}`;
+
+    await worktree.git([ "config", `url.${gggRemote.workDir}.insteadOf`, url ]);
+    await gggLocal.git([ "config", `url.${gggRemote.workDir}.insteadOf`, url ]);
+
+    // set needed config
+    await worktree.git(["config", "--add", "gitgitgadget.workDir", gggLocal.workDir]);
+    // misc-helper and gitgitgadget use this and ci-helper relies on insteadOf above
+    await worktree.git(["config", "--add", "gitgitgadget.publishRemote", gggRemote.workDir]);
+
+    await worktree.git([ "config", "user.name", "Test User" ]);
+    await gggLocal.git([ "config", "user.name", "Test User" ]);
+    await gggRemote.git([ "config", "user.name", "Test User" ]);
+    await worktree.git([ "config", "user.email", "user@example.com" ]);
+    await gggLocal.git([ "config", "user.email", "user@example.com" ]);
+    await gggRemote.git([ "config", "user.email", "user@example.com" ]);
+
+    // Initial empty commit
+    const commitA = await gggRemote.commit("A");
+    expect(commitA).not.toBeUndefined();
+
+    // Set up fake upstream branches
+    for (const branch of config.repo.trackingBranches) {
+        if (!branch.match(/master|main/)) {
+            await gggRemote.git(["branch", branch]);
+        }
+    }
+
+    return { worktree, gggLocal, gggRemote };
+}
+
+const notesRef = "--ref=refs/notes/gitgitgadget";
+const helperEnv = {
+        "GIT_AUTHOR_NAME": "J Doe",
+        "GIT_AUTHOR_EMAIL": "jdoe@example.com",
+        "GIT_COMMITTER_NAME": "J Doe",
+        "GIT_COMMITTER_EMAIL": "jdoe@example.com",
+        ...process.env
+};
+
+async function getNote(reg: RegExp, workDir: string): Promise<string> {
+    const notes = await git(["notes", notesRef], { workDir });
+    const id = notes.match(reg);
+    expect(id).not.toBeNull();
+    return await git(["notes", notesRef, "show", (id as RegExpMatchArray)[1]], { workDir });
+}
+
+test("init options and init/update tip", async () => {
+    const { worktree, gggLocal, gggRemote } = await setupRepos("mha1");
+
+    const miscHelper = async (...args: string[]): Promise<string> => {
+        const { stdout } = await execChild("node", [ "build/script/misc-helper.js", "-s",
+            "-g", gggLocal.workDir, "-G", worktree.workDir, ...args ], {env: helperEnv});
+        return stdout;
+    };
+
+    {
+        const user = "beno";
+        const options = await miscHelper( "init-gitgitgadget-options", user);
+        expect(options).toMatch(user);
+
+        const remoteOptions = await getNote(/ (.*)$/, gggRemote.workDir);
+        expect(remoteOptions).toMatch(user);
+    }
+
+    {
+        const tipCommit = "feeddeadbeef";
+        const tip = await miscHelper( "init-email-commit-tip", tipCommit);
+        expect(tip).toMatch(tipCommit);
+
+        const remotetip = await getNote(/ (.*)\n/, gggRemote.workDir);
+        expect(remotetip).toMatch(tipCommit);
+    }
+
+    {
+        const tipCommit = "feeddeadfade";
+        const tip = await miscHelper( "init-email-commit-tip", tipCommit);
+        expect(tip).toMatch(tipCommit);
+
+        const remotetip = await getNote(/ (.*)\n/, gggRemote.workDir);
+        expect(remotetip).toMatch(tipCommit);
+    }
+});
+
+test("init email commit tip and init options", async () => {
+    const { worktree, gggLocal, gggRemote } = await setupRepos("mha2");
+
+    const miscHelper = async (...args: string[]): Promise<string> => {
+        const { stdout } = await execChild("node", [ "build/script/misc-helper.js", "-s",
+            "-g", gggLocal.workDir, "-G", worktree.workDir, ...args ]);
+        return stdout;
+    };
+
+    {
+        const tipCommit = "feeddeadbeef";
+        const tip = await miscHelper( "init-email-commit-tip", tipCommit);
+        expect(tip).toMatch(tipCommit);
+
+        const remotetip = await getNote(/ (.*)$/, gggRemote.workDir);
+        expect(remotetip).toMatch(tipCommit);
+    }
+
+    {
+        const user = "beno";
+        const options = await miscHelper( "init-gitgitgadget-options", user);
+        expect(options).toMatch(user);
+
+        const remoteOptions = await getNote(/ (.*)$/, gggRemote.workDir);
+        expect(remoteOptions).toMatch(user);
+    }
+});


### PR DESCRIPTION
### GitGitGadget:updateNotesAndPullRef  `for` to `map`
As suggested in previous PR.  Includes fix by @dscho.
### Change config baseOwner to owner usage
There was no risk prior to the correction.  Should probably expand tests to fully simulate the ggg/git owner setup with PRs coming from both repos.
### Test: correct publishRemote config setting
The setting now points to local file pretending to be a remote.  Tests never used this.
### Add init-email-commit-tip command to misc-helper

The new command can reset the start point for email repo scanning. If the config is not set, the user will be told to use the command.  There is a reminder if the options have not been initialized.

The old migration code checking commit points is gone, as suggested by @dscho.

### Next step
Use an alternate config to ensure `misc-helper` tests have no chance of targeting git repos.