### PR TITLE
Add a set of GitHub Actions to perform GitGitGadget's job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.env
 /.test-dir/
 /build/
+/dist/**/*.d.ts
 /node_modules/
 /npm-debug.log
 /junit.xml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -96,6 +96,7 @@
         "CIsmtphost",
         "CIsmtppass",
         "CIsmtpopts",
+        "mailrepo",
         "parsePRURLInput",
         "users\\.noreply\\.github\\.com",
     ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -96,6 +96,7 @@
         "CIsmtphost",
         "CIsmtppass",
         "CIsmtpopts",
+        "GITGIT_(|DIR|GIT_REMOTE|MAIL_REMOTE|MAIL_EPOCH)",
         "mailrepo",
         "parsePRURLInput",
         "users\\.noreply\\.github\\.com",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -96,6 +96,7 @@
         "CIsmtphost",
         "CIsmtppass",
         "CIsmtpopts",
+        "parsePRURLInput",
         "users\\.noreply\\.github\\.com",
     ],
     "cSpell.language": "en-US",

--- a/handle-new-mails/action.yml
+++ b/handle-new-mails/action.yml
@@ -1,0 +1,19 @@
+name: 'Handle new mails'
+description: 'Processes new mails on the Git mailing list'
+author: 'Johannes Schindelin'
+inputs:
+  pr-repo-token:
+    description: 'The access token to work on the repository that holds PRs and state'
+    required: true
+  upstream-repo-token:
+    description: 'The access token to work on PRs in the upstream repository'
+    required: true
+  test-repo-token:
+    description: 'The access token to work on PRs in the test repository'
+    required: true
+runs:
+  using: 'node20'
+  main: './index.js'
+branding:
+  icon: 'git-commit'
+  color: 'orange'

--- a/handle-new-mails/index.js
+++ b/handle-new-mails/index.js
@@ -1,0 +1,12 @@
+async function run() {
+  const { CIHelper } = await import("../dist/index.js")
+
+  const ci = new CIHelper()
+
+  await ci.setupGitHubAction({
+    needsMailingListMirror: true,
+  })
+  await ci.handleNewMails()
+}
+
+run()

--- a/handle-pr-comment/action.yml
+++ b/handle-pr-comment/action.yml
@@ -1,0 +1,34 @@
+name: 'Handle PR Comment'
+description: 'Handles slash commands such as /submit and /preview'
+author: 'Johannes Schindelin'
+inputs:
+  pr-repo-token:
+    description: 'The access token to work on the repository that holds PRs and state'
+    required: true
+  upstream-repo-token:
+    description: 'The access token to work on PRs in the upstream repository'
+    required: true
+  test-repo-token:
+    description: 'The access token to work on PRs in the test repository'
+    required: true
+  smtp-host:
+    description: 'The SMTP host to use for sending emails'
+    required: true
+  smtp-user:
+    description: 'The SMTP user when sending emails'
+    required: true
+  smtp-opts:
+    description: 'Extra SMTP options in JSON format'
+    required: false
+  smtp-pass:
+    description: 'The SMTP password to use for sending emails'
+    required: true
+  pr-comment-url:
+    description: 'The URL of the PR comment to add a reaction to'
+    required: true
+runs:
+  using: 'node20'
+  main: './index.js'
+branding:
+  icon: 'git-commit'
+  color: 'orange'

--- a/handle-pr-comment/index.js
+++ b/handle-pr-comment/index.js
@@ -1,0 +1,11 @@
+async function run() {
+  const { CIHelper } = await import("../dist/index.js")
+
+  const ci = new CIHelper()
+  const { owner, commentId } = ci.parsePRCommentURLInput()
+
+  await ci.setupGitHubAction()
+  await ci.handleComment(owner, commentId)
+}
+
+run()

