### PR TITLE
Publish the GitHub Actions to a separate branch

### DIFF
--- a/.github/workflows/push-github-actions.yml
+++ b/.github/workflows/push-github-actions.yml
@@ -1,0 +1,84 @@
+name: Push GitHub Actions
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/action.yml'
+      - '**/*.js'
+      - '**/*.ts'
+      - 'package*.json'
+      - 'res/**/*'
+      - 'script/**/*'
+      - '.github/workflows/push-github-actions.yml'
+
+permissions:
+  contents: write
+
+jobs:
+    push-github-action:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v5
+          with:
+            persist-credentials: true
+        - name: Set up Node.js
+          uses: actions/setup-node@v4
+          with:
+            node-version: '20'
+        - name: Install dependencies
+          run: npm ci
+        - name: Build dist/
+          run: npm run build-dist
+        - name: Commit the result
+          id: commit
+          run: |
+            git config --local user.name "GitGitGadget CI" &&
+            git config --local user.email "ci@noreply.github.com" &&
+
+            if ! git fetch --tags origin v1
+            then
+              # Starting from scratch
+              v1=HEAD &&
+              tag_name=v1.0
+            else
+              v1=FETCH_HEAD &&
+              tag_name="$(git name-rev '--refs=refs/tags/v[0-9]*.[0-9]*' $v1)" &&
+              case "$tag_name" in
+              *' tags/v1.'*) incr="${tag_name#* tags/v1.}"; tag_name="v1.$(($incr + 1))";;
+              *)
+                tag_name=v1.0
+                ! git rev-parse --verify refs/tags/$tag_name || {
+                  echo "v1.0 already exists but is not reachable from v1?!?" >&2
+                  exit 1
+                }
+                ;;
+              esac
+            fi &&
+
+            echo '{"type":"module"}' >dist/package.json &&
+            # Include WELCOME.md in the dist/ directory
+            cp -R res dist/ &&
+            # Include the shell scripts for updating the mail-to-commit and commit-to-mail notes
+            mkdir -p dist/script &&
+            cp script/{lookup-commit,update-mail-to-commit-notes}.sh dist/script/ &&
+            # Now, add the generated files
+            git add -A dist/ &&
+            # Remove the rest
+            git rm -r -- \* ':(exclude)dist/' ':(exclude)*/action.yml' ':(exclude)*/index.js' &&
+
+            # Now make that fake merge commit
+            tree=$(git write-tree) &&
+            msg="Sync v1 with ($(git show -s --pretty=reference HEAD))" &&
+            case "$v1" in
+            HEAD) commit=$(git commit-tree -m "$msg" $tree -p HEAD);;
+            *) commit=$(git commit-tree -m "$msg" $tree -p $v1 -p HEAD);;
+            esac &&
+
+            # Now update the v1 branch and tag it
+            git update-ref refs/heads/v1 $commit &&
+            git tag $tag_name $commit &&
+            echo "result=$tag_name" >>$GITHUB_OUTPUT
+        - name: Push to v1
+          run: git push origin v1 ${{ steps.commit.outputs.result }}


### PR DESCRIPTION
This PR is part 4 (the final part in this repository) of addressing https://github.com/gitgitgadget/gitgitgadget/issues/609, and it is stacked on top of https://github.com/gitgitgadget/gitgitgadget/pull/1980, https://github.com/gitgitgadget/gitgitgadget/pull/1981, and #1982 (and therefore contains also the commits of those PRs), therefore I will leave this in draft mode until those PRs are merged.

After laying the groundwork for, and implementing, the set of GitHub Actions that can perform the same job as GitGitGadget's current Azure Pipelines can perform, this here PR adds automation to
1. transpile the `CIHelper` class (together with its dependencies) from Typescript to JavaScript,
2. bundle it as a single, dependency-less `dist/index.js`,
3. copy the required resources (`WELCOME.md`, some shell scripts) into the location expected by that `dist/index.js`,
4. remove all the rest except for the minimal GitHub Actions (`*/action.yml`, `*/index.js`),
5. commit the result as the new tip commit of the `v1` branch (creating it as needed),
6. tag that tip commit as `v1.<running-number>`,
7. push out the `v1` branch and the tag.

The result of this is that GitGitGadget can still be developed conveniently in this here repository, and whenever anything gets merged to the `main` branch, the `v1` branch is automatically updated so that it will be picked up by GitHub workflows containing statements like:

```yaml
- uses: gitgitgadget/gitgitgadget/handle-pr-comment@v1
```

That way, we _finally_ address the fragile nature of the current setup where a set of Azure Pipelines maintain their own clone of `gitgitgadget/gitgitgadget`, and having to run `npm ci && npm run build` as needed.

This closes https://github.com/gitgitgadget/gitgitgadget/issues/1759