### PR TITLE
CIHelper: avoid using the name `git.git` for the `pr-repo`

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -53,7 +53,7 @@ export class CIHelper {
         return configFile ? await getExternalConfig(configFile) : getConfig();
     }
 
-    public constructor(workDir: string = "git.git", config?: IConfig, skipUpdate?: boolean, gggConfigDir = ".") {
+    public constructor(workDir: string = "pr-repo.git", config?: IConfig, skipUpdate?: boolean, gggConfigDir = ".") {
         this.config = config !== undefined ? setConfig(config) : getConfig();
         this.gggConfigDir = gggConfigDir;
         this.workDir = workDir;


### PR DESCRIPTION
Since GitGitGadget is currently being extended to handle projects other than Git, let's just settle on the naming `pr-repo` for the local clone of the GitHub repository whose Pull Requests are to be handled (and where GitGitGadget's state is recorded in the Git notes).