### PR TITLE
Cc: the current Git GUI maintainer on corresponding patches

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,6 +73,7 @@
         "refname",
         "repo",
         "Schindelin",
+        "Sixt",
         "smee",
         "smtp",
         "stolee",

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -27,7 +27,7 @@ export class ProjectOptions {
         } else if ((await revParse(`${baseCommit}:git-gui.sh`, workDir)) !== undefined) {
             // Git GUI
             to = "--to=git@vger.kernel.org";
-            cc.push("Pratyush Yadav <me@yadavpratyush.com>");
+            cc.push("Johannes Sixt <j6t@kdbg.org>");
             upstreamBranch = "git-gui/master";
         } else if ((await revParse(`${baseCommit}:git.c`, workDir)) !== undefined) {
             // Git


### PR DESCRIPTION
I just noticed that Pratyush was still Cc:ed by default. Then I looked and was puzzled because I thought that [the `project` settings would be used](https://github.com/gitgitgadget/gitgitgadget/blob/631cfc116134c93f4c8ffa95a7d39e83392b0337/lib/project-options.ts#L19-L26) instead of [auto-magically figuring out](https://github.com/gitgitgadget/gitgitgadget/blob/631cfc116134c93f4c8ffa95a7d39e83392b0337/lib/project-options.ts#L27-L31) whether the PR in question is a Git GUI one. But then I saw that [the `defaultConfig`](https://github.com/gitgitgadget/gitgitgadget/blob/631cfc116134c93f4c8ffa95a7d39e83392b0337/lib/gitgitgadget-config.ts#L3-L45) does not have a `project` attribute ;-)