### PR TITLE
Fix parsing of long header bodies

### DIFF
--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -54,7 +54,7 @@ export async function parseMBox(mbox: string, gentle?: boolean): Promise<IParsed
 
     for (const entry of parsed.headerLines) {
         // try to parse header line and consume a leading line break after the colon in folded headers
-        const valueSet = entry.line.match(/(.*?):(?:\r?\n)? *([^]*)$/);
+        const valueSet = entry.line.match(/(.*?):(?:\r\n)? *([^]*)$/);
         if (!valueSet) {
             if (entry.line[entry.line.length - 1] === ":") {
                 continue;

--- a/lib/send-mail.ts
+++ b/lib/send-mail.ts
@@ -53,7 +53,8 @@ export async function parseMBox(mbox: string, gentle?: boolean): Promise<IParsed
     const parsed = await simpleParser(mbox, options);
 
     for (const entry of parsed.headerLines) {
-        const valueSet = entry.line.match(/(.*?): *([^]*)$/);
+        // try to parse header line and consume a leading line break after the colon in folded headers
+        const valueSet = entry.line.match(/(.*?):(?:\r?\n)? *([^]*)$/);
         if (!valueSet) {
             if (entry.line[entry.line.length - 1] === ":") {
                 continue;

--- a/tests/send-mail.test.ts
+++ b/tests/send-mail.test.ts
@@ -62,7 +62,7 @@ test("parse mbox", async () => {
         { key: "Content-Transfer-Encoding", value: "8bit" },
         { key: "MIME-Version", value: "1.0" },
         { key: "Header-with-no-value", value: "" },
-        { key: "Multiline-header", value: "\r\n new line value" },
+        { key: "Multiline-header", value: "new line value" },
     ]);
     expect(parsed.to).toEqual(to);
 });
@@ -190,4 +190,17 @@ I can be pursuaded either way.
     expect(references).toHaveLength(5);
     expect(references[0]).toEqual("pull.986.git.1624559401.gitgitgadget@gmail.com");
     expect(references[4]).toEqual("lowerReply@mail.gmail.com");
+});
+
+test("Folded Message-ID header is parsed correctly", async () => {
+    const mbox = `From 566155e00ab72541ff0ac21eab84d087b0e882a5 Mon Sep 17 00:00:00 2001
+Message-Id:
+ <pull.12345.v17.git.gitgitgadget@example.com>
+From:   Example <mail@example.com>
+Date: Fri Sep 21 12:34:56 2001
+Subject: [PATCH 0/3] My first Pull Request!
+To: reviewer@example.com
+`;
+    const parsed = await parseMBox(mbox);
+    expect(parsed.messageId).toEqual("<pull.12345.v17.git.gitgitgadget@example.com>");
 });


### PR DESCRIPTION
Improve handling of line breaks in folded headers by removing leading new lines of field bodies in folded headers, since they should have no semantical nor syntactical meaning, according to the specification. 

This general handling also provides proper soundness for other fields which might get folded. 

Fixes #1794 