### PR TITLE
lint: allow long lines if prefixed with whitespace

### DIFF
--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -111,6 +111,8 @@ export class LintCommit {
 
         for (let i = 1; i < this.lines.length; i++) {
             if (this.lines[i].length > this.maxColumns &&
+                // Allow long lines if prefixed with whitespace (ex. quoted error messages)
+                (! this.lines[i].match(/^\s+/)) &&
                 // Allow long lines if they cannot be wrapped at some
                 // white-space character, e.g. URLs. To allow ` [1] <URL>`
                 // lines, we skip the first 10 characters.

--- a/tests/commit-lint.test.ts
+++ b/tests/commit-lint.test.ts
@@ -157,7 +157,7 @@ http://www.github.com blah\n\nSigned-off-by: x`;
 blah http://www.github.com\n\nSigned-off-by: x`;
     lintCheck(commit);
 
-    commit.message = `wrapped but too long\n\n ${
+    commit.message = `wrapped but too long\n\n${
                 ""}1234578901234567890123456789012345678901234567890${
                 ""} 23456789012345678901234567890\nmore bad\nSigned-off-by: x`;
     lintCheck(commit, (lintError) => {
@@ -168,6 +168,12 @@ blah http://www.github.com\n\nSigned-off-by: x`;
     commit.message = `contains a long URL that cannot be wrapped\n\n ${
                 ""}[2] https://lore.kernel.org/git/CABPp-BH9tju7WVm=${
                 ""}QZDOvaMDdZbpNXrVWQdN-jmfN8wC6YVhmw@mail.gmail.com/\n\n${
+                ""}Signed-off-by: x}`;
+    lintCheck(commit);
+
+    commit.message = `contains a long, whitespace-prefixed error message\n\n${
+                ""}    ld-elf.so.1: /usr/local/lib/perl5/5.32/mach/CORE/libperl.so.5.32:${
+                ""} Undefined symbol "strerror_l@FBSD_1.6"\n\n${
                 ""}Signed-off-by: x}`;
     lintCheck(commit);
 });
@@ -213,7 +219,7 @@ test("combo lint tests", () => {
         expect(lintError.message).toMatch(/empty line/);
     });
 
-    commit.message = `all good but too long\n ${
+    commit.message = `all good but too long\n${
                 ""}1234578901234567890123456789012345678901234567890${
                 ""} 23456789012345678901234567890\nmore bad\nSigned-off-by: x`;
     lintCheck(commit, (lintError) => {


### PR DESCRIPTION
Quoted error messages can often be longer than 80 characters and it
makes sense to allow them to be kept on a single line.

Loosen the "line too long" check to allow long lines if they are
prefixed with whitespace, as it is customary to prefix copied error
messages, or terminal session excerpts, with whitespace.

Add a test and adjust two existing tests to not prefix long lines with a
space.