### PR TITLE
ci-helper: do error out upon problems

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -640,6 +640,8 @@ GitGitGadget needs an email address to Cc: you on your contribution, so that you
         } catch (e) {
             const error = e as Error;
             await addComment(error.toString());
+            // re-throw exception to avoid "succeeding" on error
+            throw e;
         }
     }
 

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -291,7 +291,8 @@ test("handle comment allow fail invalid user", async () => {
 
     ci.setGHGetPRComment(comment);
 
-    await ci.handleComment("gitgitgadget", 433865360);
+    await expect(ci.handleComment("gitgitgadget", 433865360)).
+        rejects.toThrow(/is not a valid GitHub username/);
     expect(ci.addPRCommentCalls[0][1])
         .toMatch(/is not a valid GitHub username/);
 });
@@ -480,7 +481,8 @@ test("handle comment submit not author", async () => {
     ci.setGHGetPRComment(comment);
     ci.setGHGetGitHubUserInfo(user);
 
-    await ci.handleComment("gitgitgadget", 433865360);
+    await expect(ci.handleComment("gitgitgadget", 433865360)).
+        rejects.toThrow(/Only the owner of a PR can submit/);
     expect(ci.addPRCommentCalls[0][1])
         .toMatch(/Only the owner of a PR can submit/);
 });
@@ -523,7 +525,8 @@ test("handle comment submit not mergeable", async () => {
     ci.setGHGetPRComment(comment);
     ci.setGHGetGitHubUserInfo(user);
 
-    await ci.handleComment("gitgitgadget", 433865360);
+    await expect(ci.handleComment("gitgitgadget", 433865360)).
+        rejects.toThrow(/does not merge cleanly/);
     expect(ci.addPRCommentCalls[0][1])
         .toMatch(/does not merge cleanly/);
 });


### PR DESCRIPTION
While frantically trying to fix a problem with GitGitGadget, I got a couple of runs that were marked as successful, but did totally not succeed at all ([#1](https://dev.azure.com/gitgitgadget/git/_build/results?buildId=140683&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=28e14b79-1d95-5195-ee03-3a68ac48a418&l=24), [#2](https://dev.azure.com/gitgitgadget/git/_build/results?buildId=140688&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=28e14b79-1d95-5195-ee03-3a68ac48a418&l=22), [#3](https://dev.azure.com/gitgitgadget/git/_build/results?buildId=140689&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=28e14b79-1d95-5195-ee03-3a68ac48a418&l=24)).

This patch is designed to fix that: when failing to submit a patch series, we _want_ the corresponding Pipeline run to be marked as "failed".