### PR TITLE
build-and-test branch cleanup needs correct token

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,6 +123,7 @@ jobs:
       uses: actions/github-script@v3
       id: clean-up
       with:
+        github-token: ${{ env.GGG_TOKEN }}
         script: |
             const exports = require(`${process.env.GITHUB_WORKSPACE}/gitgitgadget/build/lib/delete-ci-test-branches.js`)
             await exports.deleteBranches(github, process.env.GITHUB_REPOSITORY_OWNER, process.env.GGG_REPOSITORY);


### PR DESCRIPTION
The token for the test repository needs to be set so it is accessed with the correct credentials.  A failing test is [here](https://github.com/webstech/gitgitgadget/runs/5283987140?check_suite_focus=true) and the successful test is [here](https://github.com/webstech/gitgitgadget/runs/5297081827?check_suite_focus=true).

Initial tests were run using a workflow in the test repository, hiding this issue.