### PR TITLE
ci: support jsdoc linter updates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,7 +86,13 @@ module.exports = {
                 ]
             }
         ],
-        "jsdoc/newline-after-description": "error",
+        "jsdoc/tag-lines": [
+            "error",
+            "any",
+            {
+                "startLines": 1,
+            },
+        ],
         "max-classes-per-file": [
             "error",
             1

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-anti-trojan-source": "^1.1.1",
         "eslint-plugin-jest": "^27.2.1",
-        "eslint-plugin-jsdoc": "^41.1.2",
+        "eslint-plugin-jsdoc": "^43.1.1",
         "jest": "^28.1.3",
         "jest-junit": "^16.0.0",
         "test-smtp-server": "0.9.7",
@@ -663,17 +663,17 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.0.tgz",
-      "integrity": "sha512-hjK0wnsPCYLlF+HHB4R/RbUjOWeLW2SlarB67+Do5WsKILOkmIZvvPJFbtWSmbypxcjpoECLAMzoao0D4Bg5ZQ==",
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.1.tgz",
+      "integrity": "sha512-5vxWJ1gEkEF0yRd0O+uK6dHJf7adrxwQSX8PuRiPfFSAbNLnY0ZJfXaZucoz14Jj2N11xn2DnlEPwWRpYpvRjg==",
       "dev": true,
       "dependencies": {
         "comment-parser": "1.3.1",
-        "esquery": "^1.4.0",
+        "esquery": "^1.5.0",
         "jsdoc-type-pratt-parser": "~4.0.0"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+        "node": "^14 || ^16 || ^17 || ^18 || ^19 || ^20"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3087,22 +3087,22 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "41.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-41.1.2.tgz",
-      "integrity": "sha512-MePJXdGiPW7AG06CU5GbKzYtKpoHwTq1lKijjq+RwL/cQkZtBZ59Zbv5Ep0RVxSMnq6242249/n+w4XrTZ1Afg==",
+      "version": "43.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-43.1.1.tgz",
+      "integrity": "sha512-J2kjjsJ5vBXSyNzqJhceeSGTAgVgZHcPSJKo3vD4tNjUdfky98rR2VfZUDsS1GKL6isyVa8GWvr+Az7Vyg2HXA==",
       "dev": true,
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.37.0",
+        "@es-joy/jsdoccomment": "~0.37.1",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.3.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.5.0",
-        "semver": "^7.3.8",
+        "semver": "^7.5.0",
         "spdx-expression-parse": "^3.0.1"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+        "node": ">=16"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
@@ -5764,9 +5764,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7046,13 +7046,13 @@
       }
     },
     "@es-joy/jsdoccomment": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.0.tgz",
-      "integrity": "sha512-hjK0wnsPCYLlF+HHB4R/RbUjOWeLW2SlarB67+Do5WsKILOkmIZvvPJFbtWSmbypxcjpoECLAMzoao0D4Bg5ZQ==",
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.1.tgz",
+      "integrity": "sha512-5vxWJ1gEkEF0yRd0O+uK6dHJf7adrxwQSX8PuRiPfFSAbNLnY0ZJfXaZucoz14Jj2N11xn2DnlEPwWRpYpvRjg==",
       "dev": true,
       "requires": {
         "comment-parser": "1.3.1",
-        "esquery": "^1.4.0",
+        "esquery": "^1.5.0",
         "jsdoc-type-pratt-parser": "~4.0.0"
       }
     },
@@ -8902,18 +8902,18 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "41.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-41.1.2.tgz",
-      "integrity": "sha512-MePJXdGiPW7AG06CU5GbKzYtKpoHwTq1lKijjq+RwL/cQkZtBZ59Zbv5Ep0RVxSMnq6242249/n+w4XrTZ1Afg==",
+      "version": "43.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-43.1.1.tgz",
+      "integrity": "sha512-J2kjjsJ5vBXSyNzqJhceeSGTAgVgZHcPSJKo3vD4tNjUdfky98rR2VfZUDsS1GKL6isyVa8GWvr+Az7Vyg2HXA==",
       "dev": true,
       "requires": {
-        "@es-joy/jsdoccomment": "~0.37.0",
+        "@es-joy/jsdoccomment": "~0.37.1",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.3.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.5.0",
-        "semver": "^7.3.8",
+        "semver": "^7.5.0",
         "spdx-expression-parse": "^3.0.1"
       }
     },
@@ -10861,9 +10861,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-anti-trojan-source": "^1.1.1",
     "eslint-plugin-jest": "^27.2.1",
-    "eslint-plugin-jsdoc": "^41.1.2",
+    "eslint-plugin-jsdoc": "^43.1.1",
     "jest": "^28.1.3",
     "jest-junit": "^16.0.0",
     "test-smtp-server": "0.9.7",

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -395,7 +395,6 @@ test("test missing values in response using small schema", async () => {
      * url: "",
      * data: [pullRequestSimple],
      * };
-     *
      */
 
     interface IBasicUser {


### PR DESCRIPTION
- lint: remove trailing empty line
  jsdoc comments prefer no trailing empty lines.

- build(deps-dev): bump eslint-plugin-jsdoc 43.1.1
  Update eslintrc.js for breaking changes in the plugin rules.