### PR TITLE
vscode: do not format on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
-    "editor.codeActionsOnSave": {"source.fixAll.eslint": true},
+    "editor.formatOnSave": false,
+    "editor.codeActionsOnSave": {
+        "source.fixAll": "never",
+        "source.fixAll.eslint": "never"
+    },
     "[typescript]": {
         "editor.detectIndentation": false,
         "editor.autoIndent": "none",


### PR DESCRIPTION
Opinionated linters may not format code in the preferred style.  There are instances where they may break style preferences (eg ignoring line length).

Not related but the old setting was deprecated and causing conflicts when vscode kept updating it.

Especially during the transition to a new linting configuration, the user should be in charge of what format changes are committed.