### PR TITLE
Add support for distributed notes updates

### DIFF
--- a/lib/git-notes.ts
+++ b/lib/git-notes.ts
@@ -1,6 +1,22 @@
 import { emptyBlobName, git, revParse } from "./git";
 import { fromJSON, toJSON } from "./json-util";
 
+export type POJO = { [name: string]: string | string[] | number | number[] | boolean | POJO };
+
+/*
+ * Represents a temporary Git index that reflects a note tip commit, ready
+ * for making changes without committing them immediately.
+ *
+ * The purpose of this data structure is to support the `GitNotes.notesSync()`
+ * method.
+ */
+type TemporaryNoteIndex = {
+    appendNote: (oid: string, text: string) => Promise<void>,
+    setTextNote: (oid: string, text: string) => Promise<void>,
+    mutateObject: (oid: string, fn: (o: POJO) => void) => Promise<void>,
+    writeTree: () => Promise<string>
+};
+
 export class GitNotes {
     public static readonly defaultNotesRef = "refs/notes/gitgitgadget";
     public readonly workDir?: string;
@@ -101,5 +117,251 @@ export class GitNotes {
         return await git(["notes", `--ref=${this.notesRef}`, ...args], {
             workDir: this.workDir,
         });
+    }
+
+    /**
+     * Replay local-first changes on top of a quite possibly changed upstream note ref tip commit.
+     *
+     * This is intended to help in a situation where a GitHub workflow tended to some of GitGitGadget's "household
+     * chores" and updates `refs/notes/gitgitgadget` to reflect the new state, and then detects that a concurrent GitHub
+     * workflow updated that state already and pushed it to the remote repository.
+     *
+     * To deal with that, this method will reconstruct the changes that have been made to the local-only commits, and
+     * then replay them onto the upstream tip commit so that the notes ref can be pushed with the local updates
+     * (fast-forwarding).
+     *
+     * The logic is versatile enough to replay all of the changes GitGitGadget regularly makes, but it is of course no
+     * panacea: any GitHub workflow that uses this method _must_ ensure a concurrency limit (and not cancel any run that
+     * is in progress to avoid losing local-only state that reflects actual changes that were made, because that would
+     * potentially result e.g. in multiple identical comments being added to the PRs due to GitGitGadget "forgetting"
+     * that it already added the comment).
+     *
+     * Note: Instead of imitating `git replay` by rebasing the individual commits, this method infers the intention of
+     * the diff of the local-only changes and then applies the corresponding changes to a temporary Git index that is
+     * initialized using the upstream commit. Then a proper merge commit is added to combine the diverging commit
+     * histories.
+     *
+     * @param upstreamCommit The commit to merge (typically the just-fetched notes ref that diverges from the local
+     * notes ref)
+     * @returns the SHA of the merge commit to which the local notes ref was updated
+     */
+    public async notesSync(upstreamCommit: string): Promise<string> {
+        const options = { workDir: this.workDir };
+        const head = await git(["rev-parse", this.notesRef], options);
+        if (head === upstreamCommit) return head;
+        const mergeBases = (await git(["merge-base", "-a", head, upstreamCommit], options))
+            .trim()
+            .split(/\s+/);
+        if (mergeBases.length !== 1)
+            throw new Error(`${head}/${upstreamCommit}: single merge expected, got ${mergeBases.join(', ')}`);
+        if (mergeBases[0] === head) return upstreamCommit;
+        if (mergeBases[0] === upstreamCommit) return head;
+
+        const tmpIndex = await this.makeTemporaryNotesIndex(upstreamCommit, this.workDir);
+
+        // Need to do a 3-way merge
+        // not as easy as `git merge-tree` because some file contain JSON objects that need special handling
+        const diff = await git(["diff", mergeBases[0], head, "--"], options);
+        const fileNameRegExp = "(?:\\/dev\\/null|[ab]\\/(.*))";
+        const lineRangeRegExp = "(\\d+)(?:,(\\d+))?";
+        const diffSplitRegExp = new RegExp(
+            `(?:^|\\n)diff[^]*?\\n` +
+            `--- ${fileNameRegExp}\\n` +
+            `\\+\\+\\+ ${fileNameRegExp}\\n` +
+            `@@ -${lineRangeRegExp} \\+${lineRangeRegExp}.* @@.*\\n`
+        );
+        const split = diff.split(diffSplitRegExp);
+        for (let i = 1; i < split.length; i += 7) {
+            const oid = (split[i] || split[i + 1]).replace(/\//g, '');
+
+            const oldCount = split[i + 3] ? parseInt(split[i + 3], 10) : 1;
+            const newCount = split[i + 5] ? parseInt(split[i + 5], 10) : 1;
+
+            // is it an append?
+            if (oldCount < newCount && ((newCount - oldCount) % 2) === 0) {
+                const lines = split[i + 6].split(/\n/g);
+                const unexpected = lines.filter((e, j) => j < oldCount ? !e.startsWith(' ') : !e.startsWith('+'));
+                if (unexpected.length > 0) {
+                    throw new Error(`Unexpected append lines:\n${lines.join("\n")}, unexpected: ${unexpected}`);
+                }
+                const appended = lines.slice(oldCount, newCount).map(e => e.replace(/^\+/, ""));
+                if (!appended) throw new Error(`Not an append?\n${split[i + 6]}`);
+                await tmpIndex.appendNote(oid, appended.join('\n'));
+                continue;
+            }
+
+            if (newCount !== 1) throw new Error(`Modified more than a single line?\n${split[i + 6]}`);
+
+            // does it modify an existing object?
+            const modifiesObject = split[i + 6].match(/(^|\n)\+[[{"]/);
+
+            if (!modifiesObject) {
+                const text = split[i + 6].match(/(?:^|\n)\+(.*)\n?$/);
+                if (!text) throw new Error(`Not a single modified line?\n${split[i + 6]}`);
+                await tmpIndex.setTextNote(oid, text[1]);
+                continue;
+            }
+
+            const removeAdd = split[i + 6].match(/^(?:-(.*)\n)?\+(.*)$/);
+            if (!removeAdd) throw new Error(`Not a single modified line?\n${split[i + 6]}`);
+
+            const oOld = removeAdd[1] ? fromJSON<POJO>(removeAdd[1]) : {};
+            const oNew = fromJSON<POJO>(removeAdd[2]);
+            const mutation = this.inferMutation(oOld, oNew);
+            if (mutation !== null) await tmpIndex.mutateObject(oid, mutation);
+        }
+
+        const tree = await tmpIndex.writeTree();
+        const commit = await git([
+            "commit-tree", "-p", head, "-p", upstreamCommit, "-m", "Merge upstream", tree
+        ], options);
+        await git(["update-ref", "-m", "Merge upstream", this.notesRef, commit, head], options);
+        return commit;
+    }
+
+    /**
+     * Initializes a temporary Git index using a given revision (that is typically the upstream notes ref). Returns a
+     * data structure to mutate that index and eventually write out a Git tree ready for committing.
+     *
+     * @param revision the commit from which to initialize the temporary Git index (typically the tip commit of a
+     * just-fetched `refs/notes/gitgitgadget` note)
+     * @param workDir the Git work-tree or bare repository to work with
+     * @returns a temporary Git index structure ready to be mutated
+     */
+    protected async makeTemporaryNotesIndex(revision: string, workDir?: string): Promise<TemporaryNoteIndex> {
+        const options = {
+            env: { ...process.env },
+            workDir
+        };
+
+        // read the notes into the index
+        options.env.GIT_INDEX_FILE = await git(["rev-parse", "--git-path", `index.${revision}`], options);
+        await git(["read-tree", revision], options);
+
+        // determine the fan-out level
+        const emptyBlobPath = await git([
+            "ls-files", `${emptyBlobName.slice(0, 2)}*${emptyBlobName.slice(16)}`
+        ], options);
+        const cutoff = (emptyBlobPath.match(/\//g)?.length || 0) * 2 + 2;
+        const oid2notesPath = cutoff < 4
+            ? (oid: string) => oid
+            : (oid: string) => `${oid.slice(0, cutoff).match(/../g)?.join("/")}${oid.slice(cutoff)}`;
+        if (emptyBlobPath !== oid2notesPath(emptyBlobName)) {
+            throw new Error(`Fan-out mis-detected: ${emptyBlobPath} != ${oid2notesPath(emptyBlobName)}`);
+        }
+
+        const get = async (oid: string): Promise<string> => {
+            try {
+                return await git(["cat-file", "blob", `:${oid2notesPath(oid)}`], options);
+            } catch (e) {
+                return "";
+            }
+        };
+
+
+        const set = async (oid: string, text: string): Promise<void> => {
+            const blob = await git(["hash-object", "-w", "--stdin"], { stdin: text, ...options });
+            await git(["update-index", "--add", "--cacheinfo", `100644,${blob},${oid2notesPath(oid)}`], options);
+        };
+
+        return {
+            async appendNote(oid: string, text: string): Promise<void> {
+                const originalNote = await get(oid);
+                await set(oid, originalNote === "" ? text : `${originalNote}\n${text}\n`);
+            },
+            async setTextNote(oid: string, text: string) {
+                await set(oid, `${text}\n`);
+            },
+            async mutateObject(oid, fn: (o: POJO) => void): Promise<void> {
+                const originalNote = await get(oid);
+                const o = fromJSON<POJO>(originalNote || "{}");
+                fn(o);
+                const modifiedNote = `${toJSON(o)}\n`;
+                if (originalNote !== modifiedNote) await set(oid, modifiedNote);
+            },
+            async writeTree(): Promise<string> {
+                const out = await git(["write-tree"], options);
+                return out.trim();
+            }
+        };
+    }
+
+    /**
+     * Infers what changes there are between two versions of the same object and returns a function that would repeat
+     * that mutation. This function can then be used to apply the same changes to a different version of the object.
+     *
+     * By preferring the local changes in case of disagreement, this function can be used to implement a strategy
+     * similar to [Conflict-free replicated data
+     * types](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type) to allow GitGitGadget to maintain a
+     * global state in the `refs/notes/gitgitgadget` note at https://github.com/gitgitgadget/git that is updated
+     * concurrently by independently-operating GitHub workflows.
+     *
+     * @param oOld the old version of the object
+     * @param oNew the new version of the object
+     * @returns a function that would mutate `oOld` to look like `oNew`, ready to be applied to a different version of
+     * the object
+     */
+    protected inferMutation(oOld: POJO, oNew: POJO): null | ((o: POJO) => void) {
+        const keys = new Set<string>([...Object.keys(oOld), ...Object.keys(oNew)]);
+        const mutations = new Array<(o: POJO) => void>();
+        for (const key of keys) {
+            const aNew = oNew[key];
+            if (aNew === undefined) {
+                mutations.push((o: POJO) => {
+                    delete o[key];
+                });
+                continue;
+            }
+
+            const aOld = oOld[key];
+            const isArray = Array.isArray(aOld !== undefined ? aOld : aNew);
+            if (isArray) {
+                if (!Array.isArray(aNew)) throw new Error(`'${key}' was an array but now is not?`);
+                const itemsOld = aOld === undefined ? new Set() : new Set(aOld as string[]);
+
+                mutations.push((o: POJO) => {
+                    if (o[key] === undefined) o[key] = [];
+                });
+
+                for (const item of aNew as string[]) {
+                    if (!itemsOld.has(item)) mutations.push((o: POJO) => {
+                        (o[key] as string[]).push(item);
+                    });
+                }
+
+                if (aOld === undefined) continue;
+
+                const itemsNew = new Set(aNew as string[]);
+                for (const item of aOld as string[]) {
+                    if (!itemsNew.has(item)) mutations.push((o: POJO) => {
+                        const index = (o[key] as string[]).indexOf(item);
+                        if (index >= 0) (o[key] as string[]).splice(index, 1);
+                    });
+                }
+                continue;
+            }
+
+            const isObject = "object" === typeof (aOld !== undefined ? aOld : aNew);
+            if (!isObject) {
+                // is a primitive value
+                if (aOld !== aNew) mutations.push((o: POJO) => { o[key] = aNew; });
+                continue;
+            }
+
+            // is an object
+            const mutation = this.inferMutation(
+                aOld === undefined ? {} : aOld as POJO,
+                aNew === undefined ? {} : aNew as POJO
+            );
+            if (mutation === null) continue;
+            mutations.push((o: POJO) => {
+                if (o[key] === undefined) o[key] = {};
+                mutation(o[key] as POJO);
+            });
+        }
+        if (mutations.length === 0) return null;
+        return (o: POJO) => {
+            mutations.forEach(m => m(o));
+        };
     }
 }

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -22,6 +22,9 @@ function trimTrailingNewline(str: string): string {
 
 export function git(args: string[], options?: IGitOptions | undefined):
     Promise<string> {
+    // allow the command to run in a bare repository
+    if (options?.workDir?.endsWith(".git")) args = [`--git-dir=${options.workDir}`, ...args];
+
     const workDir = options && options.workDir || ".";
     if (options && options.trace) {
         process.stderr.write(`Called 'git ${args.join(" ")}' in '${workDir

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -10,6 +10,7 @@ export interface IGitOptions {
     workDir?: string;
     trimTrailingNewline?: boolean; // defaults to true
     trace?: boolean;
+    env?: NodeJS.ProcessEnv;
 }
 
 export const emptyBlobName = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391";

--- a/tests/git-notes.test.ts
+++ b/tests/git-notes.test.ts
@@ -1,7 +1,7 @@
 import { expect, jest, test } from "@jest/globals";
 import { isDirectory } from "../lib/fs-util";
 import { git, revParse } from "../lib/git";
-import { GitNotes } from "../lib/git-notes";
+import { GitNotes, POJO } from "../lib/git-notes";
 import { IPatchSeriesMetadata } from "../lib/patch-series-metadata";
 import { testCreateRepo } from "./test-lib";
 
@@ -43,4 +43,50 @@ test("set/get notes", async () => {
     expect(await notes.appendCommitNote(commit as string, "2")).toEqual("");
     expect(await notes.getCommitNotes(commit as string)).toEqual("1\n\n2");
     expect(await notes.getLastCommitNote(commit as string)).toEqual("2");
+});
+
+test("notesMerge()", async () => {
+    const repo = await testCreateRepo(__filename);
+    const notes = new GitNotes(repo.workDir);
+
+    const somePrimeNumbers = [2, 3, 7, 11, 13];
+    const o: POJO = { hello: "world", somePrimeNumbers };
+    o.extra = true;
+    const o2 = JSON.parse(JSON.stringify(o)) as POJO; // o.clone()
+
+    await notes.set("", o);
+    const commit = await revParse(notes.notesRef, repo.workDir);
+    expect(commit).not.toBeUndefined();
+    await notes.appendCommitNote(commit as string, "first note");
+
+    // branch off
+    const branchPoint = await revParse(notes.notesRef, repo.workDir);
+    await notes.appendCommitNote(commit as string, "low note");
+    somePrimeNumbers.push(17);
+    o.hello = "World!!!";
+    delete o.extra;
+    await notes.set("", o, true);
+    const branch1 = await revParse(notes.notesRef, repo.workDir);
+
+    // rewind and make some local-first changes
+    await git(["update-ref", notes.notesRef, branchPoint as string, branch1 as string], { workDir: repo.workDir });
+    await notes.appendCommitNote(commit as string, "second note");
+    await notes.setString("notes", "tsforyou");
+    o2.hello = "you!";
+    (o2.somePrimeNumbers as number[]).splice(2, 2);
+    (o2.somePrimeNumbers as number[]).push(29);
+    o2.oh = ["hai", "cat"];
+    await notes.set("", o2, true);
+
+    // now merge branch1 (or: replay HEAD onto branch1)
+    await notes.notesSync(branch1 as string);
+
+    const o3 = await notes.get("") as POJO;
+    expect(o3.extra).toBeUndefined();
+    expect(o3.somePrimeNumbers).toEqual([2, 3, 13, 17, 29]);
+    expect(o3.hello).toEqual("you!");
+    expect(o3.oh).toEqual(["hai", "cat"]);
+
+    const addedNotes = await notes.getCommitNotes(commit as string);
+    expect(addedNotes).toEqual(`first note\n\nlow note\n\nsecond note`);
 });


### PR DESCRIPTION
One of the biggest blockers preventing GitGitGadget from moving away from Azure Pipelines toward GitHub workflows is the complication that the `refs/notes/gitgitgadget` note holds global state and must therefore be updated sequentially.

In the Azure Pipelines approach, we manage that by having an agent pool of one, which naturally can only serve one request at a time. That way, every job can first fetch the GitGitGadget notes ref, do whatever it needs to do, leisurely update the notes ref to reflect the new state and push the ref. Then, the next job can do the same and there is never a situation where a job tries to push the notes ref and fails because another, concurrent job has updated said ref in the meantime.

For various reasons, adding a pool of one to GitHub Actions is impractical.

In this PR, I propose a solution that allows for jobs to run concurrently, fetching the GitGitGadget notes, doing their thing, updating the notes ref along the way, and once it is time to push the notes ref and a situation is detected where it does not fast-forward, combine the changes in a way that is inspired by [Conflict-free replicated data types (CRTD)](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type), so that it can be pushed without problems after all.

The strategy implemented in this PR is to prefer the local changes in case of a hard conflict.

This means we will still have to be careful to avoid the same GitHub workflow to run concurrently: for example, we really will only ever want at most a single instance of the job to run whose responsibility it is to read new mails from the Git mailing list and mirror the relevant ones into the corresponding PRs. Should two jobs of that workflow run at the same time, they would end up adding PR comments _twice_, which is undesirable.

However, this PR unlocks the idea to let the workflow that mirrors the Git mailing list to the PRs run concurrently with multiple workflows that submit PRs as patches to the Git mailing list.

Note that this PR only adds that functionality, but it is in no way used yet. This will be the purpose of a follow-up PR.