--- a/handle-pr-push/action.yml
+++ b/handle-pr-push/action.yml
@@ -1,0 +1,22 @@
+name: 'Handle PR Pushes'
+description: 'Handles when a PR was pushed'
+author: 'Johannes Schindelin'
+inputs:
+  pr-repo-token:
+    description: 'The access token to work on the repository that holds PRs and state'
+    required: true
+  upstream-repo-token:
+    description: 'The access token to work on PRs in the upstream repository'
+    required: true
+  test-repo-token:
+    description: 'The access token to work on PRs in the test repository'
+    required: true
+  pr-url:
+    description: 'The URL of the PR that was pushed'
+    required: true
+runs:
+  using: 'node20'
+  main: './index.js'
+branding:
+  icon: 'git-commit'
+  color: 'orange'

--- a/handle-pr-push/index.js
+++ b/handle-pr-push/index.js
@@ -1,0 +1,11 @@
+async function run() {
+  const { CIHelper } = await import("../dist/index.js")
+
+  const ci = new CIHelper()
+  const { owner, prNumber } = ci.parsePRURLInput()
+
+  await ci.setupGitHubAction()
+  await ci.handlePush(owner, prNumber)
+}
+
+run()

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -18,6 +18,7 @@ import { IPatchSeriesMetadata } from "./patch-series-metadata.js";
 import { IConfig, getExternalConfig, setConfig } from "./project-config.js";
 import { getPullRequestKeyFromURL, pullRequestKey } from "./pullRequestKey.js";
 import { ISMTPOptions } from "./send-mail.js";
+import { fileURLToPath } from "url";
 
 const readFile = util.promisify(fs.readFile);
 type CommentFunction = (comment: string) => Promise<void>;
@@ -874,6 +875,11 @@ export class CIHelper {
         }
     }
 
