### PR TITLE
git api: resolve promise in lineHandler

### DIFF
--- a/lib/git.ts
+++ b/lib/git.ts
@@ -107,8 +107,10 @@ export function git(args: string[], options?: IGitOptions | undefined):
                                     }':\nstderr: ${result.stderr
                                     }\nstdout: ${result.stdout}\n`);
             }
-            resolve(!options || options.trimTrailingNewline === false ?
-                    result.stdout : trimTrailingNewline(result.stdout));
+            if (!options?.lineHandler) { // let callback resolve the promise
+                resolve(!options || options.trimTrailingNewline === false ?
+                        result.stdout : trimTrailingNewline(result.stdout));
+            }
         }).catch((reason) => {
             reject(reason);
         });

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -45,20 +45,10 @@ export function git(args: string[], options?: IGitOptions | undefined):
                 if (!process.stdout) {
                     throw new Error(`No stdout for "git ${args.join(" ")}`);
                 }
-                let linePromise: Promise<void> | undefined;
+                const promises: Array<Promise<void>> = [];
                 const handleLine = (line: string): boolean => {
                     try {
-                        if (!linePromise) {
-                            linePromise = lineHandler(line);
-                        } else {
-                            linePromise = linePromise.then(() => {
-                                return lineHandler(line);
-                            });
-                        }
-                        linePromise.catch((reason) => {
-                            reject(reason);
-                            process.kill();
-                        });
+                        promises.push(lineHandler(line));
                     } catch (reason) {
                         reject(reason);
                         process.kill();
@@ -84,12 +74,7 @@ export function git(args: string[], options?: IGitOptions | undefined):
                     if (buffer.length > 0) {
                         handleLine(buffer);
                     }
-                    if (linePromise) {
-                        linePromise.then(() => { resolve(""); })
-                            .catch((reason) => { reject(reason); });
-                    } else {
-                        resolve("");
-                    }
+                    Promise.all(promises).then(() => resolve("")).catch(reject);
                 });
             };
         }


### PR DESCRIPTION
The returned api promise will now only be resolved by the end of stdout processing for git command output handling.  The promise was being resolved early before the output handlers had run.

This was found during testing of an upcoming mail-archive-helper.test.ts contribution.  In successful processing everything is fine as promises are completed and notes are updated correctly.

The problem is that in the `git function`, a call to `GitProcess.exec` always resolves the promise.  If there is a callback handler, it may run after this and do a second (pointless) resolve on the promise.  For mail archive handling, this means the `git log` command completes before the log output has been processed and the updated `state.latestRevision` may be set before exceptions are thrown.  During log handling in the callback, it may set notes that are not yet available to the caller of the log processor due to the early promise resolve.