### PR TITLE
Fix the URL of the "This branch is now known as <name>" links

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -317,7 +317,7 @@ export class CIHelper {
 
         // Identify branch in maintainer repo
         const maintainerBranch = `refs/remotes/${this.config.repo.maintainerBranch}/`;
-        const maintainerRepo = `${this.config.repo.maintainerBranch}.${this.config.repo.name}`;
+        const maintainerRepo = `${this.config.repo.owner}/${this.config.repo.name}`;
 
         let gitsterBranch: string | undefined =
             await git(["for-each-ref", `--points-at=${tipCommitInGitGit}`,


### PR DESCRIPTION
I noticed that https://github.com/gitgitgadget/git/pull/1404#issuecomment-1304362150 pointed to an incorrect location (hence fixed) and used the opportunity to fix an underlying problem: we should really point to the branches mirrored into GitGitGadget's fork, from where GitGitGadget determines which maintainer branch corresponds to the respective PR branch, anyway.