### PR TITLE
"Bug report " urls and line length exception advice

### DIFF
--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -114,8 +114,9 @@ export class LintCommit {
                 // Allow long lines if prefixed with whitespace (ex. quoted error messages)
                 (! this.lines[i].match(/^\s+/)) &&
                 // Allow long lines if they cannot be wrapped at some
-                // white-space character, e.g. URLs. To allow ` [1] <URL>`
-                // lines, we skip the first 10 characters.
+                // white-space character, e.g. URLs. To allow a short
+                // preamble such as `ref [1] <URL>` lines, we skip the
+                // first 10 (arbitrary) characters.
                 this.lines[i].slice(10).match(/\s/)) {
                 this.block(`Lines in the body of the commit messages ${""
                     }should be wrapped between 60 and ${

--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -120,7 +120,8 @@ export class LintCommit {
                 this.lines[i].slice(10).match(/\s/)) {
                 this.block(`Lines in the body of the commit messages ${""
                     }should be wrapped between 60 and ${
-                    this.maxColumns} characters.`);
+                    this.maxColumns} characters.\n`
+                     + `Indented lines, and lines without whitespace, are exempt`);
                 break;
             }
         }


### PR DESCRIPTION
The GitGitGadget lint checker can leave users in a Catch 22 situation
without advice on how best to resolve their reasonable conundrum.
E.g gitgitgadget/git Issue #1283 used a "Bug report " Long_URL which
reported such a fail.

1. Allow sufficient characters to fit the "Bug report " into the long
   line preamble.
2. Add guidance to the error message on allowable exceptions.

Signed-off-by: Philip Oakley <philipoakley@iee.email>