### PR TITLE
Make email repo more generic via config

### DIFF
--- a/lib/gitgitgadget-config.ts
+++ b/lib/gitgitgadget-config.ts
@@ -17,6 +17,8 @@ const defaultConfig: IConfig = {
         owner: "gitgitgadget",
         branch: "master",
         host: "lore.kernel.org",
+        url: "https://lore.kernel.org/git",
+        descriptiveName: "lore.kernel/git"
     },
     mail: {
         author: "GitGitGadget",

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -5,6 +5,7 @@ import { IGitGitGadgetOptions } from "./gitgitgadget";
 import { GitHubGlue } from "./github-glue";
 import { IMailMetadata } from "./mail-metadata";
 import { IPatchSeriesMetadata } from "./patch-series-metadata";
+import { IConfig, getConfig } from "./project-config";
 import { IParsedMBox, parseMBox,
     parseMBoxMessageIDAndReferences } from "./send-mail";
 import { SousChef } from "./sous-chef";
@@ -55,6 +56,7 @@ export class MailArchiveGitHelper {
     }
 
     protected readonly branch: string;
+    protected readonly config: IConfig = getConfig();
     protected readonly state: IGitMailingListMirrorState;
     protected readonly gggNotes: GitNotes;
     protected readonly mailArchiveGitDir: string;
@@ -109,7 +111,7 @@ export class MailArchiveGitHelper {
                 throw new Error(`Could not parse Message-ID of ${mbox}`);
             }
             console.log(`Handling "${sousChef.subject}"`);
-            const whatsCookingBaseURL = "https://lore.kernel.org/git/";
+            const whatsCookingBaseURL = this.config.mailrepo.url;
             for (const branchName of sousChef.branches.keys()) {
                 const pullRequestURL = branchNameMap.get(branchName);
                 if (pullRequestURL) {
@@ -195,8 +197,7 @@ export class MailArchiveGitHelper {
                             }, commit ${originalCommit
                             }, comment ID: ${issueCommentId}`);
 
-                const archiveURL = `https://lore.kernel.org/git/${
-                    parsed.messageID}`;
+                const archiveURL = `${this.config.mailrepo.url}/${parsed.messageID}`;
                 const header = `[On the Git mailing list](${archiveURL}), ` +
                     (parsedMbox.from ?
                      parsedMbox.from.replace(/ *<.*>/, "") : "Somebody") +

--- a/lib/project-config.ts
+++ b/lib/project-config.ts
@@ -25,6 +25,8 @@ export interface IConfig {
         owner: string;
         branch: string;
         host: string;
+        url: string;
+        descriptiveName: string;
     },
     mail: {
         author: string;

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -490,7 +490,7 @@ const commandOptions = commander.opts<ICommanderOptions>();
         const mailArchiveGitDir = await getVar("loreGitDir", commandOptions.gitgitgadgetWorkDir);
 
         if (!mailArchiveGitDir) {
-            process.stderr.write("Need a lore.kernel/git worktree");
+            process.stderr.write(`Need a ${config.mailrepo.descriptiveName} worktree`);
             process.exit(1);
         }
         const onlyPRs = new Set<number>();


### PR DESCRIPTION
Added to mailrepo:
  - url - link to access files.  Should be buildable at runtime  but that is asking for more than I can currently offer
  - descriptiveName - term to be used for messages
