### PR TITLE
WELCOME: add a note about single-commit PRs

### DIFF
--- a/res/WELCOME.md
+++ b/res/WELCOME.md
@@ -2,7 +2,9 @@
 
 Hi @${username}, and welcome to GitGitGadget, the GitHub App to send patch series to the Git mailing list from GitHub Pull Requests.
 
-Please make sure that your Pull Request has a good description, as it will be used as cover letter. You can CC potential reviewers by adding a footer to the PR description with the following syntax:
+Please make sure that your Pull Request has a good description, as it will be used as cover letter.
+
+You can CC potential reviewers by adding a footer to the PR description with the following syntax:
 
     CC: Revi Ewer <revi.ewer@example.com>, Ill Takalook <ill.takalook@example.net>
 

--- a/res/WELCOME.md
+++ b/res/WELCOME.md
@@ -2,7 +2,10 @@
 
 Hi @${username}, and welcome to GitGitGadget, the GitHub App to send patch series to the Git mailing list from GitHub Pull Requests.
 
-Please make sure that your Pull Request has a good description, as it will be used as cover letter.
+Please make sure that either:
+
+- Your Pull Request has a good description, if it consists of multiple commits, as it will be used as cover letter.
+- Your Pull Request description is empty, if it consists of a single commit, as the commit message should be descriptive enough by itself.
 
 You can CC potential reviewers by adding a footer to the PR description with the following syntax:
 

--- a/res/WELCOME.md
+++ b/res/WELCOME.md
@@ -15,7 +15,7 @@ Also, it is a good idea to review the commit messages one last time, as the Git 
 
 * the lines should not exceed 76 columns,
 * the first line should be like a header and typically start with a prefix like "tests:" or "revisions:" to state which subsystem the change is about, and
-* the commit messages' body should be describing the "why?" of the change.
+* the commit messages' body should be [describing the "why?" of the change](https://git-scm.com/docs/SubmittingPatches#describe-changes).
 * Finally, the commit messages should end in a [Signed-off-by:](https://git-scm.com/docs/SubmittingPatches#dco) line matching the commits' author.
 
 It is in general a good idea to await the automated test ("Checks") in this Pull Request before contributing the patches, e.g. to avoid trivial issues such as unportable code.


### PR DESCRIPTION
Contributors continue to send single-commit PRs to the mailing list with identical text in their commit message and below the three-dash line.

This is another simple attempt to try to prevent that.

In https://github.com/gitgitgadget/gitgitgadget.github.io/pull/8#issuecomment-1133758832 Dscho suggested adding such a check in Gitgitgadget itself, which I think is a good idea, but I lack the time to pursue it currently.

And, the current change to the welcome message does not make it _that much_ longer, which I think is a good compromise. 