+    public static async getWelcomeMessage(username: string): Promise<string> {
+        const resPath = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "..", "res", "WELCOME.md");
+        return (await readFile(resPath)).toString().replace(/\${username}/g, username);
+    }
+
     public async handlePush(repositoryOwner: string, prNumber: number): Promise<void> {
         const prKey = {
             owner: repositoryOwner,
@@ -897,7 +903,7 @@ export class CIHelper {
             this.smtpOptions,
         );
         if (!pr.hasComments && !gitGitGadget.isUserAllowed(pr.author)) {
-            const welcome = (await readFile("res/WELCOME.md")).toString().replace(/\${username}/g, pr.author);
+            const welcome = await CIHelper.getWelcomeMessage(pr.author);
             await this.github.addPRComment(prKey, welcome);
 
             await this.github.addPRLabels(prKey, ["new user"]);

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -162,6 +162,17 @@ export class CIHelper {
         return { owner, repo, prNumber: parseInt(prNumber, 10), commentId: parseInt(commentId, 10) };
     }
 
+    public parsePRURLInput(): { owner: string; repo: string; prNumber: number } {
+        const prCommentUrl = core.getInput("pr-url");
+
+        const [, owner, repo, prNumber] =
+            prCommentUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)$/) || [];
+        if (!this.config.repo.owners.includes(owner) || repo !== this.config.repo.name) {
+            throw new Error(`Invalid PR comment URL: ${prCommentUrl}`);
+        }
+        return { owner, repo, prNumber: parseInt(prNumber, 10) };
+    }
+
     public setAccessToken(repositoryOwner: string, token: string): void {
         this.github.setAccessToken(repositoryOwner, token);
         if (this.config.repo.owner === repositoryOwner) {

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -83,6 +83,15 @@ export class CIHelper {
             break;
         }
 
+        // configure the Git committer information
+        process.env.GIT_CONFIG_PARAMETERS = [
+            process.env.GIT_CONFIG_PARAMETERS,
+            "'user.name=GitGitGadget'",
+            "'user.email=gitgitgadget@gmail.com'",
+        ]
+            .filter((e) => e)
+            .join(" ");
+
         // get the access tokens via the inputs of the GitHub Action
         this.setAccessToken(this.config.repo.owner, core.getInput("pr-repo-token"));
         this.setAccessToken(this.config.repo.baseOwner, core.getInput("upstream-repo-token"));

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -90,6 +90,21 @@ export class CIHelper {
             this.setAccessToken(this.config.repo.testOwner, core.getInput("test-repo-token"));
         }
 
+        // set the SMTP options
+        try {
+            const options = {
+                smtpUser: core.getInput("smtp-user"),
+                smtpHost: core.getInput("smtp-host"),
+                smtpPass: core.getInput("smtp-pass"),
+                smtpOpts: core.getInput("smtp-opts"),
+            };
+            if (options.smtpUser && options.smtpHost && options.smtpPass) {
+                this.setSMTPOptions(options);
+            }
+        } catch (e) {
+            // Ignore, for now
+        }
+
         // eslint-disable-next-line security/detect-non-literal-fs-filename
         if (!fs.existsSync(this.workDir)) await git(["init", "--bare", "--initial-branch", "unused", this.workDir]);
         for (const [key, value] of [

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -152,6 +152,16 @@ export class CIHelper {
         await unshallow(this.workDir);
     }
 
+    public parsePRCommentURLInput(): { owner: string; repo: string; prNumber: number; commentId: number } {
+        const prCommentUrl = core.getInput("pr-comment-url");
+        const [, owner, repo, prNumber, commentId] =
+            prCommentUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)#issuecomment-(\d+)$/) || [];
+        if (!this.config.repo.owners.includes(owner) || repo !== this.config.repo.name) {
+            throw new Error(`Invalid PR comment URL: ${prCommentUrl}`);
+        }
+        return { owner, repo, prNumber: parseInt(prNumber, 10), commentId: parseInt(commentId, 10) };
+    }
+
     public setAccessToken(repositoryOwner: string, token: string): void {
         this.github.setAccessToken(repositoryOwner, token);
         if (this.config.repo.owner === repositoryOwner) {

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -2,10 +2,11 @@ import * as core from "@actions/core";
 import * as fs from "fs";
 import * as os from "os";
 import * as util from "util";
+import { spawnSync } from "child_process";
 import addressparser from "nodemailer/lib/addressparser/index.js";
 import path from "path";
 import { ILintError, LintCommit } from "./commit-lint.js";
-import { commitExists, git, emptyTreeName } from "./git.js";
+import { commitExists, git, emptyTreeName, revParse } from "./git.js";
 import { GitNotes } from "./git-notes.js";
 import { GitGitGadget, IGitGitGadgetOptions } from "./gitgitgadget.js";
 import { getConfig } from "./gitgitgadget-config.js";
@@ -70,6 +71,7 @@ export class CIHelper {
     public async setupGitHubAction(setupOptions?: {
         needsMailingListMirror?: boolean;
         needsUpstreamBranches?: boolean;
+        needsMailToCommitNotes?: boolean;
     }): Promise<void> {
         // help dugite realize where `git` is...
         const gitExecutable = os.type() === "Windows_NT" ? "git.exe" : "git";
@@ -133,6 +135,10 @@ export class CIHelper {
             await git(["config", key, value], { workDir: this.workDir });
         }
         console.time("fetch Git notes");
+        const notesRefs = [GitNotes.defaultNotesRef];
+        if (setupOptions?.needsMailToCommitNotes) {
+            notesRefs.push("refs/notes/mail-to-commit", "refs/notes/commit-to-mail");
+        }
         await git(
             [
                 "fetch",
@@ -140,7 +146,7 @@ export class CIHelper {
                 "--no-tags",
                 "origin",
                 "--depth=1",
-                `+${GitNotes.defaultNotesRef}:${GitNotes.defaultNotesRef}`,
+                ...notesRefs.map((ref) => `+${ref}:${ref}`),
             ],
             {
                 workDir: this.workDir,
@@ -217,7 +223,7 @@ export class CIHelper {
                     "remote.mirror.promisor=false", // let's fetch the mails with all of their contents
                     "fetch",
                     "mirror",
-                    "--depth=50",
+                    `--depth=${setupOptions?.needsMailToCommitNotes ? 5000 : 50}`,
                     "+REF:REF".replace("REF", this.config.mailrepo.mirrorRef || `refs/heads/lore-${epoch}`),
                 ],
                 {
@@ -315,6 +321,60 @@ export class CIHelper {
         }
         await this.mail2commit.mail2CommitNotes.setString(messageId, gitGitCommit, true);
         await this.commit2mailNotes.appendCommitNote(gitGitCommit, messageId);
+    }
+
+    /**
+     * Update the `commit-to-mail` and `mail-to-commit` Git notes refs.
+     */
+    public async updateMailToCommitNotes(): Promise<void> {
+        // We'll assume that the `commit-to-mail` and `mail-to-commit` notes refs are up to date
+        const commit2MailTipCommit = await revParse("refs/notes/commit-to-mail", this.workDir);
+        const dir = fileURLToPath(new URL(".", import.meta.url));
+        const lookupCommitScriptPath = path.resolve(dir, "..", "script", "lookup-commit.sh");
+        console.time("lookup-commit.sh");
+        const lookupCommitResult = spawnSync("sh", ["-x", lookupCommitScriptPath, "--notes", "update"], {
+            stdio: "inherit",
+            env: {
+                ...process.env,
+                GITGIT_DIR: this.workDir,
+                GITGIT_GIT_REMOTE: this.urlRepo,
+                LORE_GIT_DIR: this.mailingListMirror,
+                GITGIT_MAIL_REMOTE: this.config.mailrepo.url,
+                GITGIT_MAIL_EPOCH: "1",
+            },
+        });
+        console.timeEnd("lookup-commit.sh");
+        if (lookupCommitResult.status !== 0) throw new Error("lookup-commit.sh failed");
+        // If there were no updates, we are done
+        if (commit2MailTipCommit === (await revParse("refs/notes/commit-to-mail", this.workDir))) return;
+
+        const updateMailToCommitNotesScriptPath = path.resolve(dir, "..", "script", "update-mail-to-commit-notes.sh");
+        console.time("update-mail-to-commit-notes.sh");
+        const updateMailToCommitNotesResult = spawnSync("sh", ["-x", updateMailToCommitNotesScriptPath], {
+            stdio: "inherit",
+            env: {
+                ...process.env,
+                GITGIT_DIR: this.workDir,
+                GITGIT_GIT_REMOTE: this.urlRepo,
+            },
+        });
+        console.timeEnd("update-mail-to-commit-notes.sh");
+        if (updateMailToCommitNotesResult.status !== 0) throw new Error("update-mail-to-commit-notes.sh failed");
+
+        const mail2commitNotes = new GitNotes(this.workDir, "refs/notes/mail-to-commit");
+        await mail2commitNotes.push(this.urlRepo, this.notesPushToken);
+        const commit2MailNotes = new GitNotes(this.workDir, "refs/notes/commit-to-mail");
+        await commit2MailNotes.push(this.urlRepo, this.notesPushToken);
+
+        const commit2MailTipPatch = await git(["show", "refs/notes/commit-to-mail"], { workDir: this.workDir });
+        // Any unhandled commit will get annotated with "no match"
+        // To list all of them, the tip commit's diff is parsed and the commit hash is
+        // extracted from the "filename" on the `+++ b/` line.
+        const noMatch = commit2MailTipPatch
+            .split("\ndiff --git ")
+            .filter((d) => d.endsWith("+no match"))
+            .map((d) => d.split("\n+++ b/")[1].split("\n")[0].replace("/", ""));
+        if (noMatch.length) throw new Error(`Could not find mail(s) for: ${noMatch.join("\n")}`);
     }
 
     /**

--- a/lib/gitgitgadget-config.ts
+++ b/lib/gitgitgadget-config.ts
@@ -5,6 +5,7 @@ const defaultConfig: IConfig = {
         name: "git",
         owner: "gitgitgadget",
         baseOwner: "git",
+        testOwner: "dscho",
         owners: ["gitgitgadget", "git", "dscho"],
         branches: ["maint", "seen"],
         closingBranches: ["maint", "master"],

--- a/lib/gitgitgadget-config.ts
+++ b/lib/gitgitgadget-config.ts
@@ -19,6 +19,9 @@ const defaultConfig: IConfig = {
         branch: "master",
         host: "lore.kernel.org",
         url: "https://lore.kernel.org/git/",
+        public_inbox_epoch: 1,
+        mirrorURL: "https://github.com/gitgitgadget/git-mailing-list-mirror",
+        mirrorRef: "refs/heads/lore-1",
         descriptiveName: "lore.kernel/git",
     },
     mail: {

--- a/lib/project-config.ts
+++ b/lib/project-config.ts
@@ -12,7 +12,8 @@ export interface IConfig {
     repo: {
         name: string; // name of the repo
         owner: string; // owner of repo holding the notes (tracking data)
-        baseOwner: string; // owner of base repo
+        baseOwner: string; // owner of upstream ("base") repo
+        testOwner?: string; // owner of the test repo (if any)
         owners: string[]; // owners of clones being monitored (PR checking)
         branches: string[]; // remote branches to fetch - just use trackingBranches?
         closingBranches: string[]; // close if the pr is added to this branch

--- a/lib/project-config.ts
+++ b/lib/project-config.ts
@@ -27,6 +27,9 @@ export interface IConfig {
         branch: string;
         host: string;
         url: string;
+        public_inbox_epoch?: number;
+        mirrorURL?: string;
+        mirrorRef?: string;
         descriptiveName: string;
     };
     mail: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@types/node": "^24.3.0",
         "@types/nodemailer": "^7.0.0",
         "@types/rfc2047": "^2.0.3",
+        "@vercel/ncc": "^0.38.3",
         "eslint": "^9.33.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jest": "^29.0.1",
@@ -5022,6 +5023,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.3.tgz",
+      "integrity": "sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@actions/core": "^1.11.1",
         "@octokit/auth-app": "^8.0.2",
         "@octokit/request-error": "^7.0.0",
         "@octokit/rest": "^22.0.0",
@@ -58,6 +59,41 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -1495,6 +1531,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanfs/core": {
@@ -11299,6 +11344,15 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -11387,6 +11441,18 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "typescript-eslint": "8.39.1"
   },
   "dependencies": {
+    "@actions/core": "^1.11.1",
     "@octokit/auth-app": "^8.0.2",
     "@octokit/request-error": "^7.0.0",
     "@octokit/rest": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "tsc",
     "build-dist": "ncc build -s -m ./lib/ci-helper.ts -o dist",
     "cleanbranch": "node ./build/script/delete-test-branches.js",
-    "lint": "eslint \"{lib,script,tests,tests-config}/**/*.{ts,tsx,mjs,js}\" --ignore-pattern \"dist/**/*\"",
+    "lint": "eslint \"{lib,script,tests,tests-config}/**/*.{ts,tsx,mjs,js}\" \"*/index.js\" --ignore-pattern \"dist/**/*\"",
     "start": "node server.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --env=node",
     "test:clean": "jest --clearCache && npm test",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/node": "^24.3.0",
     "@types/nodemailer": "^7.0.0",
     "@types/rfc2047": "^2.0.3",
+    "@vercel/ncc": "^0.38.3",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jest": "^29.0.1",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
+    "build-dist": "ncc build -s -m ./lib/ci-helper.ts -o dist",
     "cleanbranch": "node ./build/script/delete-test-branches.js",
-    "lint": "eslint \"{lib,script,tests,tests-config}/**/*.{ts,tsx,mjs,js}\"",
+    "lint": "eslint \"{lib,script,tests,tests-config}/**/*.{ts,tsx,mjs,js}\" --ignore-pattern \"dist/**/*\"",
     "start": "node server.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --env=node",
     "test:clean": "jest --clearCache && npm test",

--- a/update-mail-to-commit-notes/action.yml
+++ b/update-mail-to-commit-notes/action.yml
@@ -1,0 +1,13 @@
+name: 'Update the mail <-> commit notes'
+description: 'Updates the mapping between commits and patch emails, stored in the `mail-to-commit` and `commit-to-mail` Git notes refs.'
+author: 'Johannes Schindelin'
+inputs:
+  pr-repo-token:
+    description: 'The access token to work on the repository that holds PRs and state'
+    required: true
+runs:
+  using: 'node20'
+  main: './index.js'
+branding:
+  icon: 'git-commit'
+  color: 'orange'

--- a/update-mail-to-commit-notes/index.js
+++ b/update-mail-to-commit-notes/index.js
@@ -1,0 +1,14 @@
+async function run() {
+  const { CIHelper } = await import("../dist/index.js")
+
+  const ci = new CIHelper()
+
+  await ci.setupGitHubAction({
+    needsMailingListMirror: true,
+    needsUpstreamBranches: true,
+    needsMailToCommitNotes: true,
+  })
+  await ci.updateMailToCommitNotes()
+}
+
+run()

--- a/update-prs/action.yml
+++ b/update-prs/action.yml
@@ -1,0 +1,19 @@
+name: 'Update the Pull Requests'
+description: 'Updates the Pull Requests in response to upstream commits'
+author: 'Johannes Schindelin'
+inputs:
+  pr-repo-token:
+    description: 'The access token to work on the repository that holds PRs and state'
+    required: true
+  upstream-repo-token:
+    description: 'The access token to work on PRs in the upstream repository'
+    required: true
+  test-repo-token:
+    description: 'The access token to work on PRs in the test repository'
+    required: true
+runs:
+  using: 'node20'
+  main: './index.js'
+branding:
+  icon: 'git-commit'
+  color: 'orange'

--- a/update-prs/index.js
+++ b/update-prs/index.js
@@ -1,0 +1,14 @@
+async function run() {
+  const { CIHelper } = await import("../dist/index.js")
+
+  const ci = new CIHelper()
+
+  await ci.setupGitHubAction({
+    needsUpstreamBranches: true,
+  })
+  await ci.updateOpenPrs()
+  await ci.updateCommitMappings()
+  await ci.handleOpenPRs()
+}
+
+run()


### PR DESCRIPTION
This PR is part 3 of addressing #609, and it is stacked on top of #1980 and #1981 (and therefore contains also the commits of those PRs), therefore I will leave this in draft mode until those PRs are merged.

The grand idea is to bundle the `CIHelper` class together with all its direct and transitive dependencies into one big, honking `dist/index.js`, and then add a set of really minimal GitHub Actions that call into `CIHelper`. The Actions are added in sub-directories so that they can be called in GitHub workflows via e.g. `- uses: gitgitgadget/gitgitgadget/update-prs@1`.

The component used for bundling `CIHelper` is [`@vercel/ncc` ](https://www.npmjs.com/package/@vercel/ncc). To support acting as a GitHub Action, [`@actions/core`](https://www.npmjs.com/package/@actions/core) is installed.

To allow for really minimal GitHub Actions, the `CIHelper` class is augmented accordingly to re-implement more logic that is currently either in `misc-helper.ts` or in the (non-public 😞) Azure Pipelines definitions.

The naming convention for specifying the necessary tokens as GitHub Actions inputs is:
- `upstream-repo-token`: This is to comment on PRs in `git/git`
- `pr-repo-token`: This is to comment on PRs in `gitgitgadget/git` (as well as to be able to push to that repository)
- `test-repo-token`: This is to comment on PRs in `dscho/git` (used exclusively for testing)

To clarify, here is a diagram:

```mermaid
graph TD
    user["user (contributor)"]
    upstream-repo["upstream-repo (authoritative project repo)"]
    pr-repo["pr-repo (GitGitGadget-enabled GitHub repo)"]
    GitGitGadget["GitGitGadget"]
    mailing-list["mailing-list"]

    user -->|"opens PR"| pr-repo
    user -->|"opens PR (if GitHub App installed)"| upstream-repo

    upstream-repo -->|"GitGitGadget syncs branches to"| pr-repo

    pr-repo -->|"slash commands"| GitGitGadget
    upstream-repo -->|"slash commands (if App installed)"| GitGitGadget

    GitGitGadget -->|"sends patch series"| mailing-list
```