### PR TITLE
Always pass the `config` as an explicit constructor parameter

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -53,7 +53,7 @@ export class CIHelper {
         return configFile ? await getExternalConfig(configFile) : getConfig();
     }
 
-    public constructor(workDir: string = "git.git", config?: IConfig, skipUpdate?: boolean, gggConfigDir = ".") {
+    public constructor(workDir: string = "pr-repo.git", config?: IConfig, skipUpdate?: boolean, gggConfigDir = ".") {
         this.config = config !== undefined ? setConfig(config) : getConfig();
         this.gggConfigDir = gggConfigDir;
         this.workDir = workDir;

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -854,6 +854,7 @@ export class CIHelper {
 
         try {
             const gitGitGadget = await GitGitGadget.get(
+                this.config,
                 this.gggConfigDir,
                 this.workDir,
                 this.urlRepo,
@@ -1071,6 +1072,7 @@ export class CIHelper {
         };
 
         const gitGitGadget = await GitGitGadget.get(
+            this.config,
             this.gggConfigDir,
             this.workDir,
             this.urlRepo,

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -1110,6 +1110,7 @@ export class CIHelper {
               };
         await this.maybeUpdateGGGNotes();
         const mailArchiveGit = await MailArchiveGitHelper.get(
+            this.config,
             this.notes,
             mailArchiveGitDir,
             this.github,

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -59,7 +59,7 @@ export class CIHelper {
         this.workDir = workDir;
         this.notes = new GitNotes(workDir);
         this.gggNotesUpdated = !!skipUpdate;
-        this.mail2commit = new MailCommitMapping(this.notes.workDir);
+        this.mail2commit = new MailCommitMapping(this.config, this.notes.workDir);
         this.mail2CommitMapUpdated = !!skipUpdate;
         this.github = new GitHubGlue(workDir, this.config.repo.owner, this.config.repo.name);
         this.testing = false;

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -5,7 +5,7 @@ import { IGitHubUser, IPullRequestInfo } from "./github-glue.js";
 import { PatchSeries, SendFunction } from "./patch-series.js";
 import { IPatchSeriesMetadata } from "./patch-series-metadata.js";
 import { PatchSeriesOptions } from "./patch-series-options.js";
-import { IConfig, getConfig } from "./project-config.js";
+import { IConfig } from "./project-config.js";
 import { ISMTPOptions, parseHeadersAndSendMail, parseMBox, sendMail } from "./send-mail.js";
 
 export interface IGitGitGadgetOptions {
@@ -37,6 +37,7 @@ export class GitGitGadget {
     }
 
     public static async get(
+        config: IConfig,
         gitGitGadgetDir: string,
         workDir?: string,
         publishTagsAndNotesToRemote?: string,
@@ -90,7 +91,15 @@ export class GitGitGadget {
 
         const [options, allowedUsers] = await GitGitGadget.readOptions(notes);
 
-        return new GitGitGadget(notes, options, allowedUsers, smtpOptions, publishTagsAndNotesToRemote, notesPushToken);
+        return new GitGitGadget(
+            config,
+            notes,
+            options,
+            allowedUsers,
+            smtpOptions,
+            publishTagsAndNotesToRemote,
+            notesPushToken,
+        );
     }
 
     protected static async readOptions(notes: GitNotes): Promise<[IGitGitGadgetOptions, Set<string>]> {
@@ -103,7 +112,7 @@ export class GitGitGadget {
         return [options, allowedUsers];
     }
 
-    public readonly config: IConfig = getConfig();
+    public readonly config: IConfig;
     public readonly workDir: string;
     public readonly notes: GitNotes;
     protected options: IGitGitGadgetOptions;
@@ -115,6 +124,7 @@ export class GitGitGadget {
     private readonly publishToken: string | undefined;
 
     protected constructor(
+        config: IConfig,
         notes: GitNotes,
         options: IGitGitGadgetOptions,
         allowedUsers: Set<string>,
@@ -125,6 +135,7 @@ export class GitGitGadget {
         if (!notes.workDir) {
             throw new Error("Could not determine Git worktree");
         }
+        this.config = config;
         this.workDir = notes.workDir;
         this.notes = notes;
         this.options = options;

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -302,6 +302,7 @@ export class GitGitGadget {
         options.rfc = pr.draft ?? false;
 
         const series = await PatchSeries.getFromNotes(
+            this.config,
             this.notes,
             pr.pullRequestURL,
             pr.title,

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -5,7 +5,7 @@ import { IGitGitGadgetOptions } from "./gitgitgadget.js";
 import { GitHubGlue } from "./github-glue.js";
 import { IMailMetadata } from "./mail-metadata.js";
 import { IPatchSeriesMetadata } from "./patch-series-metadata.js";
-import { IConfig, getConfig } from "./project-config.js";
+import { IConfig } from "./project-config.js";
 import { getPullRequestKey } from "./pullRequestKey.js";
 import { IParsedMBox, parseMBox, parseMBoxMessageIDAndReferences } from "./send-mail.js";
 import { SousChef } from "./sous-chef.js";
@@ -19,13 +19,14 @@ export interface IGitMailingListMirrorState {
 
 export class MailArchiveGitHelper {
     public static async get(
+        config: IConfig,
         gggNotes: GitNotes,
         mailArchiveGitDir: string,
         githubGlue: GitHubGlue,
         branch: string,
     ): Promise<MailArchiveGitHelper> {
         const state: IGitMailingListMirrorState = (await gggNotes.get<IGitMailingListMirrorState>(stateKey)) || {};
-        return new MailArchiveGitHelper(gggNotes, mailArchiveGitDir, githubGlue, state, branch);
+        return new MailArchiveGitHelper(config, gggNotes, mailArchiveGitDir, githubGlue, state, branch);
     }
 
     /**
@@ -56,19 +57,21 @@ export class MailArchiveGitHelper {
     }
 
     protected readonly branch: string;
-    protected readonly config: IConfig = getConfig();
+    protected readonly config: IConfig;
     protected readonly state: IGitMailingListMirrorState;
     protected readonly gggNotes: GitNotes;
     protected readonly mailArchiveGitDir: string;
     protected readonly githubGlue: GitHubGlue;
 
     protected constructor(
+        config: IConfig,
         gggNotes: GitNotes,
         mailArchiveGitDir: string,
         githubGlue: GitHubGlue,
         state: IGitMailingListMirrorState,
         branch: string,
     ) {
+        this.config = config;
         this.branch = branch;
         this.gggNotes = gggNotes;
         this.mailArchiveGitDir = mailArchiveGitDir;

--- a/lib/mail-commit-mapping.ts
+++ b/lib/mail-commit-mapping.ts
@@ -1,13 +1,14 @@
 import { git } from "./git.js";
 import { GitNotes } from "./git-notes.js";
-import { IConfig, getConfig } from "./project-config.js";
+import { IConfig } from "./project-config.js";
 
 export class MailCommitMapping {
-    public readonly config: IConfig = getConfig();
+    public readonly config: IConfig;
     public readonly workDir?: string;
     public readonly mail2CommitNotes: GitNotes;
 
-    public constructor(workDir?: string) {
+    public constructor(config: IConfig, workDir?: string) {
+        this.config = config;
         this.workDir = workDir;
         this.mail2CommitNotes = new GitNotes(workDir, "refs/notes/mail-to-commit");
     }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -8,7 +8,7 @@ import { IMailMetadata } from "./mail-metadata.js";
 import { md2text } from "./markdown-renderer.js";
 import { IPatchSeriesMetadata } from "./patch-series-metadata.js";
 import { PatchSeriesOptions } from "./patch-series-options.js";
-import { IConfig, getConfig } from "./project-config.js";
+import { IConfig } from "./project-config.js";
 import { ProjectOptions } from "./project-options.js";
 import { getPullRequestKeyFromURL } from "./pullRequestKey.js";
 
@@ -57,6 +57,7 @@ interface IRangeDiff {
 
 export class PatchSeries {
     public static async getFromNotes(
+        config: IConfig,
         notes: GitNotes,
         pullRequestURL: string,
         pullRequestTitle: string,
@@ -144,7 +145,17 @@ export class PatchSeries {
             options.rangeDiff = rangeDiff;
         }
 
-        return new PatchSeries(notes, options, project, metadata, rangeDiffRanges, patchCount, coverLetter, senderName);
+        return new PatchSeries(
+            config,
+            notes,
+            options,
+            project,
+            metadata,
+            rangeDiffRanges,
+            patchCount,
+            coverLetter,
+            senderName,
+        );
     }
 
     protected static async parsePullRequest(
@@ -513,7 +524,7 @@ export class PatchSeries {
         return results;
     }
 
-    public readonly config: IConfig = getConfig();
+    public readonly config: IConfig;
     public readonly notes: GitNotes;
     public readonly options: PatchSeriesOptions;
     public readonly project: ProjectOptions;
@@ -524,6 +535,7 @@ export class PatchSeries {
     public readonly patchCount: number;
 
     protected constructor(
+        config: IConfig,
         notes: GitNotes,
         options: PatchSeriesOptions,
         project: ProjectOptions,
@@ -533,6 +545,7 @@ export class PatchSeries {
         coverLetter?: string,
         senderName?: string,
     ) {
+        this.config = config;
         this.notes = notes;
         this.options = options;
         this.project = project;

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -1,5 +1,6 @@
 import { commitExists, git, revParse } from "./git.js";
-import { IConfig, getConfig, projectInfo } from "./project-config.js";
+import defaultConfig from "./gitgitgadget-config.js";
+import { IConfig, projectInfo } from "./project-config.js";
 
 // For now, only the Git, Cygwin and BusyBox projects are supported
 export class ProjectOptions {
@@ -11,7 +12,7 @@ export class ProjectOptions {
         publishToRemote?: string,
         baseCommit?: string,
     ): Promise<ProjectOptions> {
-        const config: IConfig = getConfig();
+        const config: IConfig = defaultConfig;
         let upstreamBranch: string;
         let to: string;
         let midUrlPrefix = " Message-ID: ";

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -7,6 +7,7 @@ import { getConfig } from "../lib/gitgitgadget-config.js";
 import { PatchSeries } from "../lib/patch-series.js";
 import { IPatchSeriesMetadata } from "../lib/patch-series-metadata.js";
 import { testCreateRepo } from "./test-lib.js";
+import defaultConfig from "../lib/gitgitgadget-config.js";
 
 // This test script might take quite a while to run
 jest.setTimeout(60000);
@@ -342,7 +343,7 @@ test("allow/disallow", async () => {
     const notes = new GitNotes(remote.workDir);
     await notes.set("", {} as IGitGitGadgetOptions);
 
-    const gitGitGadget = await GitGitGadget.get(workDir);
+    const gitGitGadget = await GitGitGadget.get(defaultConfig, workDir);
 
     // pretend that the notes ref had been changed in the meantime
     await notes.set("", { allowedUsers: ["first-one"] } as IGitGitGadgetOptions, true);
@@ -370,7 +371,7 @@ test("allow/disallow with env vars", async () => {
     const notes = new GitNotes(remote.workDir);
     await notes.set("", {} as IGitGitGadgetOptions);
 
-    const gitGitGadget = await GitGitGadget.get(workDir);
+    const gitGitGadget = await GitGitGadget.get(defaultConfig, workDir);
 
     // pretend that the notes ref had been changed in the meantime
     await notes.set("", { allowedUsers: ["first-one"] } as IGitGitGadgetOptions, true);

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -210,6 +210,7 @@ test("generate tag/notes from a Pull Request", async () => {
     await git(["config", "user.email", "gitgitgadget@example.com"], repo.options);
 
     const patches = await PatchSeries.getFromNotes(
+        defaultConfig,
         notes,
         pullRequestURL,
         pullRequestTitle,
@@ -252,6 +253,7 @@ to have included in git.git [https://github.com/git/git].`);
 
     const headCommit2 = await repo.revParse("HEAD");
     const patches2 = await PatchSeries.getFromNotes(
+        defaultConfig,
         notes,
         pullRequestURL,
         pullRequestTitle,

--- a/tests/mail-archive-helper.test.ts
+++ b/tests/mail-archive-helper.test.ts
@@ -3,24 +3,25 @@ import { OctokitResponse } from "@octokit/types";
 import { expect, jest, test } from "@jest/globals";
 import { fileURLToPath } from "url";
 import { GitNotes } from "../lib/git-notes.js";
-import { getConfig } from "../lib/gitgitgadget-config.js";
 import { GitHubGlue } from "../lib/github-glue.js";
 import { MailArchiveGitHelper, IGitMailingListMirrorState } from "../lib/mail-archive-helper.js";
 import { IMailMetadata } from "../lib/mail-metadata.js";
-import { setConfig } from "../lib/project-config.js";
 import { testCreateRepo } from "./test-lib.js";
+import defaultConfig from "../lib/gitgitgadget-config.js";
+import { IConfig } from "../lib/project-config.js";
 
 /* eslint max-classes-per-file: ["error", 2] */
 
 class MailArchiveGitHelperProxy extends MailArchiveGitHelper {
     public constructor(
+        config: IConfig,
         gggNotes: GitNotes,
         mailArchiveGitDir: string,
         githubGlue: GitHubGlue,
         state: IGitMailingListMirrorState,
         branch: string,
     ) {
-        super(gggNotes, mailArchiveGitDir, githubGlue, state, branch);
+        super(config, gggNotes, mailArchiveGitDir, githubGlue, state, branch);
     }
 }
 class GitHubProxy extends GitHubGlue {
@@ -96,10 +97,9 @@ interface ICommit {
     parents: [{ sha: string; url: string; html_url?: string }];
 }
 
-const config = getConfig();
+const config = { ...defaultConfig }; // make a copy
 config.repo.owner = "test";
 config.repo.name = "test";
-setConfig(config);
 
 const fromEmail = "I Replied <ireplied@gmail.com>";
 
@@ -205,7 +205,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~" },
+        "master",
+    );
 
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     await mail.processMails();
@@ -240,7 +247,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~" },
+        "master",
+    );
 
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     await mail.processMails();
@@ -279,7 +293,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~" },
+        "master",
+    );
 
     const commitsResponse = getCommitsResponse;
     const fail = false;
@@ -365,7 +386,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~~" },
+        "master",
+    );
 
     const commitsResponse = getCommitsResponse;
     const fail = false;
@@ -453,7 +481,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~" },
+        "master",
+    );
 
     const commitsResponse = getCommitsResponse;
     const fail = true;
@@ -530,7 +565,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~" },
+        "master",
+    );
 
     const commitsResponse = getCommitsResponse;
     commitsResponse.data[0].sha = mailMeta.originalCommit;

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -6,6 +6,7 @@ import { GitNotes } from "../lib/git-notes.js";
 import { PatchSeries } from "../lib/patch-series.js";
 import { ProjectOptions } from "../lib/project-options.js";
 import { testCreateRepo } from "./test-lib.js";
+import defaultConfig from "../lib/gitgitgadget-config.js";
 
 jest.setTimeout(60000);
 const sourceFileName = fileURLToPath(import.meta.url);
@@ -102,7 +103,15 @@ class PatchSeriesTest extends PatchSeries {
             }
         }
 
-        const x = new PatchSeriesTest(new GitNotes(), {}, new ProjectOptionsTest(), prMeta, undefined, 1);
+        const x = new PatchSeriesTest(
+            defaultConfig,
+            new GitNotes(),
+            {},
+            new ProjectOptionsTest(),
+            prMeta,
+            undefined,
+            1,
+        );
 
         x.insertCcAndFromLines(mails, thisAuthor, senderName);
 

--- a/tests/project-options.test.ts
+++ b/tests/project-options.test.ts
@@ -6,6 +6,7 @@ import { getConfig } from "../lib/gitgitgadget-config.js";
 import { PatchSeries } from "../lib/patch-series.js";
 import { ProjectOptions } from "../lib/project-options.js";
 import { testCreateRepo } from "./test-lib.js";
+import defaultConfig from "../lib/gitgitgadget-config.js";
 
 // This test script might take quite a while to run
 jest.setTimeout(20000);
@@ -45,7 +46,7 @@ test("project options", async () => {
                 headLabel: options2.branchName,
                 iteration: 1,
             };
-            const x = new X(new GitNotes(repo.workDir), {}, options2, prMeta, undefined, 1);
+            const x = new X(defaultConfig, new GitNotes(repo.workDir), {}, options2, prMeta, undefined, 1);
             const mbox = await x.generateMBox();
             const needle = "=?UTF-8?Q?Nguy=E1=BB=85n_Th=C3=A1i_Ng=E1=BB=8Dc?= Duy";
             expect(mbox).toEqual(expect.stringContaining(needle));


### PR DESCRIPTION
This is necessary so that the project config is reliably passed through, and the `defaultConfig` is not used by mistake.