### PR TITLE
Add feature to suppress range-diff on /submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ their behalf, and people mentioned in the Cc: footer of the Pull Request
 description.
 
 Furthermore, for all iterations of a patch series but the first one,
-GitGitGadget will insert a machine-generated representation of what changed,
-and reply to the cover letter of the previous iteration.
+GitGitGadget will insert a machine-generated representation of what changed
+between revisions,
+and reply to the cover letter of the previous iteration.  This patch revision
+diff can be supressed if the change may be too large or irrelevant by adding
+a `Range-Diff: false` footer in the Pull Request description.
 
 For convenience of reviewers, GitGitGadget will generate tags for each
 iteration it sent, and push those to [https://github.com/gitgitgadget/git](https://github.com/gitgitgadget/git). Links

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -195,3 +195,8 @@ export async function gitCommandExists(command: string, workDir?: string):
     const result = await GitProcess.exec([command, "-h"], workDir || ".");
     return result.exitCode === 129;
 }
+
+// rev-parse does not have enough info in shallow repos to determine a safe short name
+export function gitShortHash(longHash: string): string {
+    return longHash.substring(0, 8);
+}

--- a/lib/patch-series-options.ts
+++ b/lib/patch-series-options.ts
@@ -4,4 +4,5 @@ export class PatchSeriesOptions {
     public noUpdate?: boolean;
     public rfc?: boolean;
     public patience?: boolean;
+    public rangeDiff?: string;
 }

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -106,7 +106,7 @@ class PatchSeriesTest extends PatchSeries {
         }
 
         const x = new PatchSeriesTest(new GitNotes(), {},
-                new ProjectOptionsTest(), prMeta, "", 1);
+                new ProjectOptionsTest(), prMeta, undefined, 1);
 
         x.insertCcAndFromLines(mails, thisAuthor, senderName);
 

--- a/tests/project-options.test.ts
+++ b/tests/project-options.test.ts
@@ -45,7 +45,7 @@ test("project options", async () => {
                 iteration: 1,
             };
             const x = new X(new GitNotes(repo.workDir), {},
-                            options2, prMeta, "", 1);
+                            options2, prMeta, undefined, 1);
             const mbox = await x.generateMBox();
             const needle =
                 "=?UTF-8?Q?Nguy=E1=BB=85n_Th=C3=A1i_Ng=E1=BB=8Dc?= Duy";


### PR DESCRIPTION
This change introduces support for a new pull request description
footer:

Range-Diff: false

This will bypass generation of the range-diff between patch versions.
The range-diff output will be replaced with instructions for
generating it locally.  The users of this feature should comment if
the range-diff is not relevant.

## Random bits
- ~~choice of `version-diff` is trying to look at this from a user perspective~~
- readme description could be expanded (usual developer lack of doc)
- tests need to be developed.  Testing was done using webstech/gggmonitored repo.
- change does not include `mail-patch-series` support using `getFromTag`.