### PR TITLE
Format checkboxes

### DIFF
--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -36,7 +36,7 @@ export function md2text(markdown: string, columns = 76): string {
                         .replace(/(^|\n)(\n)(?!$)/g, "$1>$2"); // quote empty
                     }});
             },
-            checkBoxFormatter: (elem, walk, builder, _options) => {
+            checkBoxFormatter: (elem, walk, builder, _) => {
                 if (elem.attribs) {
                     builder.addInline(elem.attribs.checked === undefined ? "[ ]" : "[x]");
                 }

--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -36,8 +36,10 @@ export function md2text(markdown: string, columns = 76): string {
                         .replace(/(^|\n)(\n)(?!$)/g, "$1>$2"); // quote empty
                     }});
             },
-            checkBoxFormatter: (elem, walk, builder, options) => {
-                builder.addInline(elem.attribs.checked === undefined ? "[ ]" : "[x]");
+            checkBoxFormatter: (elem, walk, builder, _options) => {
+                if (elem.attribs) {
+                    builder.addInline(elem.attribs.checked === undefined ? "[ ]" : "[x]");
+                }
             },
         },
         selectors: [

--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -36,10 +36,10 @@ export function md2text(markdown: string, columns = 76): string {
                         .replace(/(^|\n)(\n)(?!$)/g, "$1>$2"); // quote empty
                     }});
             },
-            checkBoxFormatter: (elem, walk, builder, _) => {
-                if (typeof elem.attribs == "object") {
-                    builder.addInline(elem.attribs.checked === undefined ? "[ ]" : "[x]");
-                }
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            checkBoxFormatter: (elem, walk, builder, options) => {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                builder.addInline(elem.attribs.checked === undefined ? "[ ]" : "[x]");
             },
         },
         selectors: [

--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -37,7 +37,7 @@ export function md2text(markdown: string, columns = 76): string {
                     }});
             },
             checkBoxFormatter: (elem, walk, builder, _) => {
-                if (elem.attribs) {
+                if (typeof elem.attribs == "object") {
                     builder.addInline(elem.attribs.checked === undefined ? "[ ]" : "[x]");
                 }
             },

--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -36,6 +36,9 @@ export function md2text(markdown: string, columns = 76): string {
                         .replace(/(^|\n)(\n)(?!$)/g, "$1>$2"); // quote empty
                     }});
             },
+            checkBoxFormatter: (elem, walk, builder, options) => {
+                builder.addInline(elem.attribs.checked === undefined ? "[ ]" : "[x]");
+            },
         },
         selectors: [
             {
@@ -71,6 +74,10 @@ export function md2text(markdown: string, columns = 76): string {
                     trimEmptyLines: false
                 },
                 format: "blockFormatter"
+            },
+            {
+                selector: "input[type=checkbox]",
+                format: "checkBoxFormatter"
             },
         ],
     };

--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -37,7 +37,7 @@ export function md2text(markdown: string, columns = 76): string {
                     }});
             },
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            checkBoxFormatter: (elem, walk, builder, options) => {
+            checkBoxFormatter: (elem, _walk, builder, _options) => {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 builder.addInline(elem.attribs.checked === undefined ? "[ ]" : "[x]");
             },


### PR DESCRIPTION
GitHub task lists are represented in HTML as unordered lists with checkboxes. When turned into text the checkboxes are currently ignored. This affects PRs with task lists (e.g. https://github.com/git/git/pull/1359); the resulting text list has no indication anymore whether an item was checked (done) or not.

E.g. this:

- [x] done item
- [ ] item still to do

Is turned into:

` * done item`
`* item still to do`

Format checkboxes by representing checked ones by "[x]" and unchecked ones by "[ ]" to keep the information of which item was done.

This turns the text result for the example above into:

` * [x] done item`
` * [ ] item still to do`