### PR TITLE
vscode: avoid high CPU usage via search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -115,5 +115,24 @@
     "cSpell.ignorePaths": [
         "node_modules",
         "**/node_modules"
-    ]
+    ],
+    "search.ripgrep.maxThreads": 1,
+    "search.exclude": {
+        "**/.git": true,
+        "**/build": true,
+        "**/dist": true,
+        "**/git.git": true,
+        "**/mailing-list-mirror.git": true,
+        "**/node_modules": true,
+        "**/.test*": true,
+    },
+    "files.watcherExclude": {
+        "**/.git": true,
+        "**/build": true,
+        "**/dist": true,
+        "**/git.git": true,
+        "**/mailing-list-mirror.git": true,
+        "**/node_modules": true,
+        "**/.test*": true,
+    }
 }


### PR DESCRIPTION
The search feature in VS Code is quite nice, except when it bogs down the processor by trying to index files that aren't meant to be searchable, such as `node_modules/`.

While at it, also exclude the same folders from the file watcher, and restrict the often-rampant `ripgrep` processes to play nicely already.