### PR TITLE
eslint: new version preparation

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -122,9 +122,9 @@ export class CIHelper {
         }
         await this.notes.set(messageID, mailMeta, true);
 
-        if (!this.testing && mailMeta.pullRequestURL && mailMeta.pullRequestURL.startsWith(this.urlBase) ) {
-            await this.github.annotateCommit(mailMeta.originalCommit, upstreamCommit,
-                this.config.repo.owner, this.config.repo.baseOwner);
+        if (!this.testing && mailMeta.pullRequestURL && mailMeta.pullRequestURL.startsWith(this.urlBase)) {
+            await this.github.annotateCommit(mailMeta.originalCommit, upstreamCommit, this.config.repo.owner,
+                this.config.repo.baseOwner);
         }
 
         return true;
@@ -134,12 +134,10 @@ export class CIHelper {
         if (!this.gggNotesUpdated) {
             const args: string[] = [];
 
-            args.push(...this.config.repo.branches.map(branch =>
+            args.push(...this.config.repo.branches.map((branch) =>
                 `+refs/heads/${branch}:refs/remotes/upstream/${branch}`));
 
-            await git(["fetch", this.urlRepo, "--tags",
-                       "+refs/notes/gitgitgadget:refs/notes/gitgitgadget",
-                       ...args],
+            await git(["fetch", this.urlRepo, "--tags", "+refs/notes/gitgitgadget:refs/notes/gitgitgadget", ...args],
                       { workDir: this.workDir });
             this.gggNotesUpdated = true;
         }
@@ -150,9 +148,7 @@ export class CIHelper {
         }
 
         const commitsInSeen: Set<string> = new Set<string>(
-            (await git(["rev-list", "--no-merges",
-                        "^refs/remotes/upstream/maint~100",
-                        "refs/remotes/upstream/seen"],
+            (await git(["rev-list", "--no-merges", "^refs/remotes/upstream/maint~100", "refs/remotes/upstream/seen"],
                        { workDir: this.workDir })).split("\n"),
         );
         let result = false;
@@ -166,8 +162,7 @@ export class CIHelper {
         const heads = new Set<string>();
         for (const pullRequestURL of Object.keys(options.openPRs)) {
             const info = await this.getPRMetadata(pullRequestURL);
-            if (info === undefined || info.latestTag === undefined ||
-                info.baseCommit === undefined ||
+            if (info === undefined || info.latestTag === undefined || info.baseCommit === undefined ||
                 info.headCommit === undefined || info.baseLabel === undefined ||
                 info.baseLabel.match(/^gitgitgadget:git-gui\//)) {
                 continue;
@@ -209,8 +204,7 @@ export class CIHelper {
             const range1 = `${await octopus(bases)}..${await octopus(heads)}`;
             const range2 = "refs/remotes/upstream/maint~100..refs/remotes/upstream/seen";
             const start = Date.now();
-            const out = await git(["-c", "core.abbrev=40", "range-diff", "-s",
-                                   range1, range2],
+            const out = await git(["-c", "core.abbrev=40", "range-diff", "-s", range1, range2],
                                   { workDir: this.workDir });
             const duration = Date.now() - start;
             if (duration > 2000)
@@ -301,7 +295,7 @@ export class CIHelper {
         }
 
         const headMessageID = await this.getMessageIdForOriginalCommit(prMeta.headCommit);
-        const headMeta = headMessageID && await this.getMailMetadata(headMessageID);
+        const headMeta = headMessageID && (await this.getMailMetadata(headMessageID));
         const tipCommitInGitGit = headMeta && headMeta.commitInGitGit;
         if (!tipCommitInGitGit) {
             return [false, false];
@@ -320,8 +314,7 @@ export class CIHelper {
         const maintainerRepo = `${this.config.repo.owner}/${this.config.repo.name}`;
 
         let gitsterBranch: string | undefined =
-            await git(["for-each-ref", `--points-at=${tipCommitInGitGit}`,
-                       "--format=%(refname)", maintainerBranch],
+            await git(["for-each-ref", `--points-at=${tipCommitInGitGit}`, "--format=%(refname)", maintainerBranch],
                       { workDir: this.workDir });
         if (gitsterBranch) {
             const newline = gitsterBranch.indexOf("\n");
@@ -427,9 +420,9 @@ export class CIHelper {
     public async identifyMergeCommit(upstreamBranch: string, integratedCommit: string): Promise<string | undefined> {
         await this.maybeUpdateMail2CommitMap();
 
-        const revs =  await git(["rev-list", "--ancestry-path", "--parents",
-                                `${integratedCommit}..upstream/${upstreamBranch}`],
-                                { workDir: this.workDir });
+        const revs = await git(["rev-list", "--ancestry-path", "--parents",
+                               `${integratedCommit}..upstream/${upstreamBranch}`],
+                               { workDir: this.workDir });
         if (revs === "") {
             return undefined;
         }
@@ -440,7 +433,7 @@ export class CIHelper {
         let match = revs.match(`(^|\n)([^ ]+) ([^\n]+) ${commit}`);
         if (!match) {
             // Look for a descendant that *was* integrated via a merge
-            for (; ;) {
+            for (;;) {
                 match = revs.match(`(^|\n)([^ ]+) ${commit}(\n|$)`);
                 if (!match) {
                     // None found, return the original commit
@@ -455,7 +448,7 @@ export class CIHelper {
             }
         }
 
-        for (; ;) {
+        for (;;) {
             commit = match[2];
             // was this merge integrated via another merge?
             match = revs.match(`(^|\n)([^ ]+) ([^\n]+) ${commit}`);
@@ -488,7 +481,7 @@ export class CIHelper {
         if (!this.workDir) {
             throw new Error("Need a workDir");
         }
-        if (!await commitExists(prMeta.headCommit, this.workDir)) {
+        if (!(await commitExists(prMeta.headCommit, this.workDir))) {
             if (!prMeta.pullRequestURL) {
                 throw new Error(`Require URL in ${JSON.stringify(prMeta, null, 4)}`);
             }
@@ -502,16 +495,14 @@ export class CIHelper {
                 workDir: this.workDir,
             });
         }
-        const revs = await git(["rev-list",
-                                `${prMeta.baseCommit}..${prMeta.headCommit}`],
-                               { workDir: this.workDir });
+        const revs = await git(["rev-list", `${prMeta.baseCommit}..${prMeta.headCommit}`], { workDir: this.workDir });
         return revs.split(/\s+/);
     }
 
     protected warnOnMissingPublicEmail(username: string): string {
         return `WARNING: ${username} has no public email address set on GitHub;
-GitGitGadget needs an email address to Cc: you on your contribution, so that you receive any feedback ${ ""
-}on the Git mailing list. Go to https://github.com/settings/profile to make your preferred email public ${ ""
+GitGitGadget needs an email address to Cc: you on your contribution, so that you receive any feedback ${""
+}on the Git mailing list. Go to https://github.com/settings/profile to make your preferred email public ${""
 }to let GitGitGadget know which email address to use.`;
     }
 
@@ -526,7 +517,7 @@ GitGitGadget needs an email address to Cc: you on your contribution, so that you
         try {
             comment = await this.github.getPRComment(repositoryOwner, commentID);
         } catch (e) {
-            if (e instanceof RequestError && e.status === 404 ) {
+            if (e instanceof RequestError && e.status === 404) {
                 console.log(`Comment ${commentID} not found; doing nothing:\n'${JSON.stringify(e, null, 2)}'`);
                 return;
             } else {
@@ -544,7 +535,7 @@ GitGitGadget needs an email address to Cc: you on your contribution, so that you
         const prKey = {
             owner: repositoryOwner,
             repo: this.config.repo.name,
-            pull_number: comment.prNumber
+            pull_number: comment.prNumber,
         };
 
         const pullRequestURL = `https://github.com/${repositoryOwner}/${this.config.repo.name
@@ -590,14 +581,13 @@ GitGitGadget needs an email address to Cc: you on your contribution, so that you
                     const metadata = await gitGitGadget.submit(pr, userInfo);
                     const code = "\n```";
                     await addComment(`Submitted as [${metadata?.coverLetterMessageId
-                            }](https://${this.config.mailrepo.host}/${this.config.mailrepo.name}/${
-                            metadata?.coverLetterMessageId})\n\nTo fetch this version into \`FETCH_HEAD\`:${
-                            code}\ngit fetch ${this.urlRepo} ${metadata?.latestTag}${code
-                            }\n\nTo fetch this version to local tag \`${metadata?.latestTag}\`:${
-                            code}\ngit fetch --no-tags ${this.urlRepo} tag ${metadata?.latestTag}${code}${
-                            extraComment}`);
+                        }](https://${this.config.mailrepo.host}/${this.config.mailrepo.name}/${
+                        metadata?.coverLetterMessageId})\n\nTo fetch this version into \`FETCH_HEAD\`:${
+                        code}\ngit fetch ${this.urlRepo} ${metadata?.latestTag}${code
+                        }\n\nTo fetch this version to local tag \`${metadata?.latestTag}\`:${
+                        code}\ngit fetch --no-tags ${this.urlRepo} tag ${metadata?.latestTag}${code}${
+                        extraComment}`);
                 }
-
             } else if (command === "/preview") {
                 if (argument && argument !== "") {
                     throw new Error(`/preview does not accept arguments ('${argument}')`);
@@ -616,9 +606,8 @@ GitGitGadget needs an email address to Cc: you on your contribution, so that you
                     const metadata = await gitGitGadget.preview(pr, userInfo);
                     await addComment(`Preview email sent as ${metadata?.coverLetterMessageId}`);
                 }
-
             } else if (command === "/allow") {
-                const accountName = argument || await getPRAuthor();
+                const accountName = argument || (await getPRAuthor());
                 let extraComment = "";
                 try {
                     const userInfo = await this.github.getGitHubUserInfo(accountName);
@@ -636,7 +625,7 @@ GitGitGadget needs an email address to Cc: you on your contribution, so that you
                     await addComment(`User ${accountName} already allowed to use ${this.config.app.displayName}.`);
                 }
             } else if (command === "/disallow") {
-                const accountName = argument || await getPRAuthor();
+                const accountName = argument || (await getPRAuthor());
 
                 if (await gitGitGadget.denyUser(comment.author, accountName)) {
                     await addComment(`User ${accountName} is no longer allowed to use ${this.config.app.displayName}.`);
@@ -707,12 +696,12 @@ GitGitGadget needs an email address to Cc: you on your contribution, so that you
         if (result) {
             const results = await Promise.all(
                 commits.map((commit: IPRCommit) => {
-                const linter = new LintCommit(commit);
-                return linter.lint();
-            }));
+                    const linter = new LintCommit(commit);
+                    return linter.lint();
+                })
+            );
 
-            for (const lintError of
-                 (results.filter((el) => el) as ILintError[])) {
+            for (const lintError of results.filter((el) => el) as ILintError[]) {
                 await addComment(lintError.message);
                 if (lintError.checkFailed) {
                     result = false;
@@ -740,12 +729,12 @@ GitGitGadget needs an email address to Cc: you on your contribution, so that you
         const prKey = {
             owner: repositoryOwner,
             repo: this.config.repo.name,
-            pull_number: prNumber
+            pull_number: prNumber,
         };
 
         const pr = await this.github.getPRInfo(prKey);
 
-        const addComment = async (body: string): Promise<void>  => {
+        const addComment = async (body: string): Promise<void> => {
             const redacted = CIHelper.redactGitHubToken(body);
             console.log(`Adding comment to ${pr.pullRequestURL}:\n${redacted}`);
             await this.github.addPRComment(prKey, redacted);
@@ -753,8 +742,7 @@ GitGitGadget needs an email address to Cc: you on your contribution, so that you
 
         const gitGitGadget = await GitGitGadget.get(this.gggConfigDir, this.workDir);
         if (!pr.hasComments && !gitGitGadget.isUserAllowed(pr.author)) {
-            const welcome = (await readFile("res/WELCOME.md")).toString()
-                    .replace(/\${username}/g, pr.author);
+            const welcome = (await readFile("res/WELCOME.md")).toString().replace(/\${username}/g, pr.author);
             await this.github.addPRComment(prKey, welcome);
 
             await this.github.addPRLabels(prKey, ["new user"]);
@@ -769,11 +757,10 @@ GitGitGadget needs an email address to Cc: you on your contribution, so that you
 
     public async handleNewMails(mailArchiveGitDir: string, onlyPRs?: Set<number>): Promise<boolean> {
         await git(["fetch"], { workDir: mailArchiveGitDir });
-        const prFilter = !onlyPRs ? undefined :
-            (pullRequestURL: string): boolean => {
-                const match = pullRequestURL.match(/.*\/(\d+)$/);
-                return !match ? false : onlyPRs.has(parseInt(match[1], 10));
-            };
+        const prFilter = !onlyPRs ? undefined : (pullRequestURL: string): boolean => {
+            const match = pullRequestURL.match(/.*\/(\d+)$/);
+            return !match ? false : onlyPRs.has(parseInt(match[1], 10));
+        };
         await this.maybeUpdateGGGNotes();
         const mailArchiveGit = await MailArchiveGitHelper.get(this.notes, mailArchiveGitDir, this.github,
             this.config.mailrepo.branch);
@@ -854,8 +841,7 @@ GitGitGadget needs an email address to Cc: you on your contribution, so that you
     private async getPRInfo(prKey: pullRequestKey): Promise<IPullRequestInfo> {
         const pr = await this.github.getPRInfo(prKey);
 
-        if (!this.config.repo.owners.includes(pr.baseOwner) ||
-            pr.baseRepo !== this.config.repo.name) {
+        if (!this.config.repo.owners.includes(pr.baseOwner) || pr.baseRepo !== this.config.repo.name) {
             throw new Error(`Unsupported repository: ${pr.pullRequestURL}`);
         }
 

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -246,7 +246,7 @@ export class CIHelper {
         let result = false;
         let optionsUpdated = false;
         for (const pullRequestURL in options.openPRs) {
-            if (!options.openPRs.hasOwnProperty(pullRequestURL)) {
+            if (!Object.prototype.hasOwnProperty.call(options.openPRs, pullRequestURL)) {
                 continue;
             }
             console.log(`Handling ${pullRequestURL}`);

--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -21,7 +21,7 @@ export class LintCommit {
 
     public constructor(patch: IPRCommit, options?: ILintOptions | undefined) {
         this.blocked = false;
-        this.lines =  patch.message.split("\n");
+        this.lines = patch.message.split("\n");
         this.patch = patch;
 
         if (options !== undefined) {
@@ -35,7 +35,6 @@ export class LintCommit {
      * Linter method to run checks on the commit message.
      */
     public lint(): ILintError | void {
-
         const phase1 = [
             this.commitViable
         ];
@@ -44,12 +43,12 @@ export class LintCommit {
             this.commitMessageLength,
             this.bangPrefix,
             this.lowerCaseAfterPrefix,
-            this.signedOffBy
+            this.signedOffBy,
         ];
 
         const phase3 = [            // checks if phase1 was successful
             this.commitTextLength,
-            this.moreThanAHyperlink
+            this.moreThanAHyperlink,
         ];
 
         phase1.map((linter) => { linter(); });
@@ -64,11 +63,11 @@ export class LintCommit {
 
         if (this.messages.length) {
             this.messages.unshift(`\`${this.lines[0]}\``);
-            return { checkFailed: this.blocked,
-                     message: `There ${this.messages.length > 1 ?
-                     "are issues" : "is an issue"} in commit ${
-                     this.patch.commit}:\n${this.messages.join("\n")}`,
-                };
+            return {
+                checkFailed: this.blocked,
+                message: `There ${this.messages.length > 1 ? "are issues" : "is an issue"} in commit ${
+                    this.patch.commit}:\n${this.messages.join("\n")}`,
+            };
         }
     }
 
@@ -94,8 +93,7 @@ export class LintCommit {
 
     private commitMessageLength = (): void => {
         if (this.lines[0].length > this.maxColumns) {
-            this.block(`First line of commit message is too long (> ${
-                this.maxColumns} columns)`);
+            this.block(`First line of commit message is too long (> ${this.maxColumns} columns)`);
         }
     };
 
@@ -105,33 +103,29 @@ export class LintCommit {
 
     private commitTextLength = (): void => {
         if (this.lines.length > 2 && this.lines[1].length) {
-            this.block("The first line must be separated from the rest by an "
-                        + "empty line");
+            this.block("The first line must be separated from the rest by an empty line");
         }
 
         for (let i = 1; i < this.lines.length; i++) {
             if (this.lines[i].length > this.maxColumns &&
                 // Allow long lines if prefixed with whitespace (ex. quoted error messages)
-                (! this.lines[i].match(/^\s+/)) &&
+                !this.lines[i].match(/^\s+/) &&
                 // Allow long lines if they cannot be wrapped at some
                 // white-space character, e.g. URLs. To allow a short
                 // preamble such as `ref [1] <URL>` lines, we skip the
                 // first 10 (arbitrary) characters.
                 this.lines[i].slice(10).match(/\s/)) {
-                this.block(`Lines in the body of the commit messages ${""
-                    }should be wrapped between 60 and ${
-                    this.maxColumns} characters.\n`
-                     + `Indented lines, and lines without whitespace, are exempt`);
+                this.block(`Lines in the body of the commit messages should be wrapped between 60 and ${
+                        this.maxColumns} characters.\nIndented lines, and lines without whitespace, are exempt`);
                 break;
             }
         }
     };
 
     // Verify if the first line starts with a prefix (e.g. tests:), it continues
-    // in lower-case (except for ALL_CAPS as that is likely to be a code
-    // identifier)
+    // in lower-case (except for ALL_CAPS as that is likely to be a code identifier)
 
-    private lowerCaseAfterPrefix = (): void =>{
+    private lowerCaseAfterPrefix = (): void => {
         const match = this.lines[0].match(/^\S+?:\s*?([A-Z][a-z ])/);
 
         if (match) {
@@ -141,7 +135,7 @@ export class LintCommit {
 
     // Reject commits that appear to require rebasing
 
-    private bangPrefix = (): void =>{
+    private bangPrefix = (): void => {
         if (this.lines[0].match(/^(squash|fixup|amend)!/)) {
             this.block("Rebase needed to squash commit");
         }
@@ -150,7 +144,7 @@ export class LintCommit {
     // Verify there is a Signed-off-by: line - DCO check does this
     // already, but put out a message if it is indented
 
-    private signedOffBy = (): void =>{
+    private signedOffBy = (): void => {
         let signedFound = false;
 
         this.lines.map((line) => {
@@ -175,13 +169,12 @@ export class LintCommit {
     // Low hanging fruit: check the first line.
     // Hyperlink validation is NOT part of the test.
 
-    private moreThanAHyperlink = (): void =>{
+    private moreThanAHyperlink = (): void => {
         const line = this.lines[2];
         const match = line.match(/^(\w*)\s*https*:\/\/\S+\s*(\w*)/);
 
         if (match) {
-            if (!match[1].length && !match[2].length &&
-                this.lines.length === 5) {
+            if (!match[1].length && !match[2].length && this.lines.length === 5) {
                 this.block("A hyperlink requires some explanation");
             }
         }

--- a/lib/delete-ci-test-branches.ts
+++ b/lib/delete-ci-test-branches.ts
@@ -112,7 +112,7 @@ export async function deleteBranches(octocat: Octokit, owner: string,
         result.repository.refs.edges.map(ref => {
             const br = ref.node;
             const name = br.name;
-            const suffix = name.match(/ggg[_\-]test-branch-\S+?[\-_](.*)/);
+            const suffix = name.match(/ggg[_-]test-branch-\S+?[-_](.*)/);
 
             if (suffix && suffix[1] < expireDate) {
                 if (br.pulls.edges.length) {

--- a/lib/delete-ci-test-branches.ts
+++ b/lib/delete-ci-test-branches.ts
@@ -11,18 +11,18 @@ a workflow.  The default is to delete branches older than two days.
 
 declare type refGraph = {
     node: {                         // branches as refs
-        name: string,
-        id: string,
+        name: string;
+        id: string;
         pulls: {
             edges: [                // pull requests
                 {
                     node: {
-                        number: number,
-                    }
-                }
-            ]
-        }
-    }
+                        number: number;
+                    };
+                },
+            ];
+        };
+    };
 };
 
 // repository level results of the GraphQL query
@@ -30,9 +30,9 @@ declare type refGraph = {
 declare type repositoryGraph = {
     repository: {
         refs: {
-            edges: refGraph[]
-        }
-    }
+            edges: refGraph[];
+        };
+    };
 };
 
 /**
@@ -46,9 +46,9 @@ declare type repositoryGraph = {
  * @param dryRun skip deletion if true
  */
 export type deletionOptions = {
-    hours?: number,
-    minutes?: number,
-    dryRun?: boolean,
+    hours?: number;
+    minutes?: number;
+    dryRun?: boolean;
 };
 
 /**
@@ -109,15 +109,14 @@ export async function deleteBranches(octocat: Octokit, owner: string,
     // console.log(result.repository.refs.edges);
 
     await Promise.all(
-        result.repository.refs.edges.map(ref => {
+        result.repository.refs.edges.map((ref) => {
             const br = ref.node;
             const name = br.name;
             const suffix = name.match(/ggg[_-]test-branch-\S+?[-_](.*)/);
 
             if (suffix && suffix[1] < expireDate) {
                 if (br.pulls.edges.length) {
-                    console.log(
-                        `Closing PR ${br.pulls.edges[0].node.number}`);
+                    console.log(`Closing PR ${br.pulls.edges[0].node.number}`);
                 }
                 console.log(`Deleting branch ${br.name}`);
                 const mutate = `mutation DeleteBranch {
@@ -129,6 +128,6 @@ export async function deleteBranches(octocat: Octokit, owner: string,
                     console.log(`Deletion of refId: "${br.id}" skipped`);
                 }
             }
-        })
+        }),
     );
 }

--- a/lib/git-notes.ts
+++ b/lib/git-notes.ts
@@ -32,11 +32,9 @@ export class GitNotes {
         return await this.setString(key, toJSON(value), force);
     }
 
-    public async setString(key: string, value: string, force?: boolean):
-        Promise<void> {
+    public async setString(key: string, value: string, force?: boolean): Promise<void> {
         const obj = await this.key2obj(key);
-        if (obj !== emptyBlobName &&
-            !await revParse(`${obj}^{blob}`, this.workDir)) {
+        if (obj !== emptyBlobName && !(await revParse(`${obj}^{blob}`, this.workDir))) {
             try {
                 /*
                  * Annotate the notes ref's tip itself, just to make sure that
@@ -61,8 +59,7 @@ export class GitNotes {
         }
     }
 
-    public async appendCommitNote(commit: string, note: string):
-        Promise<string> {
+    public async appendCommitNote(commit: string, note: string): Promise<string> {
         return await this.notes("append", "-m", note, commit);
     }
 
@@ -76,12 +73,8 @@ export class GitNotes {
     }
 
     public async update(url: string): Promise<void> {
-        if (this.notesRef === "refs/notes/gitgitgadget" ||
-            this.notesRef === "refs/notes/commit-to-mail" ||
-            this.notesRef === "refs/notes/mail-to-commit") {
-            await git(["fetch", url,
-                       `+${this.notesRef}:${this.notesRef}`],
-                      { workDir: this.workDir });
+        if (this.notesRef.match(/^refs\/notes\/(gitgitgadget|commit-to-mail|mail-to-commit)$/)) {
+            await git(["fetch", url, `+${this.notesRef}:${this.notesRef}`], { workDir: this.workDir });
         } else {
             throw new Error(`Don't know how to update ${this.notesRef}`);
         }

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -19,12 +19,10 @@ function trimTrailingNewline(str: string): string {
     return str.replace(/\r?\n$/, "");
 }
 
-export function git(args: string[], options?: IGitOptions | undefined):
-    Promise<string> {
+export function git(args: string[], options?: IGitOptions | undefined): Promise<string> {
     const workDir = options && options.workDir || ".";
     if (options && options.trace) {
-        process.stderr.write(`Called 'git ${args.join(" ")}' in '${workDir
-                            }':\n${new Error().stack}\n`);
+        process.stderr.write(`Called 'git ${args.join(" ")}' in '${workDir}':\n${new Error().stack}\n`);
     }
 
     return new Promise<string>((resolve, reject) => {
@@ -94,18 +92,14 @@ export function git(args: string[], options?: IGitOptions | undefined):
             };
         }
 
-        GitProcess.exec(args, workDir, options as IGitExecutionOptions)
-        .then((result) => {
+        GitProcess.exec(args, workDir, options as IGitExecutionOptions).then((result) => {
             if (result.exitCode) {
-                reject(new Error(`git ${args.join(" ")
-                                } failed: ${result.exitCode
-                                },\n${result.stderr}`));
+                reject(new Error(`git ${args.join(" ")} failed: ${result.exitCode},\n${result.stderr}`));
                 return;
             }
             if (options && options.trace) {
-                process.stderr.write(`Output of 'git ${args.join(" ")
-                                    }':\nstderr: ${result.stderr
-                                    }\nstdout: ${result.stdout}\n`);
+                process.stderr.write(`Output of 'git ${args.join(" ")}':\nstderr: ${result.stderr}\nstdout: ${
+                                    result.stdout}\n`);
             }
             if (!options?.lineHandler) { // let callback resolve the promise
                 resolve(!options || options.trimTrailingNewline === false ?
@@ -129,11 +123,8 @@ export function git(args: string[], options?: IGitOptions | undefined):
  *    the working directory in which to run `git rev-parse`
  * @returns { string | undefined } the full SHA-1, or undefined
  */
-export async function revParse(argument: string, workDir?: string):
-    Promise<string | undefined> {
-    const result = await GitProcess.exec(["rev-parse", "--verify", "-q",
-                                          argument],
-                                         workDir || ".");
+export async function revParse(argument: string, workDir?: string): Promise<string | undefined> {
+    const result = await GitProcess.exec(["rev-parse", "--verify", "-q", argument], workDir || ".");
     return result.exitCode ? undefined : trimTrailingNewline(result.stdout);
 }
 
@@ -145,9 +136,7 @@ export async function revParse(argument: string, workDir?: string):
  *    the working directory in which to run `git rev-parse`
  * @returns number the number of commits in the commit range
  */
-export async function revListCount(rangeArgs: string | string[],
-                                   workDir = "."):
-    Promise<number> {
+export async function revListCount(rangeArgs: string | string[], workDir = "."): Promise<number> {
     const gitArgs: string[] = ["rev-list", "--count"];
     if (typeof(rangeArgs) === "string") {
         gitArgs.push(rangeArgs);
@@ -169,13 +158,11 @@ export async function revListCount(rangeArgs: string | string[],
  * @param {string} workDir the Git worktree where to look
  * @returns {boolean} whether the commit exists
  */
-export async function commitExists(commit: string, workDir: string):
-    Promise<boolean> {
+export async function commitExists(commit: string, workDir: string): Promise<boolean> {
     return await revParse(`${commit}^{commit}`, workDir) !== undefined;
 }
 
-export async function gitConfig(key: string, workDir?: string):
-    Promise<string | undefined> {
+export async function gitConfig(key: string, workDir?: string): Promise<string | undefined> {
     const result = await GitProcess.exec(["config", key], workDir || ".");
     if (result.exitCode !== 0) {
         return undefined;
@@ -187,13 +174,11 @@ export async function gitConfigForEach(key: string,
                                        callbackfn: (value: string) => void,
                                        workDir?: string):
     Promise<void> {
-    const result = await GitProcess.exec(["config", "--get-all", key],
-                                         workDir || ".");
+    const result = await GitProcess.exec(["config", "--get-all", key], workDir || ".");
     result.stdout.split(/\r?\n/).map(callbackfn);
 }
 
-export async function gitCommandExists(command: string, workDir?: string):
-    Promise<boolean> {
+export async function gitCommandExists(command: string, workDir?: string): Promise<boolean> {
     const result = await GitProcess.exec([command, "-h"], workDir || ".");
     return result.exitCode === 129;
 }

--- a/lib/gitgitgadget-config.ts
+++ b/lib/gitgitgadget-config.ts
@@ -18,28 +18,28 @@ const defaultConfig: IConfig = {
         branch: "master",
         host: "lore.kernel.org",
         url: "https://lore.kernel.org/git/",
-        descriptiveName: "lore.kernel/git"
+        descriptiveName: "lore.kernel/git",
     },
     mail: {
         author: "GitGitGadget",
-        sender: "GitGitGadget"
+        sender: "GitGitGadget",
     },
     app: {
         appID: 12836,
         installationID: 195971,
         name: "gitgitgadget",
         displayName: "GitGitGadget",
-        altname: "gitgitgadget-git"
+        altname: "gitgitgadget-git",
     },
     lint: {
         maxCommitsIgnore: [
-            "https://github.com/gitgitgadget/git/pull/923"
+            "https://github.com/gitgitgadget/git/pull/923",
         ],
         maxCommits: 30,
     },
     user: {
         allowUserAsLogin: false,
-    }
+    },
 };
 
 export default defaultConfig;

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -70,8 +70,7 @@ export class GitGitGadget {
 
         const [options, allowedUsers] = await GitGitGadget.readOptions(notes);
 
-        return new GitGitGadget(notes, options, allowedUsers,
-                                { smtpHost, smtpOpts, smtpPass, smtpUser },
+        return new GitGitGadget(notes, options, allowedUsers, { smtpHost, smtpOpts, smtpPass, smtpUser },
                                 publishTagsAndNotesToRemote);
     }
 
@@ -144,7 +143,7 @@ export class GitGitGadget {
             throw new Error(`User ${vouchingUser} lacks permission for this.`);
         }
 
-        if (!this.isUserAllowed(user)) {
+        if (!this.allowedUsers.delete(user)) {
             return false;
         }
         for (let i = 0; i < this.options.allowedUsers.length; i++) {
@@ -153,7 +152,7 @@ export class GitGitGadget {
                 break;
             }
         }
-        this.allowedUsers.delete(user);
+
         await this.notes.set("", this.options, true);
         await this.pushNotesRef();
         return true;
@@ -260,16 +259,13 @@ export class GitGitGadget {
         await this.updateNotesAndPullRef(pr.baseOwner, pr.number, previousTag);
 
         const series =
-            await PatchSeries.getFromNotes(this.notes, pr.pullRequestURL,
-                                           pr.title, pr.body, pr.baseLabel,
-                                           pr.baseCommit, pr.headLabel,
-                                           pr.headCommit, options,
+            await PatchSeries.getFromNotes(this.notes, pr.pullRequestURL, pr.title, pr.body, pr.baseLabel,
+                                           pr.baseCommit, pr.headLabel, pr.headCommit, options,
                                            userInfo.name, userInfo.email);
 
         const patchSeriesMetadata =
-            await series.generateAndSend(console, send,
-                                         this.publishTagsAndNotesToRemote,
-                                         pr.pullRequestURL, new Date());
+            await series.generateAndSend(console, send, this.publishTagsAndNotesToRemote, pr.pullRequestURL,
+                                         new Date());
         return patchSeriesMetadata;
     }
 }

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -65,9 +65,7 @@ export class GitHubGlue {
 
     public async annotateCommit(originalCommit: string, gitGitCommit: string,
                                 repositoryOwner: string, baseOwner: string): Promise<number> {
-        const output =
-            await git(["show", "-s", "--format=%h %cI", gitGitCommit],
-                      { workDir: this.workDir });
+        const output = await git(["show", "-s", "--format=%h %cI", gitGitCommit], { workDir: this.workDir });
         const match = output.match(/^(\S+) (\S+)$/);
         if (!match) {
             throw new Error(`Could not find ${gitGitCommit}: '${output}'`);
@@ -101,8 +99,7 @@ export class GitHubGlue {
      * @param {string} cc to add
      * @returns the comment ID and the URL to the comment
      */
-    public async addPRCc(pullRequest: pullRequestKeyInfo, cc: string):
-        Promise<void> {
+    public async addPRCc(pullRequest: pullRequestKeyInfo, cc: string): Promise<void> {
         const id = cc.match(/<(.*)>/);
 
         if (!id || id[1] === "gitster@pobox.com") {
@@ -167,8 +164,7 @@ export class GitHubGlue {
      * @param {string} comment the comment
      * @returns the comment ID and the URL to the comment
      */
-    public async addPRComment(pullRequest: pullRequestKeyInfo, comment: string):
-        Promise<{id: number; url: string}> {
+    public async addPRComment(pullRequest: pullRequestKeyInfo, comment: string): Promise<{ id: number; url: string }> {
         const prKey = getPullRequestKey(pullRequest);
 
         await this.ensureAuthenticated(prKey.owner);
@@ -197,13 +193,12 @@ export class GitHubGlue {
                                     commit: string,
                                     gitWorkDir: string | undefined,
                                     comment: string, line?: number | undefined):
-        Promise<{id: number; url: string}> {
+        Promise<{ id: number; url: string }> {
         const prKey = getPullRequestKey(pullRequest);
 
         await this.ensureAuthenticated(prKey.owner);
 
-        const files = await git(["diff", "--name-only",
-                                 `${commit}^..${commit}`, "--"],
+        const files = await git(["diff", "--name-only", `${commit}^..${commit}`, "--"],
                                 {workDir: gitWorkDir});
         const path = files.replace(/\n[^]*/, "");
 
@@ -212,7 +207,7 @@ export class GitHubGlue {
             commit_id: commit,
             path,
             line: line || 1,
-            ...prKey
+            ...prKey,
         });
         return {
             id: status.data.id,
@@ -228,19 +223,17 @@ export class GitHubGlue {
      * @param {string} comment the comment to add
      * @returns the comment ID and the URL to the added comment
      */
-    public async addPRCommentReply(pullRequest: pullRequestKeyInfo, id: number,
-                                   comment: string):
-        Promise<{id: number, url: string}> {
+    public async addPRCommentReply(pullRequest: pullRequestKeyInfo, id: number, comment: string):
+        Promise<{ id: number, url: string }> {
         const prKey = getPullRequestKey(pullRequest);
 
         await this.ensureAuthenticated(prKey.owner);
 
-        const status = await this.client.rest.pulls.createReplyForReviewComment(
-            {
-                body: comment,
-                comment_id: id,
-                ...prKey
-            });
+        const status = await this.client.rest.pulls.createReplyForReviewComment({
+            body: comment,
+            comment_id: id,
+            ...prKey,
+        });
         return {
             id: status.data.id,
             url: status.data.html_url,
@@ -259,16 +252,15 @@ export class GitHubGlue {
         await this.ensureAuthenticated(prKey.owner);
 
         const result = await this.client.rest.pulls.update({
-            "body": body || undefined,
-            "title": title || undefined,
-            ...prKey
+            body,
+            title,
+            ...prKey,
         });
 
         return result.data.id;
     }
 
-    public async addPRLabels(pullRequest: pullRequestKeyInfo, labels: string[]):
-        Promise<string[]> {
+    public async addPRLabels(pullRequest: pullRequestKeyInfo, labels: string[]): Promise<string[]> {
         const prKey = getPullRequestKey(pullRequest);
 
         await this.ensureAuthenticated(prKey.owner);
@@ -288,7 +280,7 @@ export class GitHubGlue {
         await this.ensureAuthenticated(prKey.owner);
         await this.client.rest.pulls.update({
             state: "closed",
-            ...prKey
+            ...prKey,
         });
 
         const result = await this.client.rest.issues.createComment({
@@ -302,8 +294,7 @@ export class GitHubGlue {
 
     // The following public methods do not require authentication
 
-    public async getOpenPRs(repositoryOwner: string):
-        Promise<IPullRequestInfo[]> {
+    public async getOpenPRs(repositoryOwner: string): Promise<IPullRequestInfo[]> {
         const result: IPullRequestInfo[] = [];
         const response = await this.client.rest.pulls.list({
             owner: repositoryOwner,
@@ -342,11 +333,8 @@ export class GitHubGlue {
      * @param prKey the Pull Request's basic id (owner, repo, number)
      * @returns information about that Pull Request
      */
-    public async getPRInfo(prKey: pullRequestKey):
-        Promise<IPullRequestInfo> {
-        const response = await this.client.rest.pulls.get({
-            ...prKey
-        });
+    public async getPRInfo(prKey: pullRequestKey): Promise<IPullRequestInfo> {
+        const response = await this.client.rest.pulls.get({ ...prKey });
 
         const pullRequest = response.data;
         if (!pullRequest.user) {
@@ -378,8 +366,7 @@ export class GitHubGlue {
      * @param commentID the ID of the PR/issue comment
      * @returns the text in the comment
      */
-    public async getPRComment(repositoryOwner: string, commentID: number):
-        Promise<IPRComment> {
+    public async getPRComment(repositoryOwner: string, commentID: number): Promise<IPRComment> {
         const response = await this.client.rest.issues.getComment({
             comment_id: commentID,
             owner: repositoryOwner,
@@ -407,8 +394,7 @@ export class GitHubGlue {
      * @param prNumber the Pull Request's number
      * @returns the set of commits
      */
-    public async getPRCommits(repositoryOwner: string, prNumber: number):
-         Promise<IPRCommit[]> {
+    public async getPRCommits(repositoryOwner: string, prNumber: number): Promise<IPRCommit[]> {
         const response = await this.client.rest.pulls.listCommits({
             owner: repositoryOwner,
             pull_number: prNumber,
@@ -456,7 +442,7 @@ export class GitHubGlue {
             username: login,
         });
 
-        if (response.status === 200 ) {
+        if (response.status === 200) {
             return {
                 email: response.data.email,
                 login: response.data.login,
@@ -468,8 +454,7 @@ export class GitHubGlue {
         }
     }
 
-    protected async ensureAuthenticated(repositoryOwner: string):
-        Promise<void> {
+    protected async ensureAuthenticated(repositoryOwner: string): Promise<void> {
         if (repositoryOwner !== this.authenticated) {
             const infix = repositoryOwner === "gitgitgadget" ? "" : `.${repositoryOwner}`;
             const tokenKey = `gitgitgadget${infix}.githubToken`;

--- a/lib/mail-commit-mapping.ts
+++ b/lib/mail-commit-mapping.ts
@@ -9,12 +9,10 @@ export class MailCommitMapping {
 
     public constructor(workDir?: string) {
         this.workDir = workDir;
-        this.mail2CommitNotes = new GitNotes(workDir,
-                                             "refs/notes/mail-to-commit");
+        this.mail2CommitNotes = new GitNotes(workDir, "refs/notes/mail-to-commit");
     }
 
-    public async getGitGitCommitForMessageId(messageID: string):
-        Promise<string | undefined> {
+    public async getGitGitCommitForMessageId(messageID: string): Promise<string | undefined> {
         return await this.mail2CommitNotes.getString(messageID);
     }
 

--- a/lib/markdown-renderer.ts
+++ b/lib/markdown-renderer.ts
@@ -4,37 +4,38 @@ import { marked } from "marked";
 // Provide our own renderings of headings and block quotes.
 
 export function md2text(markdown: string, columns = 76): string {
-
     let quoteDepth = 0;
     const formatOptions: HtmlToTextOptions = {
         wordwrap: columns,
         formatters: {
             headerFormatter: (elem, walk, builder, options) => {
                 builder.openBlock({
-                    leadingLineBreaks: options.leadingLineBreaks || 2});
+                    leadingLineBreaks: options.leadingLineBreaks || 2 });
                 walk(elem.children, builder);
                 builder.closeBlock({
                     trailingLineBreaks: options.trailingLineBreaks || 2,
-                    blockTransform: str => {
+                    blockTransform: (str) => {
                         const underline = str.substring(str.lastIndexOf("\n") + 1)
                             .replace(/./g, "=");
                         return `${str}\n${underline}`;
-                    }});
+                    },
+                });
             },
             blockFormatter: (elem, walk, builder, options) => {
                 builder.openBlock({
                     leadingLineBreaks: options.leadingLineBreaks || 2,
-                    reservedLineLength: quoteDepth? 1 : 2});
+                    reservedLineLength: quoteDepth ? 1 : 2});
                 quoteDepth++;
                 walk(elem.children, builder);
                 quoteDepth--;
-                builder.closeBlock({ trailingLineBreaks:
-                    options.trailingLineBreaks || 2,
-                    blockTransform: str => { return str
-                        .replace(/^>/mg, ">>") // add to quote
-                        .replace(/^(?!>|$)/mg, "> ")   // new quote
+                builder.closeBlock({
+                    trailingLineBreaks: options.trailingLineBreaks || 2,
+                    blockTransform: (str) => { return str
+                        .replace(/^>/gm, ">>") // add to quote
+                        .replace(/^(?!>|$)/gm, "> ") // new quote
                         .replace(/(^|\n)(\n)(?!$)/g, "$1>$2"); // quote empty
-                    }});
+                    },
+                });
             },
             checkBoxFormatter: (elem, _walk, builder) => {
                 const attribs = elem.attribs as { checked?: string };
@@ -51,34 +52,34 @@ export function md2text(markdown: string, columns = 76): string {
             {
                 selector: "h1",
                 options: {
-                    uppercase: false
+                    uppercase: false,
                 },
                 format: "headerFormatter",
             },
             {
                 selector: "h2",
                 options: {
-                    uppercase: false
+                    uppercase: false,
                 },
                 format: "headerFormatter",
             },
             {
                 selector: "h3",
                 options: {
-                    uppercase: false
+                    uppercase: false,
                 },
                 format: "headerFormatter",
             },
             {
                 selector: "blockquote",
                 options: {
-                    trimEmptyLines: false
+                    trimEmptyLines: false,
                 },
-                format: "blockFormatter"
+                format: "blockFormatter",
             },
             {
                 selector: "input[type=checkbox]",
-                format: "checkBoxFormatter"
+                format: "checkBoxFormatter",
             },
         ],
     };

--- a/lib/misc-action.ts
+++ b/lib/misc-action.ts
@@ -68,7 +68,7 @@ async function getExternalConfig(file: string): Promise<IConfig> {
 }
 
 function lintConfig(config: IConfig): void {
-    if (!config.hasOwnProperty("project")) {
+    if (!Object.prototype.hasOwnProperty.call(config, "project")) {
         throw new Error(`User configurations must have a 'project:'.  Not found in:\n${
             JSON.stringify(config, null, 2)}`);
     }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -1,6 +1,6 @@
 import addressparser from "nodemailer/lib/addressparser/index.js";
 import mimeFuncs from "nodemailer/lib/mime-funcs/index.js";
-import { commitExists, git, gitConfig, gitShortHash, revListCount, revParse, } from "./git.js";
+import { commitExists, git, gitConfig, gitShortHash, revListCount, revParse } from "./git.js";
 import { GitNotes } from "./git-notes.js";
 import { IGitGitGadgetOptions } from "./gitgitgadget.js";
 import { IMailMetadata } from "./mail-metadata.js";
@@ -70,8 +70,7 @@ export class PatchSeries {
         if (!workDir) {
             throw new Error("Need a worktree!");
         }
-        let metadata: IPatchSeriesMetadata | undefined =
-            await notes.get<IPatchSeriesMetadata>(pullRequestURL);
+        let metadata: IPatchSeriesMetadata | undefined = await notes.get<IPatchSeriesMetadata>(pullRequestURL);
 
         const currentRange = `${baseCommit}..${headCommit}`;
         const patchCount = await revListCount(["--no-merges", currentRange], workDir);
@@ -92,7 +91,7 @@ export class PatchSeries {
             };
         } else {
             if (!options.noUpdate &&   // allow reprint of submitted PRs
-                !await git(["rev-list", `${metadata.headCommit}...${headCommit}`], { workDir })) {
+                !(await git(["rev-list", `${metadata.headCommit}...${headCommit}`], { workDir }))) {
                 throw new Error(`${headCommit} was already submitted`);
             }
 
@@ -121,11 +120,11 @@ export class PatchSeries {
             cc,
             coverLetter,
             rangeDiff
-        } = await PatchSeries.parsePullRequest(workDir,
-                                               pullRequestTitle,
-                                               pullRequestBody,
-                                               wrapCoverLetterAt,
-                                               indentCoverLetter);
+        } = (await PatchSeries.parsePullRequest(workDir,
+                                                pullRequestTitle,
+                                                pullRequestBody,
+                                                wrapCoverLetterAt,
+                                                indentCoverLetter));
 
         // if known, add submitter to email chain
         if (senderEmail) {
@@ -172,25 +171,15 @@ export class PatchSeries {
             // Just ignore it
         }
 
-        const {
-            basedOn,
-            cc,
-            coverLetterBody,
-            rangeDiff,
-        } = PatchSeries.parsePullRequestBody(prBody);
+        const { basedOn, cc, coverLetterBody, rangeDiff } = PatchSeries.parsePullRequestBody(prBody);
 
         const coverLetter = `${prTitle}\n${coverLetterBody.length ? `\n${coverLetterBody}` : ""}`;
         let wrappedLetter = md2text(coverLetter, wrapCoverLetterAtColumn);
         if (indentCoverLetter) {
-            wrappedLetter = wrappedLetter.replace(/^/mg, indentCoverLetter);
+            wrappedLetter = wrappedLetter.replace(/^/gm, indentCoverLetter);
         }
 
-        return {
-            basedOn,
-            cc,
-            coverLetter: wrappedLetter,
-            rangeDiff,
-        };
+        return { basedOn, cc, coverLetter: wrappedLetter, rangeDiff };
     }
 
     protected static parsePullRequestBody(prBody: string): {
@@ -228,8 +217,7 @@ export class PatchSeries {
                             basedOn = match2[2];
                             break;
                         case "cc:":
-                            addressparser(match2[2], { flatten: true })
-                                .forEach((e: addressparser.Address) => {
+                            addressparser(match2[2], { flatten: true }).forEach((e: addressparser.Address) => {
                                 if (e.name) {
                                     cc.push(`${e.name} <${e.address}>`);
                                 } else {
@@ -257,7 +245,7 @@ export class PatchSeries {
             basedOn,
             cc,
             coverLetterBody,
-            rangeDiff
+            rangeDiff,
         };
     }
 
@@ -334,7 +322,7 @@ export class PatchSeries {
         const encoded = mimeFuncs.encodeWords(sender);
 
         /* Don't quote if already quoted */
-        if (encoded.startsWith("\"") && encoded.match(/"\s*</)) {
+        if (encoded.startsWith('"') && encoded.match(/"\s*</)) {
             return encoded;
         }
 
@@ -407,9 +395,8 @@ export class PatchSeries {
 
     protected static generateTagMessage(mail: string, isCoverLetter: boolean, midUrlPrefix: string,
                                         inReplyTo: string[] | undefined): string {
-        const regex = isCoverLetter ?
-            /\nSubject: (\[.*?\] )?([^]*?(?=\n[^ ]))[^]*?\n\n([^]*?)\n*-- \n/ :
-            /\nSubject: (\[.*?\] )?([^]*?(?=\n[^ ]))[^]*?\n\n([^]*?)\n*---\n/;
+        const regex = isCoverLetter ? /\nSubject: (\[.*?\] )?([^]*?(?=\n[^ ]))[^]*?\n\n([^]*?)\n*-- \n/
+                                    : /\nSubject: (\[.*?\] )?([^]*?(?=\n[^ ]))[^]*?\n\n([^]*?)\n*---\n/;
         const match = mail.match(regex);
         if (!match) {
             throw new Error(`Could not generate tag message from mail:\n\n${mail}`);
@@ -445,10 +432,10 @@ export class PatchSeries {
             }
         }
 
-        let insert =`Published-As: ${url}/releases/tag/${tagName}\nFetch-It-Via: git fetch ${url} ${tagName}\n`;
+        let insert = `Published-As: ${url}/releases/tag/${tagName}\nFetch-It-Via: git fetch ${url} ${tagName}\n`;
 
         if (basedOn) {
-            insert =`Based-On: ${basedOn} at ${url}\nFetch-Base-Via: git fetch ${url} ${basedOn}\n${insert}`;
+            insert = `Based-On: ${basedOn} at ${url}\nFetch-Base-Via: git fetch ${url} ${basedOn}\n${insert}`;
         }
 
         if (!tagMessage.match(/\n[-A-Za-z]+: [^\n]*\n$/)) {
@@ -457,8 +444,7 @@ export class PatchSeries {
         return tagMessage + insert;
     }
 
-    protected static insertFooters(mail: string, isCoverLetter: boolean,
-                                   footers: string[]): string {
+    protected static insertFooters(mail: string, isCoverLetter: boolean, footers: string[]): string {
         const regex = isCoverLetter ? /^([^]*?\n)(-- \n[^]*)$/ : /^([^]*?\n---\n(?:\n[A-Za-z:]+ [^]*?\n\n)?)([^]*)$/;
         const match = mail.match(regex);
         if (!match) {
@@ -473,7 +459,7 @@ export class PatchSeries {
         let count = 0;
 
         const time = forceDate.getTime();
-        for (let i = 0, j = mails.length - 1; i < mails.length; i++ , j--) {
+        for (let i = 0, j = mails.length - 1; i < mails.length; i++, j--) {
             const mail = mails[i];
 
             /* Look for the date header */
@@ -575,8 +561,7 @@ export class PatchSeries {
         this.insertCcAndFromLines(mails, thisAuthor, this.senderName);
         if (mails.length > 1) {
             if (this.coverLetter) {
-                const match2 = mails[0].match(
-                    /^([^]*?\n\*\*\* BLURB HERE \*\*\*\n\n)([^]*)/);
+                const match2 = mails[0].match(/^([^]*?\n\*\*\* BLURB HERE \*\*\*\n\n)([^]*)/);
                 if (!match2) {
                     throw new Error(`Could not find blurb in ${mails[0]}`);
                 }
@@ -645,9 +630,7 @@ export class PatchSeries {
 
         if (this.options.noUpdate) {
             logger.log(`Would generate tag ${tagName} with message:\n\n ${
-                tagMessage.split("\n").map((line: string) => {
-                    return "    " + line;
-                }).join("\n")}`);
+                tagMessage.split("\n").map((line: string) => { return "    " + line; }).join("\n")}`);
         } else {
             logger.log("Generating tag object");
             await this.generateTagObject(tagName, tagMessage);
@@ -723,9 +706,7 @@ export class PatchSeries {
 
         if (this.options.dryRun) {
             logger.log(`Would send this mbox:\n\n${
-                mbox.split("\n").map((line) => {
-                    return "    " + line;
-                }).join("\n")}`);
+                mbox.split("\n").map((line) => { return "    " + line; }).join("\n") }`);
         } else if (send) {
             for (const mail of mails) {
                 await send(mail);
@@ -762,18 +743,17 @@ export class PatchSeries {
                     messageID: mid,
                     originalCommit,
                     pullRequestURL: this.metadata.pullRequestURL,
-                    firstPatchLine
+                    firstPatchLine,
                 } as IMailMetadata;
                 await this.notes.set(mid, mailMeta, true);
-                if (globalOptions && originalCommit &&
-                    this.metadata.pullRequestURL) {
+                if (globalOptions && originalCommit && this.metadata.pullRequestURL) {
                     if (!globalOptions.activeMessageIDs) {
                         globalOptions.activeMessageIDs = {};
                     }
                     globalOptions.activeMessageIDs[mid] = originalCommit;
                 }
 
-                if (originalCommit && await commitExists(originalCommit, this.project.workDir)) {
+                if (originalCommit && (await commitExists(originalCommit, this.project.workDir))) {
                     await this.notes.appendCommitNote(originalCommit, mid);
                 }
             }
@@ -822,9 +802,9 @@ export class PatchSeries {
         if (subjectPrefix) {
             args.push("--subject-prefix=" + subjectPrefix);
         }
-        if (this.patchCount > 1 ) {
+        if (this.patchCount > 1) {
             if (!this.coverLetter) {
-                    throw new Error(`Branch ${this.project.branchName} needs a description`);
+                throw new Error(`Branch ${this.project.branchName} needs a description`);
             }
             args.push("--cover-letter");
         }
@@ -860,7 +840,6 @@ export class PatchSeries {
             tagName = "+" + tagName;
         }
         await git(["push", this.project.publishToRemote,`+${this.project.branchName}`, tagName],
-                  { workDir: this.project.workDir },
-        );
+                  { workDir: this.project.workDir });
     }
 }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -366,7 +366,7 @@ export class PatchSeries {
                 const onBehalfOf = i === 0 && senderName ? PatchSeries.encodeSender(senderName) :
                     authorMatch[2].replace(/ <.*>$/, "");
                 // Special-case GitGitGadget to send from  "<author> via GitGitGadget"
-                replaceSender = `\"${onBehalfOf.replace(/^"(.*)"$/, "$1").replace(/"/g, "\\\"")
+                replaceSender = `"${onBehalfOf.replace(/^"(.*)"$/, "$1").replace(/"/g, "\\\"")
                     } via ${this.config.mail.sender}" ${isGitGitGadget[1]}`;
             } else if (authorMatch[2] === thisAuthor) {
                 return;

--- a/lib/project-config.ts
+++ b/lib/project-config.ts
@@ -19,7 +19,7 @@ export interface IConfig {
         trackingBranches: string[]; // comment if the pr is added to this branch
         maintainerBranch?: string;  // branch/owner manually implementing changes
         host: string;
-    },
+    };
     mailrepo: {
         name: string;
         owner: string;
@@ -27,27 +27,27 @@ export interface IConfig {
         host: string;
         url: string;
         descriptiveName: string;
-    },
+    };
     mail: {
         author: string;
         sender: string;
-    },
-    project?: projectInfo | undefined, // project-options values
+    };
+    project?: projectInfo | undefined; // project-options values
     app: {
         appID: number;
         installationID: number;
          name: string;
-         displayName: string;           // name to use in comments to identify app
-         altname: string | undefined;   // is this even needed?
-    },
+         displayName: string;       // name to use in comments to identify app
+         altname: string | undefined; // is this even needed?
+    };
     lint: {
-        maxCommitsIgnore?: string[];    // array of pull request urls to skip check
-        maxCommits: number;             // limit on number of commits in a pull request
-    },
+        maxCommitsIgnore?: string[]; // array of pull request urls to skip check
+        maxCommits: number;         // limit on number of commits in a pull request
+    };
     user: {
-        allowUserAsLogin: boolean;      // use GitHub login as name if name is private
-    }
-};
+        allowUserAsLogin: boolean;  // use GitHub login as name if name is private
+    };
+}
 
 let config: IConfig;                // singleton
 
@@ -64,7 +64,7 @@ export function getConfig(): IConfig {
     return config;
 }
 
-type importedConfig = { default: IConfig; }
+type importedConfig = { default: IConfig };
 
 /**
  * Load a config.  The config may be a javascript file (plain or generated
@@ -80,7 +80,7 @@ export async function loadConfig(file: string): Promise<IConfig> {
         const { default: newConfig } = (await import(file)) as importedConfig;
         loadedConfig = newConfig;
     } else {
-        const fileText = fs.readFileSync(file, {encoding: "utf-8"});
+        const fileText = fs.readFileSync(file, { encoding: "utf-8" });
         loadedConfig = JSON.parse(fileText) as IConfig;
     }
 

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -10,7 +10,7 @@ export class ProjectOptions {
         let to: string;
         let midUrlPrefix = " Message-ID: ";
 
-        if (config.hasOwnProperty("project")) {
+        if (Object.prototype.hasOwnProperty.call(config, "project")) {
             const project = config.project as projectInfo;
             to = `--to=${project.to}`;
             upstreamBranch = project.branch;

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -18,12 +18,12 @@ export class ProjectOptions {
             for (const user of project.cc) {
                 cc.push(user);
             }
-        } else if (await revParse(`${baseCommit}:git-gui.sh`, workDir) !== undefined) {
+        } else if ((await revParse(`${baseCommit}:git-gui.sh`, workDir)) !== undefined) {
             // Git GUI
             to = "--to=git@vger.kernel.org";
             cc.push("Pratyush Yadav <me@yadavpratyush.com>");
             upstreamBranch = "git-gui/master";
-        } else if (await revParse(`${baseCommit}:git.c`, workDir) !== undefined) {
+        } else if ((await revParse(`${baseCommit}:git.c`, workDir)) !== undefined) {
             // Git
             to = "--to=git@vger.kernel.org";
             // Do *not* Cc: Junio Hamano by default
@@ -35,12 +35,12 @@ export class ProjectOptions {
                 upstreamBranch = "upstream/master";
             }
             midUrlPrefix = "https://lore.kernel.org/git/";
-        } else if (await revParse(`${baseCommit}:winsup`, workDir) !== undefined) {
+        } else if ((await revParse(`${baseCommit}:winsup`, workDir)) !== undefined) {
             // Cygwin
             to = "--to=cygwin-patches@cygwin.com";
             upstreamBranch = "cygwin/master";
             midUrlPrefix = "https://www.mail-archive.com/search?l=cygwin-patches@cygwin.com&q=";
-        } else if (await revParse(`${baseCommit}:include/busybox.h`, workDir) !== undefined) {
+        } else if ((await revParse(`${baseCommit}:include/busybox.h`, workDir)) !== undefined) {
             // BusyBox
             to = "--to=busybox@busybox.net";
             upstreamBranch = "busybox/master";
@@ -58,8 +58,7 @@ export class ProjectOptions {
             upstreamBranch = basedOn;
         }
 
-        if (!baseCommit &&
-            await git(["rev-list", branchName + ".." + upstreamBranch], { workDir })) {
+        if (!baseCommit && (await git(["rev-list", branchName + ".." + upstreamBranch], { workDir }))) {
             throw new Error(`Branch ${branchName} is not rebased to ${upstreamBranch}`);
         }
 

--- a/lib/pull-action.ts
+++ b/lib/pull-action.ts
@@ -60,7 +60,7 @@ async function getExternalConfig(file: string): Promise<IConfig> {
 }
 
 function lintConfig(config: IConfig): void {
-    if (!config.hasOwnProperty("project")) {
+    if (!Object.prototype.hasOwnProperty.call(config, "project")) {
         throw new Error(`User configurations must have a 'project:'.  Not found in\n${
             JSON.stringify(config, null, 2)}`);
     }

--- a/lib/pullRequestKey.ts
+++ b/lib/pullRequestKey.ts
@@ -7,12 +7,12 @@ export type pullRequestKey = {
     owner: string;
     repo: string;
     pull_number: number;
-}
+};
 
 export type pullRequestKeyInfo = string | pullRequestKey;
 
 export function getPullRequestKey(pullRequest: pullRequestKeyInfo): pullRequestKey {
-    return typeof(pullRequest) === "string" ? getPullRequestKeyFromURL(pullRequest) : pullRequest;
+    return typeof pullRequest === "string" ? getPullRequestKeyFromURL(pullRequest) : pullRequest;
 }
 
 export function getPullRequestKeyFromURL(pullRequestURL: string): pullRequestKey {
@@ -21,6 +21,5 @@ export function getPullRequestKeyFromURL(pullRequestURL: string): pullRequestKey
         throw new Error(`Unrecognized PR URL: "${pullRequestURL}`);
     }
 
-    return {owner: match[1], repo: match[2], pull_number: parseInt(match[3], 10)};
+    return { owner: match[1], repo: match[2], pull_number: parseInt(match[3], 10) };
 }
-

--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -1,7 +1,7 @@
 import { simpleParser, SimpleParserOptions } from "mailparser";
 import { createTransport, SendMailOptions } from "nodemailer";
 import SMTPTransport from "nodemailer/lib/smtp-transport";
-import rfc2047  from "rfc2047";
+import rfc2047 from "rfc2047";
 
 export interface IParsedMBox {
     body: string;
@@ -22,10 +22,8 @@ export interface ISMTPOptions {
     smtpPass: string;
 }
 
-export async function parseHeadersAndSendMail(mbox: string,
-                                              smtpOptions: ISMTPOptions):
-    Promise<string> {
-    return await sendMail( await parseMBox(mbox), smtpOptions);
+export async function parseHeadersAndSendMail(mbox: string, smtpOptions: ISMTPOptions): Promise<string> {
+    return await sendMail(await parseMBox(mbox), smtpOptions);
 }
 
 /**
@@ -48,8 +46,8 @@ export async function parseMBox(mbox: string, gentle?: boolean): Promise<IParsed
 
     const options: SimpleParserOptions = {
         skipHtmlToText: true,
-        skipTextLinks : true,
-        skipTextToHtml: true
+        skipTextLinks: true,
+        skipTextToHtml: true,
     };
 
     const parsed = await simpleParser(mbox, options);
@@ -66,9 +64,7 @@ export async function parseMBox(mbox: string, gentle?: boolean): Promise<IParsed
         const value = valueSet[2];
 
         switch (entry.key) {
-            case "cc": cc = (cc || []).concat(value.replace(/\r?\n/g, " ").split(", ").map(item =>
-                    item.trim()
-                )); break;
+            case "cc": cc = (cc || []).concat(value.replace(/\r?\n/g, " ").split(", ").map(item => item.trim())); break;
             case "date": date = value; break;
             case "fcc": break;
             case "from": from = rfc2047.decode(value.trim()); break;
@@ -97,8 +93,7 @@ export async function parseMBox(mbox: string, gentle?: boolean): Promise<IParsed
     };
 }
 
-export function parseMBoxMessageIDAndReferences(parsed: IParsedMBox):
-        {messageID: string; references: string[]} {
+export function parseMBoxMessageIDAndReferences(parsed: IParsedMBox): { messageID: string; references: string[] } {
     const references: string[] = [];
     const seen: Set<string> = new Set<string>();
     /*
@@ -111,8 +106,7 @@ export function parseMBoxMessageIDAndReferences(parsed: IParsedMBox):
      * using regular expressions due to its recursive nature) but seems to be
      * good enough for the Git mailing list.
      */
-    const msgIdRegex =
-        /^\s*<([^>]+)>(\s*|,)(\([^")]*("[^"]*")?\)\s*|\([^)]*\)$)?(<.*)?$/;
+    const msgIdRegex = /^\s*<([^>]+)>(\s*|,)(\([^")]*("[^"]*")?\)\s*|\([^)]*\)$)?(<.*)?$/;
     for (const header of parsed.headers ?? []) {
         if (header.key.match(/In-Reply-To|References/i)) {
             let value: string = header.value.replace(/[\r\n]/g, " ");
@@ -142,9 +136,7 @@ export function parseMBoxMessageIDAndReferences(parsed: IParsedMBox):
     return { messageID: messageID[1], references };
 }
 
-export async function sendMail(mail: IParsedMBox,
-                               smtpOptions: ISMTPOptions):
-    Promise<string> {
+export async function sendMail(mail: IParsedMBox, smtpOptions: ISMTPOptions): Promise<string> {
     const transportOpts: SMTPTransport.Options = {
         auth: {
             pass: smtpOptions.smtpPass,
@@ -156,13 +148,12 @@ export async function sendMail(mail: IParsedMBox,
 
     if (smtpOptions.smtpOpts) {
         // Add quoting for JSON.parse
-        const smtpOpts = smtpOptions.smtpOpts
-            .replace(/([ {])([a-zA-Z0-9.]+?) *?:/g,"$1\"$2\":");
+        const smtpOpts = smtpOptions.smtpOpts.replace(/([ {])([a-zA-Z0-9.]+?) *?:/g,"$1\"$2\":");
         Object.assign(transportOpts, JSON.parse(smtpOpts));
     }
 
     return new Promise<string>((resolve, reject) => {
-        const transporter = createTransport( transportOpts );
+        const transporter = createTransport(transportOpts);
 
         // setup email data with unicode symbols
         const mailOptions: SendMailOptions = {
@@ -174,8 +165,7 @@ export async function sendMail(mail: IParsedMBox,
             raw: mail.raw,
         };
 
-        transporter.sendMail(mailOptions, (error, info: { messageId: string })
-            : void => {
+        transporter.sendMail(mailOptions, (error, info: { messageId: string }): void => {
             if (error) {
                 reject(error);
             } else {

--- a/lib/sous-chef.ts
+++ b/lib/sous-chef.ts
@@ -7,40 +7,32 @@ export class SousChef {
     public readonly mbox: string;
     public readonly messageID: string | undefined;
     public readonly subject: string | undefined;
-    public readonly branches = new Map<string, {
-            merged: string | undefined;
-            sectionName: string;
-            text: string;
-        }>();
+    public readonly branches = new Map<string, { merged: string | undefined; sectionName: string; text: string }>();
 
     public constructor(mbox: string) {
         this.mbox = mbox;
 
-        const sections = mbox.split(/^-{10,}\n\[([^\]]+)\]\n/mg);
+        const sections = mbox.split(/^-{10,}\n\[([^\]]+)\]\n/gm);
         for (let i = 1; i < sections.length; i += 2) {
             const sectionName = sections[i];
 
             const branches = sections[i + 1].split(/\n\* ([a-z][^]+?)\n\n/m);
             for (let j = 1; j < branches.length; j += 2) {
-                const match = branches[j]
-                    .match(/([^ ]+).*\n *(\(merged to [^)]+\))?/m);
+                const match = branches[j].match(/([^ ]+).*\n *(\(merged to [^)]+\))?/m);
                 if (!match) {
                     continue;
                 }
 
                 const branchName = match[1];
                 const merged = match[2];
-                const text = branches[j + 1]
-                    .replace(/^ /mg, "").replace(/\s*$/, "");
+                const text = branches[j + 1].replace(/^ /gm, "").replace(/\s*$/, "");
                 this.branches.set(branchName, { merged, sectionName, text });
             }
         }
 
-        const messageIDMatch =
-            `\n${sections[0]}`.match(/\nMessage-ID: <([^>]+)>/i);
+        const messageIDMatch = `\n${sections[0]}`.match(/\nMessage-ID: <([^>]+)>/i);
         this.messageID = messageIDMatch?.[1];
-        const subjectMatch =
-            `\n${sections[0]}`.match(/\nSubject: (.*)/i);
+        const subjectMatch = `\n${sections[0]}`.match(/\nSubject: (.*)/i);
         this.subject = subjectMatch?.[1];
     }
 }

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -450,7 +450,7 @@ async function getExternalConfig(file: string): Promise<IConfig> {
     const filePath = path.resolve(file);
     const newConfig = await loadConfig(filePath);
 
-    if (!newConfig.hasOwnProperty("project")) {
+    if (!Object.prototype.hasOwnProperty.call(newConfig, "project")) {
         throw new Error(`User configurations must have a 'project:'.  Not found in ${filePath}`);
     }
 

--- a/tests/git-notes.test.ts
+++ b/tests/git-notes.test.ts
@@ -24,7 +24,8 @@ test("set/get notes", async () => {
         workDir: repo.workDir,
     })).toMatch(/\n\+hello$/);
 
-    const pullRequestURL = "https://github.com/gitgitgadget/git/pull/1";
+    const gitURL = "https://github.com/gitgitgadget/git";
+    const pullRequestURL = `${gitURL}/git/pull/1`;
     const metadata: IPatchSeriesMetadata = {
         baseCommit: "0123456789012345678901234567890123456789",
         baseLabel: "gitgitgadget:test",
@@ -45,4 +46,18 @@ test("set/get notes", async () => {
     expect(await notes.appendCommitNote(commit as string, "2")).toEqual("");
     expect(await notes.getCommitNotes(commit as string)).toEqual("1\n\n2");
     expect(await notes.getLastCommitNote(commit as string)).toEqual("2");
+
+    // error tests for update
+    await expect(notes.update(gitURL)).resolves.toBeUndefined();
+    const notesM2C = new GitNotes(repo.workDir, "refs/notes/mail-to-commit");
+    await expect(notesM2C.update(gitURL)).resolves.toBeUndefined();
+    const notesC2M = new GitNotes(repo.workDir, "refs/notes/commit-to-mail");
+    await expect(notesC2M.update(gitURL)).resolves.toBeUndefined();
+    const notesBad = new GitNotes(repo.workDir, "unknown");
+    await expect(notesBad.update(gitURL)).rejects.toThrow(/know how to update/);
+    const notesNotM2Chead = new GitNotes(repo.workDir, "xrefs/notes/mail-to-commit");
+    await expect(notesNotM2Chead.update(gitURL)).rejects.toThrow(/know how to update/);
+    const notesNotM2Ctail = new GitNotes(repo.workDir, "refs/notes/mail-to-commitx");
+    await expect(notesNotM2Ctail.update(gitURL)).rejects.toThrow(/know how to update/);
+
 });

--- a/tests/github-glue.test.ts
+++ b/tests/github-glue.test.ts
@@ -89,7 +89,7 @@ test("pull requests", async () => {
         // branch/PR request that gets cleaned up separately.
 
         if (!process.env.GITHUB_WORKFLOW &&
-            !process.env.hasOwnProperty("system.definitionId")) {
+            !Object.prototype.hasOwnProperty.call(process.env, "system.definitionId")) {
             let pullRequestURL = "";
 
             oldPrs.map(pr => {


### PR DESCRIPTION
Prep work for moving to updated eslint with new flat config format.  Initial conversion shows `prettier` does not appear to be running in the current setup.  This set of patches reduces the number of problems from over 500 to ~350.  It is mostly fixing formatting problems that are resolved using the extended line length now in use.  Prettier may be more opinionated than we would like.

The patches are mostly single file per patch in case any need to be removed.

lint: use Object.prototype.hasOwnProperty for safety
lint: remove superfluous escapes
lint: add parens around await as per linter
lint: cleanup ',' versus ';' usage
lint: misc linter issues
lint: misc linter issues
lint: clean up terminators
lint: misc linter issues
lint: misc clean up
lint: mostly format updates and a grep change
lint: clean up and `Error` type casting
lint: formatting issues
lint: line length and space issues
lint: undent a section of code 
