### PR TITLE
Re architecture token handling

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -576,7 +576,7 @@ export class CIHelper {
         };
 
         try {
-            const gitGitGadget = await GitGitGadget.get(this.gggConfigDir, this.workDir);
+            const gitGitGadget = await GitGitGadget.get(this.gggConfigDir, this.workDir, this.notesPushToken);
             if (!gitGitGadget.isUserAllowed(comment.author)) {
                 throw new Error(`User ${comment.author} is not yet permitted to use ${this.config.app.displayName}`);
             }
@@ -782,7 +782,7 @@ export class CIHelper {
             await this.github.addPRComment(prKey, redacted);
         };
 
-        const gitGitGadget = await GitGitGadget.get(this.gggConfigDir, this.workDir);
+        const gitGitGadget = await GitGitGadget.get(this.gggConfigDir, this.workDir, this.notesPushToken);
         if (!pr.hasComments && !gitGitGadget.isUserAllowed(pr.author)) {
             const welcome = (await readFile("res/WELCOME.md")).toString().replace(/\${username}/g, pr.author);
             await this.github.addPRComment(prKey, welcome);

--- a/lib/git-notes.ts
+++ b/lib/git-notes.ts
@@ -19,10 +19,16 @@ type TemporaryNoteIndex = {
 };
 
 export class GitNotes {
-    public async push(url: string) {
+    public async push(url: string, token: string | undefined = undefined): Promise<void> {
+        const auth = !token
+            ? []
+            : [
+                  "-c",
+                  `http.extraheader=Authorization: Basic ${Buffer.from(`x-access-token:${token}`).toString("base64")}`,
+              ];
         for (const backoff of [50, 500, 2000, 5000, 20000, 0]) {
             try {
-                await git(["push", url, "--", `${this.notesRef}`], {
+                await git([...auth, "push", url, "--", `${this.notesRef}`], {
                     workDir: this.workDir,
                 });
             } catch (e) {

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -284,6 +284,7 @@ export class GitGitGadget {
             this.publishTagsAndNotesToRemote,
             pr.pullRequestURL,
             new Date(),
+            this.publishToken,
         );
         if (!options.noUpdate) {
             await this.pushNotesRef();

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -36,7 +36,7 @@ export class GitGitGadget {
         return workDir;
     }
 
-    public static async get(gitGitGadgetDir: string, workDir?: string): Promise<GitGitGadget> {
+    public static async get(gitGitGadgetDir: string, workDir?: string, notesPushToken?: string): Promise<GitGitGadget> {
         if (!workDir) {
             workDir = await this.getWorkDir(gitGitGadgetDir);
         }
@@ -76,6 +76,7 @@ export class GitGitGadget {
             allowedUsers,
             { smtpHost, smtpOpts, smtpPass, smtpUser },
             publishTagsAndNotesToRemote,
+            notesPushToken,
         );
     }
 
@@ -98,6 +99,7 @@ export class GitGitGadget {
     protected readonly smtpOptions: ISMTPOptions;
 
     protected readonly publishTagsAndNotesToRemote: string;
+    private readonly publishToken: string | undefined;
 
     protected constructor(
         notes: GitNotes,
@@ -105,6 +107,7 @@ export class GitGitGadget {
         allowedUsers: Set<string>,
         smtpOptions: ISMTPOptions,
         publishTagsAndNotesToRemote: string,
+        publishToken?: string,
     ) {
         if (!notes.workDir) {
             throw new Error("Could not determine Git worktree");
@@ -117,6 +120,7 @@ export class GitGitGadget {
         this.smtpOptions = smtpOptions;
 
         this.publishTagsAndNotesToRemote = publishTagsAndNotesToRemote;
+        this.publishToken = publishToken;
     }
 
     public isUserAllowed(user: string): boolean {
@@ -240,7 +244,7 @@ export class GitGitGadget {
     }
 
     protected async pushNotesRef(): Promise<void> {
-        await this.notes.push(this.publishTagsAndNotesToRemote);
+        await this.notes.push(this.publishTagsAndNotesToRemote, this.publishToken);
 
         // re-read options
         [this.options, this.allowedUsers] = await GitGitGadget.readOptions(this.notes);

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -555,6 +555,7 @@ export class PatchSeries {
         publishTagsAndNotesToRemote?: string,
         pullRequestURL?: string,
         forceDate?: Date,
+        publishToken?: string,
     ): Promise<IPatchSeriesMetadata | undefined> {
         let globalOptions: IGitGitGadgetOptions | undefined;
         if (this.options.dryRun) {
@@ -822,8 +823,20 @@ export class PatchSeries {
             if (this.options.dryRun) {
                 logger.log("Would publish tag");
             } else {
+                const auth = [];
+                if (publishToken) {
+                    auth.push(
+                        "-c",
+                        [
+                            `http.extraheader=Authorization:`,
+                            `Basic`,
+                            Buffer.from(`x-access-token:${publishToken}`).toString("base64"),
+                        ].join(" "),
+                    );
+                }
+
                 logger.log("Publishing tag");
-                await git(["push", publishTagsAndNotesToRemote, `refs/tags/${tagName}`], {
+                await git([...auth, "push", publishTagsAndNotesToRemote, `refs/tags/${tagName}`], {
                     workDir: this.notes.workDir,
                 });
             }


### PR DESCRIPTION
The primary motivation for this change is to move GitGitGadget towards a set of GitHub Actions that are used in GitHub workflows. The urgency comes from a secondary, originally unanticipated motivation: When I merged #1473, I broke the current Azure Pipelines (the fancy push-or-merge-and-push strategy does not work because the Azure Pipelines cannot push the Git notes to `gitgitgadget/git` due to missing authorization).

So here comes a set of changes to allow specifying the token(s) to use by `CIHelper` in a _much_ more intentional way. Previously, the idea was that the token to use was specified via the Git config options `gitgitgadget.githubToken` (and `gitgitgadget.git.githubToken` for `git/git`, where GitGitGadget requires less permissions; It does not need to push, just do things like adding PR comments). This still works, for backwards-compatibility (at least until I managed to move everything over to GitHub Actions/workflows), but now there is a much more explicit way to configure the tokens to use for specific GitHub rogs in the `CIHelper` object. This new method is now also called from `misc-helper`, which should fix the Azure Pipelines.