### PR TITLE
build(deps): fix bump marked from 10.0.0 to 11.1.0

### DIFF
--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -83,5 +83,5 @@ export function md2text(markdown: string, columns = 76): string {
         ],
     };
 
-    return htmlToText(marked.parse(markdown), formatOptions);
+    return htmlToText(marked.parse(markdown) as string, formatOptions);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "json-stable-stringify": "^1.1.0",
         "jsonwebtoken": "^9.0.2",
         "mailparser": "^3.6.5",
-        "marked": "^10.0.0",
+        "marked": "^11.1.0",
         "nodemailer": "^6.9.7",
         "rfc2047": "^4.0.1"
       },
@@ -5400,9 +5400,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-10.0.0.tgz",
-      "integrity": "sha512-YiGcYcWj50YrwBgNzFoYhQ1hT6GmQbFG8SksnYJX1z4BXTHSOrz1GB5/Jm2yQvMg4nN1FHP4M6r03R10KrVUiA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.1.0.tgz",
+      "integrity": "sha512-fvKJWAPEafVj1dwGwcPI5mBB/0pvViL6NlCbNDG1HOIRwwAU/jeMoFxfbRLuirO1wRH7m4yPvBqD/O1wyWvayw==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11022,9 +11022,9 @@
       "dev": true
     },
     "marked": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-10.0.0.tgz",
-      "integrity": "sha512-YiGcYcWj50YrwBgNzFoYhQ1hT6GmQbFG8SksnYJX1z4BXTHSOrz1GB5/Jm2yQvMg4nN1FHP4M6r03R10KrVUiA=="
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.1.0.tgz",
+      "integrity": "sha512-fvKJWAPEafVj1dwGwcPI5mBB/0pvViL6NlCbNDG1HOIRwwAU/jeMoFxfbRLuirO1wRH7m4yPvBqD/O1wyWvayw=="
     },
     "meow": {
       "version": "10.1.3",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "json-stable-stringify": "^1.1.0",
     "jsonwebtoken": "^9.0.2",
     "mailparser": "^3.6.5",
-    "marked": "^10.0.0",
+    "marked": "^11.1.0",
     "nodemailer": "^6.9.7",
     "rfc2047": "^4.0.1"
   },


### PR DESCRIPTION
Cast `marked.parse()` return value as string.

Fix for failing #1507.