### PR TITLE
Adjust the "reply to this" links

### DIFF
--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -11,7 +11,7 @@ import { IParsedMBox, parseMBox, parseMBoxMessageIDAndReferences } from "./send-
 import { SousChef } from "./sous-chef.js";
 
 export const stateKey = "git@vger.kernel.org <-> GitGitGadget";
-const replyToThisURL = "https://github.com/gitgitgadget/gitgitgadget/wiki/ReplyToThis";
+const replyToThisURL = "https://gitgitgadget.github.io/reply-to-this";
 
 export interface IGitMailingListMirrorState {
     latestRevision?: string;

--- a/res/WELCOME.md
+++ b/res/WELCOME.md
@@ -42,7 +42,7 @@ Once on the list of permitted usernames, you can contribute the patches to the G
 
 If you want to see what email(s) would be sent for a `/submit` request, add a PR comment `/preview` to have the email(s) sent to you.  You must have a public GitHub email address for this. Note that any reviewers CC'd via the list in the PR description will *not* actually be sent emails.
 
-After you submit, GitGitGadget will respond with another comment that contains the link to the cover letter mail in the Git mailing list archive. Please make sure to monitor the discussion in that thread and to address comments and suggestions (while the comments and suggestions will be mirrored into the PR by GitGitGadget, you will still want to [reply via mail](https://github.com/gitgitgadget/gitgitgadget/wiki/ReplyToThis)).
+After you submit, GitGitGadget will respond with another comment that contains the link to the cover letter mail in the Git mailing list archive. Please make sure to monitor the discussion in that thread and to address comments and suggestions (while the comments and suggestions will be mirrored into the PR by GitGitGadget, you will still want to [reply via mail](https://gitgitgadget.github.io/reply-to-this)).
 
 If you do not want to subscribe to the Git mailing list just to be able to respond to a mail, you can download the mbox from the [Git mailing list archive](https://lore.kernel.org/git) (click the `(raw)` link), then import it into your mail program. If you use GMail, you can do this via:
 


### PR DESCRIPTION
Since the wiki was locked down for external contributors (to prevent spam and vandalism), it was not really a good place for the information. As of https://github.com/gitgitgadget/gitgitgadget.github.io/pull/21 it moved to GitGitGadget's home page.

Let's stop referring to the wiki for that reason, and refer to the new location instead.