### PR TITLE
Prepare config handling for the upcoming GitHub Action

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -582,7 +582,12 @@ export class CIHelper {
         };
 
         try {
-            const gitGitGadget = await GitGitGadget.get(this.gggConfigDir, this.workDir, this.notesPushToken);
+            const gitGitGadget = await GitGitGadget.get(
+                this.gggConfigDir,
+                this.workDir,
+                this.urlRepo,
+                this.notesPushToken,
+            );
             if (!gitGitGadget.isUserAllowed(comment.author)) {
                 throw new Error(`User ${comment.author} is not yet permitted to use ${this.config.app.displayName}`);
             }
@@ -788,7 +793,7 @@ export class CIHelper {
             await this.github.addPRComment(prKey, redacted);
         };
 
-        const gitGitGadget = await GitGitGadget.get(this.gggConfigDir, this.workDir, this.notesPushToken);
+        const gitGitGadget = await GitGitGadget.get(this.gggConfigDir, this.workDir, this.urlRepo, this.notesPushToken);
         if (!pr.hasComments && !gitGitGadget.isUserAllowed(pr.author)) {
             const welcome = (await readFile("res/WELCOME.md")).toString().replace(/\${username}/g, pr.author);
             await this.github.addPRComment(prKey, welcome);

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -45,7 +45,7 @@ export class CIHelper {
         return configFile ? await getExternalConfig(configFile) : getConfig();
     }
 
-    public constructor(workDir: string, config?: IConfig, skipUpdate?: boolean, gggConfigDir = ".") {
+    public constructor(workDir: string = "git.git", config?: IConfig, skipUpdate?: boolean, gggConfigDir = ".") {
         this.config = config !== undefined ? setConfig(config) : getConfig();
         this.gggConfigDir = gggConfigDir;
         this.workDir = workDir;

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -14,6 +14,7 @@ import { IMailMetadata } from "./mail-metadata.js";
 import { IPatchSeriesMetadata } from "./patch-series-metadata.js";
 import { IConfig, getExternalConfig, setConfig } from "./project-config.js";
 import { getPullRequestKeyFromURL, pullRequestKey } from "./pullRequestKey.js";
+import { ISMTPOptions } from "./send-mail.js";
 
 const readFile = util.promisify(fs.readFile);
 type CommentFunction = (comment: string) => Promise<void>;
@@ -39,6 +40,7 @@ export class CIHelper {
     private gggNotesUpdated: boolean;
     private mail2CommitMapUpdated: boolean;
     private notesPushToken: string | undefined;
+    private smtpOptions?: ISMTPOptions;
     protected maxCommitsExceptions: string[];
 
     public static async getConfig(configFile?: string): Promise<IConfig> {
@@ -65,6 +67,10 @@ export class CIHelper {
         if (this.config.repo.owner === repositoryOwner) {
             this.notesPushToken = token;
         }
+    }
+
+    public setSMTPOptions(smtpOptions: ISMTPOptions): void {
+        this.smtpOptions = smtpOptions;
     }
 
     /*
@@ -587,6 +593,7 @@ export class CIHelper {
                 this.workDir,
                 this.urlRepo,
                 this.notesPushToken,
+                this.smtpOptions,
             );
             if (!gitGitGadget.isUserAllowed(comment.author)) {
                 throw new Error(`User ${comment.author} is not yet permitted to use ${this.config.app.displayName}`);
@@ -793,7 +800,13 @@ export class CIHelper {
             await this.github.addPRComment(prKey, redacted);
         };
 
-        const gitGitGadget = await GitGitGadget.get(this.gggConfigDir, this.workDir, this.urlRepo, this.notesPushToken);
+        const gitGitGadget = await GitGitGadget.get(
+            this.gggConfigDir,
+            this.workDir,
+            this.urlRepo,
+            this.notesPushToken,
+            this.smtpOptions,
+        );
         if (!pr.hasComments && !gitGitGadget.isUserAllowed(pr.author)) {
             const welcome = (await readFile("res/WELCOME.md")).toString().replace(/\${username}/g, pr.author);
             await this.github.addPRComment(prKey, welcome);

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -36,12 +36,17 @@ export class GitGitGadget {
         return workDir;
     }
 
-    public static async get(gitGitGadgetDir: string, workDir?: string, notesPushToken?: string): Promise<GitGitGadget> {
+    public static async get(
+        gitGitGadgetDir: string,
+        workDir?: string,
+        publishTagsAndNotesToRemote?: string,
+        notesPushToken?: string,
+    ): Promise<GitGitGadget> {
         if (!workDir) {
             workDir = await this.getWorkDir(gitGitGadgetDir);
         }
 
-        const publishTagsAndNotesToRemote = await getVar("publishRemote", gitGitGadgetDir);
+        if (!publishTagsAndNotesToRemote) publishTagsAndNotesToRemote = await getVar("publishRemote", gitGitGadgetDir);
         if (!publishTagsAndNotesToRemote) {
             throw new Error("No remote to which to push configured");
         }

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -71,10 +71,15 @@ export class GitGitGadget {
             const smtpPass = await getVar("smtpPass", gitGitGadgetDir);
             const smtpOpts = await getVar("smtpOpts", gitGitGadgetDir);
 
-            if (!smtpUser || !smtpHost || !smtpPass) {
-                throw new Error("No SMTP settings configured");
+            if (smtpUser && smtpHost && smtpPass) smtpOptions = { smtpHost, smtpOpts, smtpPass, smtpUser };
+            else if (smtpUser || smtpHost || smtpPass) {
+                const missing: string[] = [
+                    smtpUser ? "" : "smtpUser",
+                    smtpHost ? "" : "smtpHost",
+                    smtpPass ? "" : "smtpPass",
+                ].filter((e) => e);
+                throw new Error(`Partial SMTP configuration detected (${missing.join(", ")} missing)`);
             }
-            smtpOptions = { smtpHost, smtpOpts, smtpPass, smtpUser };
         }
 
         const [options, allowedUsers] = await GitGitGadget.readOptions(notes);
@@ -98,7 +103,7 @@ export class GitGitGadget {
     protected options: IGitGitGadgetOptions;
     protected allowedUsers: Set<string>;
 
-    protected readonly smtpOptions: ISMTPOptions;
+    protected readonly smtpOptions?: ISMTPOptions;
 
     protected readonly publishTagsAndNotesToRemote: string;
     private readonly publishToken: string | undefined;
@@ -107,7 +112,7 @@ export class GitGitGadget {
         notes: GitNotes,
         options: IGitGitGadgetOptions,
         allowedUsers: Set<string>,
-        smtpOptions: ISMTPOptions,
+        smtpOptions: ISMTPOptions | undefined,
         publishTagsAndNotesToRemote: string,
         publishToken?: string,
     ) {
@@ -168,6 +173,10 @@ export class GitGitGadget {
 
     // Send emails only to the user
     public async preview(pr: IPullRequestInfo, userInfo: IGitHubUser): Promise<IPatchSeriesMetadata | undefined> {
+        const smtpOptions = this.smtpOptions;
+        if (!smtpOptions) {
+            throw new Error("No SMTP options configured");
+        }
         if (!userInfo.email) {
             throw new Error(`No email in user info for ${userInfo.login}`);
         }
@@ -178,7 +187,7 @@ export class GitGitGadget {
             mbox.cc = [];
             mbox.to = email;
             console.log(mbox);
-            return await sendMail(mbox, this.smtpOptions);
+            return await sendMail(mbox, smtpOptions);
         };
 
         return await this.genAndSend(pr, userInfo, { noUpdate: true }, send);
@@ -186,8 +195,12 @@ export class GitGitGadget {
 
     // Send emails out for review
     public async submit(pr: IPullRequestInfo, userInfo: IGitHubUser): Promise<IPatchSeriesMetadata | undefined> {
+        const smtpOptions = this.smtpOptions;
+        if (!smtpOptions) {
+            throw new Error("No SMTP options configured");
+        }
         const send = async (mail: string): Promise<string> => {
-            return await parseHeadersAndSendMail(mail, this.smtpOptions);
+            return await parseHeadersAndSendMail(mail, smtpOptions);
         };
 
         return await this.genAndSend(pr, userInfo, {}, send);

--- a/lib/misc-action.ts
+++ b/lib/misc-action.ts
@@ -35,7 +35,7 @@ export async function handleAction(parms: actionInterface): Promise<void> {
         throw new Error(`git WorkDir '${parms.repositoryDir}' not found.`);
     }
 
-    const ci = new CIHelper(parms.repositoryDir, parms.skipUpdate ? true : false, parms.configRepositoryDir);
+    const ci = new CIHelper(parms.repositoryDir, config, parms.skipUpdate ? true : false, parms.configRepositoryDir);
 
     if (parms.action === "update-open-prs") {
         const result = await ci.updateOpenPrs();

--- a/lib/project-config.ts
+++ b/lib/project-config.ts
@@ -64,6 +64,25 @@ export function getConfig(): IConfig {
     return config;
 }
 
+export async function getExternalConfig(file: string): Promise<IConfig> {
+    const filePath = path.resolve(file);
+    const newConfig = await loadConfig(filePath);
+
+    if (!Object.prototype.hasOwnProperty.call(newConfig, "project")) {
+        throw new Error(`User configurations must have a 'project:'.  Not found in ${filePath}`);
+    }
+
+    if (!newConfig.repo.owner.match(/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i)) {
+        throw new Error(`Invalid 'owner' ${newConfig.repo.owner} in ${filePath}`);
+    }
+
+    if (!newConfig.repo.baseOwner.match(/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i)) {
+        throw new Error(`Invalid 'baseOwner' ${newConfig.repo.baseOwner} in ${filePath}`);
+    }
+
+    return newConfig;
+}
+
 type importedConfig = { default: IConfig };
 
 /**

--- a/lib/pull-action.ts
+++ b/lib/pull-action.ts
@@ -38,7 +38,7 @@ export async function handlePRUpdate(parms: PRUpdateInterface): Promise<void> {
         throw new Error(`git WorkDir '${parms.repositoryDir}' not found.`);
     }
 
-    const ci = new CIHelper(parms.repositoryDir, parms.skipUpdate ? true : false, parms.configRepositoryDir);
+    const ci = new CIHelper(parms.repositoryDir, config, parms.skipUpdate ? true : false, parms.configRepositoryDir);
 
     if (parms.action === "comment") {
         if (parms.commentId) {

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -5,12 +5,11 @@ import { CIHelper } from "../lib/ci-helper.js";
 import { isDirectory } from "../lib/fs-util.js";
 import { git, gitConfig } from "../lib/git.js";
 import { IGitGitGadgetOptions, getVar } from "../lib/gitgitgadget.js";
-import { getConfig } from "../lib/gitgitgadget-config.js";
 import { GitHubGlue } from "../lib/github-glue.js";
 import { toPrettyJSON } from "../lib/json-util.js";
 import { IGitMailingListMirrorState, stateKey } from "../lib/mail-archive-helper.js";
 import { IPatchSeriesMetadata } from "../lib/patch-series-metadata.js";
-import { IConfig, getExternalConfig, setConfig } from "../lib/project-config.js";
+import { IConfig } from "../lib/project-config.js";
 
 let commander = new Command();
 const publishRemoteKey = "publishRemote";
@@ -46,9 +45,7 @@ interface ICommanderOptions {
 const commandOptions = commander.opts<ICommanderOptions>();
 
 (async (): Promise<void> => {
-    const config: IConfig = commandOptions.config
-        ? setConfig(await getExternalConfig(commandOptions.config))
-        : getConfig();
+    const config: IConfig = await CIHelper.getConfig(commandOptions.config);
 
     const getGitGitWorkDir = async (): Promise<string> => {
         if (!commandOptions.gitWorkDir) {
@@ -69,7 +66,12 @@ const commandOptions = commander.opts<ICommanderOptions>();
         return commandOptions.gitWorkDir;
     };
 
-    const ci = new CIHelper(await getGitGitWorkDir(), commandOptions.skipUpdate, commandOptions.gitgitgadgetWorkDir);
+    const ci = new CIHelper(
+        await getGitGitWorkDir(),
+        config,
+        commandOptions.skipUpdate,
+        commandOptions.gitgitgadgetWorkDir,
+    );
 
     const configureNotesPushToken = async (): Promise<void> => {
         const token = await gitConfig("gitgitgadget.githubToken");

--- a/script/misc-helper.ts
+++ b/script/misc-helper.ts
@@ -10,8 +10,7 @@ import { GitHubGlue } from "../lib/github-glue.js";
 import { toPrettyJSON } from "../lib/json-util.js";
 import { IGitMailingListMirrorState, stateKey } from "../lib/mail-archive-helper.js";
 import { IPatchSeriesMetadata } from "../lib/patch-series-metadata.js";
-import { IConfig, loadConfig, setConfig } from "../lib/project-config.js";
-import path from "path";
+import { IConfig, getExternalConfig, setConfig } from "../lib/project-config.js";
 
 let commander = new Command();
 const publishRemoteKey = "publishRemote";
@@ -488,22 +487,3 @@ const commandOptions = commander.opts<ICommanderOptions>();
     process.stderr.write(`Caught error ${reason}:\n${reason.stack}\n`);
     process.exit(1);
 });
-
-async function getExternalConfig(file: string): Promise<IConfig> {
-    const filePath = path.resolve(file);
-    const newConfig = await loadConfig(filePath);
-
-    if (!Object.prototype.hasOwnProperty.call(newConfig, "project")) {
-        throw new Error(`User configurations must have a 'project:'.  Not found in ${filePath}`);
-    }
-
-    if (!newConfig.repo.owner.match(/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i)) {
-        throw new Error(`Invalid 'owner' ${newConfig.repo.owner} in ${filePath}`);
-    }
-
-    if (!newConfig.repo.baseOwner.match(/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i)) {
-        throw new Error(`Invalid 'baseOwner' ${newConfig.repo.baseOwner} in ${filePath}`);
-    }
-
-    return newConfig;
-}

--- a/tests-config/ci-helper.test.ts
+++ b/tests-config/ci-helper.test.ts
@@ -94,7 +94,7 @@ class TestCIHelper extends CIHelper {
     public addPRLabelsCalls: Array<[_: string, labels: string[]]>;
 
     public constructor(workDir: string, debug = false, gggDir = ".") {
-        super(workDir, debug, gggDir);
+        super(workDir, config, debug, gggDir);
         this.testing = true;
         this.ghGlue = this.github;
 
@@ -240,7 +240,7 @@ test("identify merge that integrated some commit", async () => {
     const commitD = await repo.merge("d", commitF);
     await repo.git(["update-ref", `refs/remotes/upstream/${config.repo.trackingBranches[2]}`, commitD]);
 
-    const ci = new CIHelper(repo.workDir, true);
+    const ci = new CIHelper(repo.workDir, config, true);
     expect(commitB).not.toBeUndefined();
     expect(await ci.identifyMergeCommit(config.repo.trackingBranches[2], commitG)).toEqual(commitD);
     expect(await ci.identifyMergeCommit(config.repo.trackingBranches[2], commitE)).toEqual(commitC);

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -32,7 +32,7 @@ function testQ(label: string, fn: AsyncFn) {
     });
 }
 
-getConfig();
+const config = getConfig();
 
 const eMailOptions = {
     smtpserver: new testSmtpServer(),
@@ -61,7 +61,7 @@ class TestCIHelper extends CIHelper {
     public addPRLabelsCalls: Array<[_: string, labels: string[]]>;
 
     public constructor(workDir: string, debug = false, gggDir = ".") {
-        super(workDir, debug, gggDir);
+        super(workDir, config, debug, gggDir);
         this.testing = true;
         this.ghGlue = this.github;
 
@@ -203,7 +203,7 @@ testQ("identify merge that integrated some commit", async () => {
     const commitD = await repo.merge("d", commitF);
     await repo.git(["update-ref", "refs/remotes/upstream/seen", commitD]);
 
-    const ci = new CIHelper(repo.workDir, true);
+    const ci = new CIHelper(repo.workDir, config, true);
     expect(commitB).not.toBeUndefined();
     expect(await ci.identifyMergeCommit("seen", commitG)).toEqual(commitD);
     expect(await ci.identifyMergeCommit("seen", commitE)).toEqual(commitC);


### PR DESCRIPTION
This is part 1 of going for [the idea to switch from Azure Pipelines to GitHub workflows](https://github.com/gitgitgadget/gitgitgadget/issues/609).

In this PR, I tried to break out the commits into their own change set which are concerned with setting up GitGitGadget to do its work, including the configuration which repositories to clone and where to.