### PR TITLE
Do not break actions if comment is not found

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -2,6 +2,7 @@ import addressparser from "nodemailer/lib/addressparser";
 import { Octokit } from "@octokit/rest";
 import { git, gitConfig } from "./git";
 import { getPullRequestKey, pullRequestKeyInfo, pullRequestKey } from "./pullRequestKey";
+export { RequestError } from "@octokit/request-error";
 
 export interface IPullRequestInfo {
     pullRequestURL: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@octokit/auth-app": "^4.0.5",
+        "@octokit/request-error": "^3.0.1",
         "@octokit/rest": "^19.0.4",
         "commander": "^9.4.0",
         "dugite": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "@octokit/auth-app": "^4.0.5",
+    "@octokit/request-error": "^3.0.1",
     "@octokit/rest": "^19.0.4",
     "commander": "^9.4.0",
     "dugite": "^2.0.0",


### PR DESCRIPTION
Occasionally a comment may be deleted before it is seen by ggg.  This should not cause a failed action to show on the GitHub dashboard.
