### PR TITLE
Update node and actions versions in workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     # Check out repo under sub-dir so other repo can be checked out
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: gitgitgadget
 
@@ -90,14 +90,14 @@ jobs:
       if: env.GGG_SMTP_USER || env.GGG_SMTP_PASS || env.GGG_SMTP_HOST
 
     # Check out github-glue.test.ts repo if configured for it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: ${{ github.repository_owner }}/${{ env.GGG_REPOSITORY }}
         token: ${{ env.GGG_TOKEN }}
         path: ${{ env.GGG_REPOSITORY }}
       if: env.GGG_TOKEN
 
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v3
       with:
         node-version: '${{ matrix.node-version }}' # optional, default is 10.x
 
@@ -120,7 +120,7 @@ jobs:
       working-directory: gitgitgadget
 
     - name: Clean up two day old branches and PRs
-      uses: actions/github-script@v3
+      uses: actions/github-script@v6
       id: clean-up
       with:
         github-token: ${{ env.GGG_TOKEN }}


### PR DESCRIPTION
Use node 18 LTS and latest versions of the workflow actions.

This will get rid of the warnings in the actions jobs.