### PR TITLE
MailArchiveHelper: avoid invalid links to the mail archive

### DIFF
--- a/lib/gitgitgadget-config.ts
+++ b/lib/gitgitgadget-config.ts
@@ -17,7 +17,7 @@ const defaultConfig: IConfig = {
         owner: "gitgitgadget",
         branch: "master",
         host: "lore.kernel.org",
-        url: "https://lore.kernel.org/git",
+        url: "https://lore.kernel.org/git/",
         descriptiveName: "lore.kernel/git"
     },
     mail: {

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -197,7 +197,7 @@ export class MailArchiveGitHelper {
                             }, commit ${originalCommit
                             }, comment ID: ${issueCommentId}`);
 
-                const archiveURL = `${this.config.mailrepo.url}/${parsed.messageID}`;
+                const archiveURL = `${this.config.mailrepo.url}${parsed.messageID}`;
                 const header = `[On the Git mailing list](${archiveURL}), ` +
                     (parsedMbox.from ?
                      parsedMbox.from.replace(/ *<.*>/, "") : "Somebody") +


### PR DESCRIPTION
I just noticed that e.g. https://github.com/git/git/pull/1302#issuecomment-1221211481 contains an incorrect link. Let's fix that.