### PR TITLE
Support mostly lowercase `In-reply-to` header

### DIFF
--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -114,7 +114,7 @@ export function parseMBoxMessageIDAndReferences(parsed: IParsedMBox):
     const msgIdRegex =
         /^\s*<([^>]+)>(\s*|,)(\([^")]*("[^"]*")?\)\s*|\([^)]*\)$)?(<.*)?$/;
     for (const header of parsed.headers ?? []) {
-        if (header.key === "In-Reply-To" || header.key === "References") {
+        if (header.key.match(/In-Reply-To|References/i)) {
             let value: string = header.value.replace(/[\r\n]/g, " ");
             while (value) {
                 const match = value.match(msgIdRegex);

--- a/tests/send-mail.test.ts
+++ b/tests/send-mail.test.ts
@@ -183,6 +183,8 @@ References: <pull.986.git.1624559401.gitgitgadget@gmail.com>
 Date:   Thu, 24 Feb 2022 12:35:13 -0800
 In-Reply-To: <CAPMMpogerttWdjGBNxJaqHT4bd3_igDx4_Fxev2eNHqexZ=aLQ@mail.gmail.com>
         (Tao Klerks's message of "Thu, 24 Feb 2022 18:52:27 +0100")
+In-reply-to: <lowerReply@mail.gmail.com>
+        (Tao Klerks's message of "Thu, 24 Feb 2022 18:52:27 +0100")
 Message-ID: <xmqq5yp4knpa.fsf@gitster.g>
 
 I can be pursuaded either way.
@@ -190,6 +192,7 @@ I can be pursuaded either way.
     const parsed = await parseMBox(mbox);
     const { messageID, references } = parseMBoxMessageIDAndReferences(parsed);
     expect(messageID).toEqual("xmqq5yp4knpa.fsf@gitster.g");
-    expect(references).toHaveLength(4);
+    expect(references).toHaveLength(5);
     expect(references[0]).toEqual("pull.986.git.1624559401.gitgitgadget@gmail.com");
+    expect(references[4]).toEqual("lowerReply@mail.gmail.com");
 });


### PR DESCRIPTION
Some email handlers may only capitalize the first header character, making the relationships unknown.

Both `In-Reply-To` and  `In-reply-to` are now accepted.

If the mail server chooses to use some form of `In-Reply-To` instead of `References`, the relationship will be created.

This was observed in some messages on the [git-mailing-list-mirror](https://github.com/gitgitgadget/git-mailing-list-mirror/commits/lore-1/m).