### PR TITLE
CI: add tests for git serialization and sequencing

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "transform": {
       "\\.(ts|tsx)$": "ts-jest"
     },
-    "testRegex": "/tests/(?!test-lib).*\\.(ts|tsx|js)$"
+    "testRegex": "/tests/.*\\.test\\.(ts|tsx|js)$"
   },
   "devDependencies": {
     "@types/html-to-text": "^8.1.1",

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,6 +1,95 @@
-import { expect, test } from "@jest/globals";
-import { gitConfig } from "../lib/git";
+import { expect, jest, test } from "@jest/globals";
+import { git, gitConfig } from "../lib/git";
+import logger from "./logger";
+
+jest.setTimeout(180000);
+
+// init config in env
+const configCount = 20;
+process.env.GIT_CONFIG_COUNT = `${configCount}`;
+for (let i = 0; i < configCount; i++) {
+    process.env[`GIT_CONFIG_KEY_${i}`] = `TEST.TS.case${i}`;
+    process.env[`GIT_CONFIG_VALUE_${i}`] = `test.case${i} value`;
+}
+
+const sleep = async (ms: number) => {
+    await new Promise<void>((resolve) => {
+        setTimeout(() => { resolve(); }, ms);
+    });
+};
 
 test("finds core.bare", async () => {
     expect(await gitConfig("core.bare")).toMatch(/true|false/);
+});
+
+test("serialization", async () => {
+    let waitTime = 10;
+    type vars = { myWait: number; waitTime: number };
+    const times = new Array<vars>();
+
+    const lineHandler = async (): Promise<void> => {
+        if (waitTime) {
+            const myWait = --waitTime;
+            logger(`waiting ${myWait}`);
+            await sleep(waitTime*50+waitTime%2*60); // odd/even have different waits
+            logger(`waiting ${myWait} done`);
+            // track waitTime before and after wait
+            times.push( {myWait, waitTime});
+        }
+    };
+
+    expect(await git(["config", "--get-regexp", "TEST"], {lineHandler})).toMatch("");
+    times.map((el) => {
+        logger(el.waitTime, el.myWait);
+    });
+    times.map((el) => {
+        expect(el.waitTime).toEqual(el.myWait);
+    });
+});
+
+test("sequencing", async () => {
+    let waitTime = configCount;
+    let buffer = "";
+
+    const lineHandler = async (line: string): Promise<void> => {
+        waitTime--;
+        await sleep(waitTime*50+waitTime%2*60); // odd/even have different waits
+        buffer += `${line}\n`;
+    };
+
+    expect(await git(["config", "--get-regexp", "TEST"], {lineHandler})).toMatch("");
+    expect(await git(["config", "--get-regexp", "TEST"], { trimTrailingNewline: false })).toEqual(buffer);
+});
+
+test("slow stdout", async () => {
+    // ready for syntax checking
+    const codeModel = `
+    {
+        let i = 30;
+        const o = setInterval(() => {
+            process.stdout.write('Printing line ' + i + '$nl');
+            if (!--i) {
+                clearInterval(o);
+            }
+        }, 100);
+    }
+    `;
+
+    // compact spaces/newlines and add one as needed
+    const code = codeModel.replace(/ +/g, " ").replace(/\n/g, "").replace(/\$nl/, "\\n");
+
+    let buffer = "";
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    const lineHandler = async (line: string): Promise<void> => {
+        buffer += `${line}\n`;
+    };
+
+    // set config (using "-c", `alias.node="!node"`, does not work - ! is escaped)
+    process.env.GIT_CONFIG_COUNT = `1`;
+    process.env.GIT_CONFIG_KEY_0 = `alias.node`;
+    process.env.GIT_CONFIG_VALUE_0 = `!node`;
+
+    expect(await git([`node`, `-e`, `${code}`], {lineHandler})).toEqual("");
+    expect(await git([`node`, `-e`, `${code}`])).toEqual(buffer);
 });

--- a/tests/logger.ts
+++ b/tests/logger.ts
@@ -1,0 +1,20 @@
+// Utility to assist in testing.  Provides a logger to use if --GGGVERBOSE is specified on the command.
+// This makes it easier to leave verbose log info in the source in case it is needed.
+// Normal use would be: npm test --GGGVERBOSE some.test.ts
+
+// Using code:
+// import logger from "./logger";
+// logger("some  test related data");
+
+const logger = (() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const debugLog = (...body: any[]) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return console.log(...body);
+    };
+    const nodebugLog = () => { return; };
+
+    return process.env.npm_config_GGGVERBOSE ? debugLog : nodebugLog;
+})();
+
+export default logger;


### PR DESCRIPTION
Multiple commits in the patch series.

1. Ci: add a logger if --GGGVERBOSE is specified
   Utility to allow tracing to be left in test cases.  It would be displayed if --GGGVERBOSE is specified on the npm command.

    Usage:
    import logger from "./logger";
    logger("some  test related data");

2. CI: Add tests for git  line handlers
Three new tests to check serial execution, sequence of execution and slow git command processing.  The first two are similar but slightly different.  Serial checks to ensure other promises do not start before the current function has returned. Sequencing checks to ensure the output is processed in the proper order.
The slow processing tests verifies the command output is handled okay even when the command completes earlier.

3. git.ts: revert 49b15b8 (git linehandler issue)

    There are some issues with this patch.  Reverting to prior code pending another solution (a recent change appears to fix the problem).

Prior to the last commit to remove a previous commit (not sure of the best way to do this), [jobs](https://github.com/gitgitgadget/gitgitgadget/actions/runs/3820754267) were failing.