### PR TITLE
Fix parsing of the `References:` header

### DIFF
--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -115,7 +115,7 @@ export function parseMBoxMessageIDAndReferences(parsed: IParsedMBox):
         /^\s*<([^>]+)>(\s*|,)(\([^")]*("[^"]*")?\)\s*|\([^)]*\)$)?(<.*)?$/;
     for (const header of parsed.headers ?? []) {
         if (header.key === "In-Reply-To" || header.key === "References") {
-            let value: string = header.value;
+            let value: string = header.value.replace(/[\r\n]/g, " ");
             while (value) {
                 const match = value.match(msgIdRegex);
                 if (!match) {


### PR DESCRIPTION
When we replaced our home-grown mbox parser with a version that uses the `mailparser`, we did not adjust the regex when parsing the `References:` header.

As a consequence, our parser got confused when the references stretched over multiple lines (because the regex did not expect Carriage Returns nor Line Feeds).

Let's fix this.

This fixes https://github.com/gitgitgadget/gitgitgadget/issues/904.