### PR TITLE
lib: prepare for an interim maintainer

### DIFF
--- a/script/lookup-commit.sh
+++ b/script/lookup-commit.sh
@@ -239,7 +239,7 @@ test notes != "$mode" || {
 
 		# gitk,git-gui patches are often taken via Pull Requests, let's look only at patches from known git.git (interim) maintainers
 		case "$(git -C "$GITGIT_DIR" show -s --format=%cn "$commit")" in
-		"Linus Torvalds"|"Junio C Hamano"|"Shawn O. Pearce"|"Jeff King"|"Jonathan Nieder") ;; # these should be mostly on the mailing list
+		"Linus Torvalds"|"Junio C Hamano"|"Shawn O. Pearce"|"Jeff King"|"Jonathan Nieder"|"Taylor Blau") ;; # these should be mostly on the mailing list
 		*) continue;; # these are not expected to have been discussed on the mailing list
 		esac
 

--- a/script/lookup-commit.sh
+++ b/script/lookup-commit.sh
@@ -70,10 +70,12 @@ update_gitgit_dir () {
 
 	if git -C "$GITGIT_DIR" rev-parse --verify refs/remotes/gitster/seen >/dev/null 2>&1
 	then
+		# Let's take 'seen' from the official source at git.git.
+		git -C "$GITGIT_DIR" remote set-url gitster https://github.com/git/git
 		git -C "$GITGIT_DIR" fetch gitster ||
 		die "Could not update the 'gitster' remote to $GITGIT_DIR"
 	else
-		git -C "$GITGIT_DIR" remote add -f gitster https://github.com/gitster/git ||
+		git -C "$GITGIT_DIR" remote add -f gitster https://github.com/git/git ||
 		die "Could not add the 'gitster' remote to $GITGIT_DIR"
 	fi
 }

--- a/script/lookup-commit.sh
+++ b/script/lookup-commit.sh
@@ -237,15 +237,6 @@ test notes != "$mode" || {
 			continue
 		fi
 
-		amlog="$(git -C "$GITGIT_DIR" notes --ref=refs/notes/gitster-amlog show "$commit" 2>/dev/null | head -n 1)"
-		if test -n "$amlog"
-		then
-			amlog=${amlog%>}
-			amlog=${amlog#Message-Id: <}
-			printf 'M 100644 inline %s\ndata <<EOF\n%s\nEOF\n' "$commitpath" "$amlog"
-			continue
-		fi
-
 		# gitk,git-gui patches are often taken via Pull Requests, let's look only at patches from known git.git (interim) maintainers
 		case "$(git -C "$GITGIT_DIR" show -s --format=%cn "$commit")" in
 		"Linus Torvalds"|"Junio C Hamano"|"Shawn O. Pearce"|"Jeff King"|"Jonathan Nieder") ;; # these should be mostly on the mailing list


### PR DESCRIPTION
This pull request prepares GitGitGadget for the interim maintainer. The changes here are broken out into two sets:

- First, a handful of patches which replace "gitster" in comments and code with "maintainer", but does not actually change the location from gitster/git.
- Then, a final patch which replaces the location of the upstream gitster/git with ttaylorr/git.

The final patch 572cb9316f5ddec710243d720955153318ae1794 should be reverted once Junio is back online.

##

/cc @dscho 