### PR TITLE
CIHelper: do set the `GIT_EXEC_PATH` correctly

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -86,7 +86,7 @@ export class CIHelper {
             // see https://github.com/desktop/dugite/blob/v2.7.1/lib/git-environment.ts#L44-L64
             // Also: We cannot use `await git(["--exec-path"]);` because that would use Dugite, which would
             // override `GIT_EXEC_PATH` and then `git --exec-path` would report _that_...
-            process.env.GIT_EXEC_PATH = spawnSync("/usr/bin/git", ["--exec-path"]).stdout.toString("utf-8").trimEnd();
+            process.env.GIT_EXEC_PATH = spawnSync(gitPath, ["--exec-path"]).stdout.toString("utf-8").trimEnd();
             break;
         }
 


### PR DESCRIPTION
In 7d538e54 (CIHelper: add a convenient function to initialize e.g. the Git worktree, 2025-08-15), I added logic to find the `git` executable on the `PATH`, and to appease the `dugite` module whose Git functionality GitGitGadget uses, set `GIT_EXEC_PATH` accordingly.

Unfortunately, I made a mistake and auto-piloted `/usr/bin/git` into the call that was supposed to determine the correct `GIT_EXEC_PATH`, when really, I wanted to use the just-found `git` executable instead.

Let's fix that mistake.