### PR TITLE
MailArchiveGitHelper: format replies as emails in the GGG PR

### DIFF
--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -48,8 +48,10 @@ export class MailArchiveGitHelper {
             return "";
         }
 
-        const wrap = "``````````\n";
-        return `${wrap}${body}${body.endsWith("\n") ? "" : "\n"}${wrap}`;
+        const backTicks = "``````````";
+        const wrapTop = `${backTicks}email\n`;
+        const wrapBottom = `${backTicks}\n`;
+        return `${wrapTop}${body}${body.endsWith("\n") ? "" : "\n"}${wrapBottom}`;
     }
 
     protected readonly branch: string;


### PR DESCRIPTION
GitHub's Linguist, which powers Markdown code block syntax highlighting
[1], understands ```` ```email```` as an indication to format
the following code block as en email [2]. This allows quoted text from
previous emails to be colored differently.

Syntax-highlight the replies from the mailing list in the corresponding
PR comments.

[1] https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting
[2] https://github.com/github/linguist/blob/cddf7476af4c95d1572956ffc5c0cb84f7e431c5/lib/linguist/languages.yml#L1467-L1481