### PR TITLE
CIHelper.warnOnMissingPublicEmail: remove newlines

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -509,9 +509,9 @@ export class CIHelper {
 
     protected warnOnMissingPublicEmail(username: string): string {
         return `WARNING: ${username} has no public email address set on GitHub;
-GitGitGadget needs an email address to Cc: you on your contribution, so that you receive any feedback
-on the Git mailing list. Go to https://github.com/settings/profile to make your preferred email public
-to let GitGitGadget know which email address to use.`;
+GitGitGadget needs an email address to Cc: you on your contribution, so that you receive any feedback ${ ""
+}on the Git mailing list. Go to https://github.com/settings/profile to make your preferred email public ${ ""
+}to let GitGitGadget know which email address to use.`;
     }
 
     /**


### PR DESCRIPTION
Message looks a little disjointed if the window is not wide enough.  The first line intentionally still has a `\n`.

Tried using `oneLine` from [common-tags](https://github.com/zspecza/common-tags) but the types get linting errors.  Under the covers it does a regex - would be nice if there was something in the language spec for this.