### PR TITLE
mail archive - catch comment errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@types/jsonwebtoken": "^8.5.9",
         "@types/mailparser": "^3.4.0",
         "@types/marked": "^4.0.8",
-        "@types/nodemailer": "^6.4.6",
+        "@types/nodemailer": "^6.4.7",
         "@types/rfc2047": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.46.1",
         "@typescript-eslint/parser": "^5.46.1",
@@ -1730,9 +1730,9 @@
       "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg=="
     },
     "node_modules/@types/nodemailer": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.6.tgz",
-      "integrity": "sha512-pD6fL5GQtUKvD2WnPmg5bC2e8kWCAPDwMPmHe/ohQbW+Dy0EcHgZ2oCSuPlWNqk74LS5BVMig1SymQbFMPPK3w==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.7.tgz",
+      "integrity": "sha512-f5qCBGAn/f0qtRcd4SEn88c8Fp3Swct1731X4ryPKqS61/A3LmmzN8zaEz7hneJvpjFbUUgY7lru/B/7ODTazg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -7851,9 +7851,9 @@
       "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg=="
     },
     "@types/nodemailer": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.6.tgz",
-      "integrity": "sha512-pD6fL5GQtUKvD2WnPmg5bC2e8kWCAPDwMPmHe/ohQbW+Dy0EcHgZ2oCSuPlWNqk74LS5BVMig1SymQbFMPPK3w==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.7.tgz",
+      "integrity": "sha512-f5qCBGAn/f0qtRcd4SEn88c8Fp3Swct1731X4ryPKqS61/A3LmmzN8zaEz7hneJvpjFbUUgY7lru/B/7ODTazg==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/jsonwebtoken": "^8.5.9",
     "@types/mailparser": "^3.4.0",
     "@types/marked": "^4.0.8",
-    "@types/nodemailer": "^6.4.6",
+    "@types/nodemailer": "^6.4.7",
     "@types/rfc2047": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",


### PR DESCRIPTION
Email comments on specific commits (not 0 in series) fail if the first line is not part of the change.  This is part of a couple of patches to get past this problem.  Failed commit commenting will be a PR comment.   First step to make sure comments are not missed.

Future patches will 
- track the initial changed line in a patch in the metadata
- check if the commit is no longer part of the patch

Noting this is not tested by the CI at this point.  This patch is to ensure emails are added as comments.