### PR TITLE
Add functionality to initialize the Git notes

### DIFF
--- a/handle-new-mails/action.yml
+++ b/handle-new-mails/action.yml
@@ -2,6 +2,9 @@ name: 'Handle new mails'
 description: 'Processes new mails on the Git mailing list'
 author: 'Johannes Schindelin'
 inputs:
+  config:
+    description: 'The GitGitGadget configuration to use (see https://github.com/gitgitgadget/gitgitgadget/blob/HEAD/lib/project-config.ts)'
+    required: false # not just yet...
   pr-repo-token:
     description: 'The access token to work on the repository that holds PRs and state'
     required: true

--- a/handle-pr-comment/action.yml
+++ b/handle-pr-comment/action.yml
@@ -2,6 +2,9 @@ name: 'Handle PR Comment'
 description: 'Handles slash commands such as /submit and /preview'
 author: 'Johannes Schindelin'
 inputs:
+  config:
+    description: 'The GitGitGadget configuration to use (see https://github.com/gitgitgadget/gitgitgadget/blob/HEAD/lib/project-config.ts)'
+    required: false # not just yet...
   pr-repo-token:
     description: 'The access token to work on the repository that holds PRs and state'
     required: true

--- a/handle-pr-push/action.yml
+++ b/handle-pr-push/action.yml
@@ -2,6 +2,9 @@ name: 'Handle PR Pushes'
 description: 'Handles when a PR was pushed'
 author: 'Johannes Schindelin'
 inputs:
+  config:
+    description: 'The GitGitGadget configuration to use (see https://github.com/gitgitgadget/gitgitgadget/blob/HEAD/lib/project-config.ts)'
+    required: false # not just yet...
   pr-repo-token:
     description: 'The access token to work on the repository that holds PRs and state'
     required: true

--- a/initialize-git-notes/action.yml
+++ b/initialize-git-notes/action.yml
@@ -1,0 +1,20 @@
+name: 'Initialize the Git notes'
+description: 'Creates initial, mostly empty Git notes for GitGitGadget to store its state in.'
+author: 'Johannes Schindelin'
+inputs:
+  config:
+    description: 'The GitGitGadget configuration to use (see https://github.com/gitgitgadget/gitgitgadget/blob/HEAD/lib/project-config.ts)'
+    required: false # not just yet...
+  pr-repo-token:
+    description: 'The access token to work on the repository that holds PRs and state'
+    required: true
+  initial-user:
+    description: 'The user that is initially the only one allowed to use GitGitGadget in the given project'
+    default: ${{ github.actor }}
+    required: true
+runs:
+  using: 'node20'
+  main: './index.js'
+branding:
+  icon: 'git-commit'
+  color: 'orange'

--- a/initialize-git-notes/index.js
+++ b/initialize-git-notes/index.js
@@ -1,0 +1,11 @@
+async function run() {
+  const { CIHelper } = await import("../dist/index.js")
+
+  const ci = new CIHelper()
+
+  await ci.setupGitHubAction({
+    createGitNotes: true,
+  })
+}
+
+run()

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -53,7 +53,7 @@ export class CIHelper {
         return configFile ? await getExternalConfig(configFile) : getConfig();
     }
 
-    public constructor(workDir: string = "git.git", config?: IConfig, skipUpdate?: boolean, gggConfigDir = ".") {
+    public constructor(workDir: string = "pr-repo.git", config?: IConfig, skipUpdate?: boolean, gggConfigDir = ".") {
         this.config = config !== undefined ? setConfig(config) : getConfig();
         this.gggConfigDir = gggConfigDir;
         this.workDir = workDir;

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -854,6 +854,7 @@ export class CIHelper {
 
         try {
             const gitGitGadget = await GitGitGadget.get(
+                this.config,
                 this.gggConfigDir,
                 this.workDir,
                 this.urlRepo,
@@ -1071,6 +1072,7 @@ export class CIHelper {
         };
 
         const gitGitGadget = await GitGitGadget.get(
+            this.config,
             this.gggConfigDir,
             this.workDir,
             this.urlRepo,

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -1110,6 +1110,7 @@ export class CIHelper {
               };
         await this.maybeUpdateGGGNotes();
         const mailArchiveGit = await MailArchiveGitHelper.get(
+            this.config,
             this.notes,
             mailArchiveGitDir,
             this.github,

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -53,8 +53,17 @@ export class CIHelper {
         return configFile ? await getExternalConfig(configFile) : getConfig();
     }
 
+    protected static getConfigAsGitHubActionInput(): IConfig | undefined {
+        if (process.env.GITHUB_ACTIONS !== "true") return undefined;
+        const json = core.getInput("config");
+        if (!json) return undefined;
+        const config = JSON.parse(json) as IConfig | undefined;
+        if (typeof config === "object" && config.project !== undefined) return config;
+        return undefined;
+    }
+
     public constructor(workDir: string = "pr-repo.git", config?: IConfig, skipUpdate?: boolean, gggConfigDir = ".") {
-        this.config = config !== undefined ? setConfig(config) : getConfig();
+        this.config = config !== undefined ? setConfig(config) : CIHelper.getConfigAsGitHubActionInput() || getConfig();
         this.gggConfigDir = gggConfigDir;
         this.workDir = workDir;
         this.notes = new GitNotes(workDir);

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -59,7 +59,7 @@ export class CIHelper {
         this.workDir = workDir;
         this.notes = new GitNotes(workDir);
         this.gggNotesUpdated = !!skipUpdate;
-        this.mail2commit = new MailCommitMapping(this.notes.workDir);
+        this.mail2commit = new MailCommitMapping(this.config, this.notes.workDir);
         this.mail2CommitMapUpdated = !!skipUpdate;
         this.github = new GitHubGlue(workDir, this.config.repo.owner, this.config.repo.name);
         this.testing = false;

--- a/lib/git-notes.ts
+++ b/lib/git-notes.ts
@@ -120,6 +120,14 @@ export class GitNotes {
         return notes.replace(/^[^]*\n\n/, "");
     }
 
+    public async initializeWithEmptyCommit(): Promise<void> {
+        const emptyTree = await git(["hash-object", "-t", "tree", "--stdin"], { stdin: "", workDir: this.workDir });
+        const emptyCommit = await git(["commit-tree", "-m", "Initial empty commit", emptyTree], {
+            workDir: this.workDir,
+        });
+        await git(["update-ref", this.notesRef, emptyCommit, ""], { workDir: this.workDir });
+    }
+
     public async update(url: string): Promise<void> {
         if (this.notesRef.match(/^refs\/notes\/(gitgitgadget|commit-to-mail|mail-to-commit)$/)) {
             await git(["fetch", "--no-tags", url, `+${this.notesRef}:${this.notesRef}`], { workDir: this.workDir });

--- a/lib/gitgitgadget-config.ts
+++ b/lib/gitgitgadget-config.ts
@@ -27,6 +27,8 @@ const defaultConfig: IConfig = {
     mail: {
         author: "GitGitGadget",
         sender: "GitGitGadget",
+        smtpUser: "gitgitgadget@gmail.com",
+        smtpHost: "smtp.gmail.com",
     },
     app: {
         appID: 12836,
@@ -42,6 +44,18 @@ const defaultConfig: IConfig = {
     user: {
         allowUserAsLogin: false,
     },
+    syncUpstreamBranches: [
+        {
+            sourceRepo: "gitster/git",
+            targetRepo: "gitgitgadget/git",
+            sourceRefRegex: "^refs/heads/(maint-\\d|[a-z][a-z]/)",
+        },
+        {
+            sourceRepo: "j6t/git-gui",
+            targetRepo: "gitgitgadget/git",
+            targetRefNamespace: "git-gui/",
+        },
+    ],
 };
 
 export default defaultConfig;

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -5,7 +5,7 @@ import { IGitHubUser, IPullRequestInfo } from "./github-glue.js";
 import { PatchSeries, SendFunction } from "./patch-series.js";
 import { IPatchSeriesMetadata } from "./patch-series-metadata.js";
 import { PatchSeriesOptions } from "./patch-series-options.js";
-import { IConfig, getConfig } from "./project-config.js";
+import { IConfig } from "./project-config.js";
 import { ISMTPOptions, parseHeadersAndSendMail, parseMBox, sendMail } from "./send-mail.js";
 
 export interface IGitGitGadgetOptions {
@@ -37,6 +37,7 @@ export class GitGitGadget {
     }
 
     public static async get(
+        config: IConfig,
         gitGitGadgetDir: string,
         workDir?: string,
         publishTagsAndNotesToRemote?: string,
@@ -90,7 +91,15 @@ export class GitGitGadget {
 
         const [options, allowedUsers] = await GitGitGadget.readOptions(notes);
 
-        return new GitGitGadget(notes, options, allowedUsers, smtpOptions, publishTagsAndNotesToRemote, notesPushToken);
+        return new GitGitGadget(
+            config,
+            notes,
+            options,
+            allowedUsers,
+            smtpOptions,
+            publishTagsAndNotesToRemote,
+            notesPushToken,
+        );
     }
 
     protected static async readOptions(notes: GitNotes): Promise<[IGitGitGadgetOptions, Set<string>]> {
@@ -103,7 +112,7 @@ export class GitGitGadget {
         return [options, allowedUsers];
     }
 
-    public readonly config: IConfig = getConfig();
+    public readonly config: IConfig;
     public readonly workDir: string;
     public readonly notes: GitNotes;
     protected options: IGitGitGadgetOptions;
@@ -115,6 +124,7 @@ export class GitGitGadget {
     private readonly publishToken: string | undefined;
 
     protected constructor(
+        config: IConfig,
         notes: GitNotes,
         options: IGitGitGadgetOptions,
         allowedUsers: Set<string>,
@@ -125,6 +135,7 @@ export class GitGitGadget {
         if (!notes.workDir) {
             throw new Error("Could not determine Git worktree");
         }
+        this.config = config;
         this.workDir = notes.workDir;
         this.notes = notes;
         this.options = options;

--- a/lib/gitgitgadget.ts
+++ b/lib/gitgitgadget.ts
@@ -302,6 +302,7 @@ export class GitGitGadget {
         options.rfc = pr.draft ?? false;
 
         const series = await PatchSeries.getFromNotes(
+            this.config,
             this.notes,
             pr.pullRequestURL,
             pr.title,

--- a/lib/mail-archive-helper.ts
+++ b/lib/mail-archive-helper.ts
@@ -5,7 +5,7 @@ import { IGitGitGadgetOptions } from "./gitgitgadget.js";
 import { GitHubGlue } from "./github-glue.js";
 import { IMailMetadata } from "./mail-metadata.js";
 import { IPatchSeriesMetadata } from "./patch-series-metadata.js";
-import { IConfig, getConfig } from "./project-config.js";
+import { IConfig } from "./project-config.js";
 import { getPullRequestKey } from "./pullRequestKey.js";
 import { IParsedMBox, parseMBox, parseMBoxMessageIDAndReferences } from "./send-mail.js";
 import { SousChef } from "./sous-chef.js";
@@ -19,13 +19,14 @@ export interface IGitMailingListMirrorState {
 
 export class MailArchiveGitHelper {
     public static async get(
+        config: IConfig,
         gggNotes: GitNotes,
         mailArchiveGitDir: string,
         githubGlue: GitHubGlue,
         branch: string,
     ): Promise<MailArchiveGitHelper> {
         const state: IGitMailingListMirrorState = (await gggNotes.get<IGitMailingListMirrorState>(stateKey)) || {};
-        return new MailArchiveGitHelper(gggNotes, mailArchiveGitDir, githubGlue, state, branch);
+        return new MailArchiveGitHelper(config, gggNotes, mailArchiveGitDir, githubGlue, state, branch);
     }
 
     /**
@@ -56,19 +57,21 @@ export class MailArchiveGitHelper {
     }
 
     protected readonly branch: string;
-    protected readonly config: IConfig = getConfig();
+    protected readonly config: IConfig;
     protected readonly state: IGitMailingListMirrorState;
     protected readonly gggNotes: GitNotes;
     protected readonly mailArchiveGitDir: string;
     protected readonly githubGlue: GitHubGlue;
 
     protected constructor(
+        config: IConfig,
         gggNotes: GitNotes,
         mailArchiveGitDir: string,
         githubGlue: GitHubGlue,
         state: IGitMailingListMirrorState,
         branch: string,
     ) {
+        this.config = config;
         this.branch = branch;
         this.gggNotes = gggNotes;
         this.mailArchiveGitDir = mailArchiveGitDir;

--- a/lib/mail-commit-mapping.ts
+++ b/lib/mail-commit-mapping.ts
@@ -1,13 +1,14 @@
 import { git } from "./git.js";
 import { GitNotes } from "./git-notes.js";
-import { IConfig, getConfig } from "./project-config.js";
+import { IConfig } from "./project-config.js";
 
 export class MailCommitMapping {
-    public readonly config: IConfig = getConfig();
+    public readonly config: IConfig;
     public readonly workDir?: string;
     public readonly mail2CommitNotes: GitNotes;
 
-    public constructor(workDir?: string) {
+    public constructor(config: IConfig, workDir?: string) {
+        this.config = config;
         this.workDir = workDir;
         this.mail2CommitNotes = new GitNotes(workDir, "refs/notes/mail-to-commit");
     }

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -8,7 +8,7 @@ import { IMailMetadata } from "./mail-metadata.js";
 import { md2text } from "./markdown-renderer.js";
 import { IPatchSeriesMetadata } from "./patch-series-metadata.js";
 import { PatchSeriesOptions } from "./patch-series-options.js";
-import { IConfig, getConfig } from "./project-config.js";
+import { IConfig } from "./project-config.js";
 import { ProjectOptions } from "./project-options.js";
 import { getPullRequestKeyFromURL } from "./pullRequestKey.js";
 
@@ -57,6 +57,7 @@ interface IRangeDiff {
 
 export class PatchSeries {
     public static async getFromNotes(
+        config: IConfig,
         notes: GitNotes,
         pullRequestURL: string,
         pullRequestTitle: string,
@@ -144,7 +145,17 @@ export class PatchSeries {
             options.rangeDiff = rangeDiff;
         }
 
-        return new PatchSeries(notes, options, project, metadata, rangeDiffRanges, patchCount, coverLetter, senderName);
+        return new PatchSeries(
+            config,
+            notes,
+            options,
+            project,
+            metadata,
+            rangeDiffRanges,
+            patchCount,
+            coverLetter,
+            senderName,
+        );
     }
 
     protected static async parsePullRequest(
@@ -513,7 +524,7 @@ export class PatchSeries {
         return results;
     }
 
-    public readonly config: IConfig = getConfig();
+    public readonly config: IConfig;
     public readonly notes: GitNotes;
     public readonly options: PatchSeriesOptions;
     public readonly project: ProjectOptions;
@@ -524,6 +535,7 @@ export class PatchSeries {
     public readonly patchCount: number;
 
     protected constructor(
+        config: IConfig,
         notes: GitNotes,
         options: PatchSeriesOptions,
         project: ProjectOptions,
@@ -533,6 +545,7 @@ export class PatchSeries {
         coverLetter?: string,
         senderName?: string,
     ) {
+        this.config = config;
         this.notes = notes;
         this.options = options;
         this.project = project;

--- a/lib/project-config.ts
+++ b/lib/project-config.ts
@@ -35,6 +35,8 @@ export interface IConfig {
     mail: {
         author: string;
         sender: string;
+        smtpUser: string;
+        smtpHost: string;
     };
     project?: projectInfo | undefined; // project-options values
     app: {
@@ -51,6 +53,12 @@ export interface IConfig {
     user: {
         allowUserAsLogin: boolean; // use GitHub login as name if name is private
     };
+    syncUpstreamBranches: Array<{
+        sourceRepo: string; // e.g. "gitster/git"
+        targetRepo: string; // e.g. "gitgitgadget/git"
+        sourceRefRegex?: string; // e.g. "^refs/heads/(maint-\\d|[a-z][a-z]/)"
+        targetRefNamespace?: string; // e.g. "git-gui/"
+    }>; // branches to sync from upstream to our repo
 }
 
 let config: IConfig; // singleton

--- a/lib/project-config.ts
+++ b/lib/project-config.ts
@@ -8,57 +8,70 @@ export type projectInfo = {
     urlPrefix: string; // url to 'listserv' of mail (should it be in mailrepo?)
 };
 
+export interface IRepoConfig {
+    name: string; // name of the repo
+    owner: string; // owner of repo holding the notes (tracking data)
+    baseOwner: string; // owner of upstream ("base") repo
+    testOwner?: string; // owner of the test repo (if any)
+    owners: string[]; // owners of clones being monitored (PR checking)
+    branches: string[]; // remote branches to fetch - just use trackingBranches?
+    closingBranches: string[]; // close if the pr is added to this branch
+    trackingBranches: string[]; // comment if the pr is added to this branch
+    maintainerBranch?: string; // branch/owner manually implementing changes
+    host: string;
+}
+
+export interface IMailRepoConfig {
+    name: string;
+    owner: string;
+    branch: string;
+    host: string;
+    url: string;
+    public_inbox_epoch?: number;
+    mirrorURL?: string;
+    mirrorRef?: string;
+    descriptiveName: string;
+}
+export interface IMailConfig {
+    author: string;
+    sender: string;
+    smtpUser: string;
+    smtpHost: string;
+}
+
+export interface IAppConfig {
+    appID: number;
+    installationID: number;
+    name: string;
+    displayName: string; // name to use in comments to identify app
+    altname: string | undefined; // is this even needed?
+}
+
+export interface ILintConfig {
+    maxCommitsIgnore?: string[]; // array of pull request urls to skip check
+    maxCommits: number; // limit on number of commits in a pull request
+}
+
+export interface IUserConfig {
+    allowUserAsLogin: boolean; // use GitHub login as name if name is private
+}
+
+export interface ISyncUpstreamBranchesConfig {
+    sourceRepo: string; // e.g. "gitster/git"
+    targetRepo: string; // e.g. "gitgitgadget/git"
+    sourceRefRegex?: string; // e.g. "^refs/heads/(maint-\\d|[a-z][a-z]/)"
+    targetRefNamespace?: string; // e.g. "git-gui/"
+}
+
 export interface IConfig {
-    repo: {
-        name: string; // name of the repo
-        owner: string; // owner of repo holding the notes (tracking data)
-        baseOwner: string; // owner of upstream ("base") repo
-        testOwner?: string; // owner of the test repo (if any)
-        owners: string[]; // owners of clones being monitored (PR checking)
-        branches: string[]; // remote branches to fetch - just use trackingBranches?
-        closingBranches: string[]; // close if the pr is added to this branch
-        trackingBranches: string[]; // comment if the pr is added to this branch
-        maintainerBranch?: string; // branch/owner manually implementing changes
-        host: string;
-    };
-    mailrepo: {
-        name: string;
-        owner: string;
-        branch: string;
-        host: string;
-        url: string;
-        public_inbox_epoch?: number;
-        mirrorURL?: string;
-        mirrorRef?: string;
-        descriptiveName: string;
-    };
-    mail: {
-        author: string;
-        sender: string;
-        smtpUser: string;
-        smtpHost: string;
-    };
+    repo: IRepoConfig;
+    mailrepo: IMailRepoConfig;
+    mail: IMailConfig;
     project?: projectInfo | undefined; // project-options values
-    app: {
-        appID: number;
-        installationID: number;
-        name: string;
-        displayName: string; // name to use in comments to identify app
-        altname: string | undefined; // is this even needed?
-    };
-    lint: {
-        maxCommitsIgnore?: string[]; // array of pull request urls to skip check
-        maxCommits: number; // limit on number of commits in a pull request
-    };
-    user: {
-        allowUserAsLogin: boolean; // use GitHub login as name if name is private
-    };
-    syncUpstreamBranches: Array<{
-        sourceRepo: string; // e.g. "gitster/git"
-        targetRepo: string; // e.g. "gitgitgadget/git"
-        sourceRefRegex?: string; // e.g. "^refs/heads/(maint-\\d|[a-z][a-z]/)"
-        targetRefNamespace?: string; // e.g. "git-gui/"
-    }>; // branches to sync from upstream to our repo
+    app: IAppConfig;
+    lint: ILintConfig;
+    user: IUserConfig;
+    syncUpstreamBranches: ISyncUpstreamBranchesConfig[]; // branches to sync from upstream to our repo
 }
 
 let config: IConfig; // singleton

--- a/lib/project-options.ts
+++ b/lib/project-options.ts
@@ -1,5 +1,6 @@
 import { commitExists, git, revParse } from "./git.js";
-import { IConfig, getConfig, projectInfo } from "./project-config.js";
+import defaultConfig from "./gitgitgadget-config.js";
+import { IConfig, projectInfo } from "./project-config.js";
 
 // For now, only the Git, Cygwin and BusyBox projects are supported
 export class ProjectOptions {
@@ -11,7 +12,7 @@ export class ProjectOptions {
         publishToRemote?: string,
         baseCommit?: string,
     ): Promise<ProjectOptions> {
-        const config: IConfig = getConfig();
+        const config: IConfig = defaultConfig;
         let upstreamBranch: string;
         let to: string;
         let midUrlPrefix = " Message-ID: ";

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,8 @@
         "ts-jest-resolver": "^2.0.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2",
-        "typescript-eslint": "8.41.0"
+        "typescript-eslint": "8.41.0",
+        "typia": "^9.7.2"
       },
       "engines": {
         "node": ">= 18.16.1"
@@ -1602,6 +1603,28 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
+      "integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -3457,6 +3480,13 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@samchon/openapi": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@samchon/openapi/-/openapi-4.7.1.tgz",
+      "integrity": "sha512-+rkMlSKMt7l3KGWJVWUle1CXEm0vA8FIF2rufHl+T1gN/gGrTEhL1gDK3FHYf8Nl5XReK0r1vL6Q2QTMwQN7xQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
       "license": "MIT",
@@ -4129,6 +4159,13 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "5.2.3",
@@ -5163,6 +5200,13 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/babel-jest": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.0.5.tgz",
@@ -5276,11 +5320,44 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "node_modules/bowser": {
       "version": "2.12.0",
@@ -5360,6 +5437,31 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -5483,6 +5585,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/chownr": {
       "version": "2.0.0",
       "license": "ISC",
@@ -5510,6 +5619,42 @@
       "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -5566,6 +5711,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5609,6 +5764,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/comment-json": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
+      "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.3",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/comment-parser": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
@@ -5626,6 +5798,13 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5691,6 +5870,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-data-property": {
@@ -5772,6 +5964,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/dugite": {
@@ -6487,6 +6689,32 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6825,6 +7053,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -6923,6 +7161,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -6996,6 +7255,70 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inquirer": {
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
+      "integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/external-editor": "^1.0.0",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inquirer/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ipv6-normalize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ipv6-normalize/-/ipv6-normalize-1.0.1.tgz",
@@ -7060,6 +7383,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7077,6 +7410,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9842,6 +10188,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "license": "MIT"
@@ -9879,6 +10232,23 @@
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -10080,6 +10450,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.2.tgz",
@@ -10199,6 +10576,30 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "dev": true,
@@ -10243,6 +10644,16 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/package-manager-detector": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
+      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quansync": "^0.2.7"
+      }
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -10577,6 +10988,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10598,12 +11026,41 @@
       ],
       "license": "MIT"
     },
+    "node_modules/randexp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "drange": "^1.0.2",
+        "ret": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/regexp-tree": {
       "version": "0.1.27",
@@ -10613,6 +11070,16 @@
       "license": "MIT",
       "bin": {
         "regexp-tree": "bin/regexp-tree"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {
@@ -10682,6 +11149,37 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -10707,6 +11205,16 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10729,6 +11237,16 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -10928,6 +11446,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -11197,6 +11725,13 @@
         "node": ">= 18.16.1"
       }
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tlds": {
       "version": "1.259.0",
       "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.259.0.tgz",
@@ -11436,6 +11971,38 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/typia": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-9.7.2.tgz",
+      "integrity": "sha512-eLIKd0KHZtSvbsA+FYwX+Y0ZBt0BwVGz3GgODQX+6GfGL4DOzKW02LEx62oUZg6vCQX1BL5xyiPXAIdW+Hc51g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@samchon/openapi": "^4.7.1",
+        "@standard-schema/spec": "^1.0.0",
+        "commander": "^10.0.0",
+        "comment-json": "^4.2.3",
+        "inquirer": "^8.2.5",
+        "package-manager-detector": "^0.2.0",
+        "randexp": "^0.5.3"
+      },
+      "bin": {
+        "typia": "lib/executable/typia.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.0 <5.10.0"
+      }
+    },
+    "node_modules/typia/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "2.0.0",
       "license": "MIT"
@@ -11560,6 +12127,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "dev": true,
@@ -11594,6 +12168,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,8 @@
         "ts-jest": "^29.4.1",
         "ts-jest-resolver": "^2.0.1",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.2",
+        "ts-patch": "^3.3.0",
+        "typescript": "~5.9.2",
         "typescript-eslint": "8.41.0",
         "typia": "^9.7.2"
       },
@@ -6978,6 +6979,47 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/global-prefix": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
+      "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^4.1.3",
+        "kind-of": "^6.0.3",
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/global-prefix/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -7254,6 +7296,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/inquirer": {
       "version": "8.2.7",
@@ -10109,6 +10161,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/leac": {
       "version": "0.6.0",
       "license": "MIT",
@@ -11881,6 +11943,25 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-patch": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.3.0.tgz",
+      "integrity": "sha512-zAOzDnd5qsfEnjd9IGy1IRuvA7ygyyxxdxesbhMdutt8AHFjD8Vw8hU2rMF89HX1BKRWFYqKHrO8Q6lw0NeUZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "global-prefix": "^4.0.0",
+        "minimist": "^1.2.8",
+        "resolve": "^1.22.2",
+        "semver": "^7.6.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "bin": {
+        "ts-patch": "bin/ts-patch.js",
+        "tspc": "bin/tspc.js"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "ts-jest-resolver": "^2.0.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
-    "typescript-eslint": "8.41.0"
+    "typescript-eslint": "8.41.0",
+    "typia": "^9.7.2"
   },
   "dependencies": {
     "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:clean": "jest --clearCache && npm test",
     "test:config": "npm run test -- --testRegex=/tests-config/.*\\.test\\.ts",
     "test:watch": "jest --watch --notify --notifyMode=change --coverage",
-    "ci": "npm run lint && npm run test -- --ci --reporters=default --reporters=jest-junit"
+    "ci": "npm run lint && npm run test -- --ci --reporters=default --reporters=jest-junit",
+    "prepare": "ts-patch install"
   },
   "bugs": {
     "url": "https://github.com/gitgitgadget/gitgitgadget/issues"
@@ -70,7 +71,8 @@
     "ts-jest": "^29.4.1",
     "ts-jest-resolver": "^2.0.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2",
+    "ts-patch": "^3.3.0",
+    "typescript": "~5.9.2",
     "typescript-eslint": "8.41.0",
     "typia": "^9.7.2"
   },

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -7,6 +7,7 @@ import { getConfig } from "../lib/gitgitgadget-config.js";
 import { PatchSeries } from "../lib/patch-series.js";
 import { IPatchSeriesMetadata } from "../lib/patch-series-metadata.js";
 import { testCreateRepo } from "./test-lib.js";
+import defaultConfig from "../lib/gitgitgadget-config.js";
 
 // This test script might take quite a while to run
 jest.setTimeout(60000);
@@ -342,7 +343,7 @@ test("allow/disallow", async () => {
     const notes = new GitNotes(remote.workDir);
     await notes.set("", {} as IGitGitGadgetOptions);
 
-    const gitGitGadget = await GitGitGadget.get(workDir);
+    const gitGitGadget = await GitGitGadget.get(defaultConfig, workDir);
 
     // pretend that the notes ref had been changed in the meantime
     await notes.set("", { allowedUsers: ["first-one"] } as IGitGitGadgetOptions, true);
@@ -370,7 +371,7 @@ test("allow/disallow with env vars", async () => {
     const notes = new GitNotes(remote.workDir);
     await notes.set("", {} as IGitGitGadgetOptions);
 
-    const gitGitGadget = await GitGitGadget.get(workDir);
+    const gitGitGadget = await GitGitGadget.get(defaultConfig, workDir);
 
     // pretend that the notes ref had been changed in the meantime
     await notes.set("", { allowedUsers: ["first-one"] } as IGitGitGadgetOptions, true);

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -210,6 +210,7 @@ test("generate tag/notes from a Pull Request", async () => {
     await git(["config", "user.email", "gitgitgadget@example.com"], repo.options);
 
     const patches = await PatchSeries.getFromNotes(
+        defaultConfig,
         notes,
         pullRequestURL,
         pullRequestTitle,
@@ -252,6 +253,7 @@ to have included in git.git [https://github.com/git/git].`);
 
     const headCommit2 = await repo.revParse("HEAD");
     const patches2 = await PatchSeries.getFromNotes(
+        defaultConfig,
         notes,
         pullRequestURL,
         pullRequestTitle,

--- a/tests/mail-archive-helper.test.ts
+++ b/tests/mail-archive-helper.test.ts
@@ -3,24 +3,25 @@ import { OctokitResponse } from "@octokit/types";
 import { expect, jest, test } from "@jest/globals";
 import { fileURLToPath } from "url";
 import { GitNotes } from "../lib/git-notes.js";
-import { getConfig } from "../lib/gitgitgadget-config.js";
 import { GitHubGlue } from "../lib/github-glue.js";
 import { MailArchiveGitHelper, IGitMailingListMirrorState } from "../lib/mail-archive-helper.js";
 import { IMailMetadata } from "../lib/mail-metadata.js";
-import { setConfig } from "../lib/project-config.js";
 import { testCreateRepo } from "./test-lib.js";
+import defaultConfig from "../lib/gitgitgadget-config.js";
+import { IConfig } from "../lib/project-config.js";
 
 /* eslint max-classes-per-file: ["error", 2] */
 
 class MailArchiveGitHelperProxy extends MailArchiveGitHelper {
     public constructor(
+        config: IConfig,
         gggNotes: GitNotes,
         mailArchiveGitDir: string,
         githubGlue: GitHubGlue,
         state: IGitMailingListMirrorState,
         branch: string,
     ) {
-        super(gggNotes, mailArchiveGitDir, githubGlue, state, branch);
+        super(config, gggNotes, mailArchiveGitDir, githubGlue, state, branch);
     }
 }
 class GitHubProxy extends GitHubGlue {
@@ -96,10 +97,9 @@ interface ICommit {
     parents: [{ sha: string; url: string; html_url?: string }];
 }
 
-const config = getConfig();
+const config = { ...defaultConfig }; // make a copy
 config.repo.owner = "test";
 config.repo.name = "test";
-setConfig(config);
 
 const fromEmail = "I Replied <ireplied@gmail.com>";
 
@@ -205,7 +205,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~" },
+        "master",
+    );
 
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     await mail.processMails();
@@ -240,7 +247,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~" },
+        "master",
+    );
 
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     await mail.processMails();
@@ -279,7 +293,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~" },
+        "master",
+    );
 
     const commitsResponse = getCommitsResponse;
     const fail = false;
@@ -365,7 +386,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~~" },
+        "master",
+    );
 
     const commitsResponse = getCommitsResponse;
     const fail = false;
@@ -453,7 +481,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~" },
+        "master",
+    );
 
     const commitsResponse = getCommitsResponse;
     const fail = true;
@@ -530,7 +565,14 @@ This Pull Request contains some ipsum lorem.
     const notes = new GitNotes(repo.workDir);
     await notes.set(mailMeta.messageID, mailMeta, true);
 
-    const mail = new MailArchiveGitHelperProxy(notes, repo.workDir, github, { latestRevision: "HEAD~" }, "master");
+    const mail = new MailArchiveGitHelperProxy(
+        config,
+        notes,
+        repo.workDir,
+        github,
+        { latestRevision: "HEAD~" },
+        "master",
+    );
 
     const commitsResponse = getCommitsResponse;
     commitsResponse.data[0].sha = mailMeta.originalCommit;

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -6,6 +6,7 @@ import { GitNotes } from "../lib/git-notes.js";
 import { PatchSeries } from "../lib/patch-series.js";
 import { ProjectOptions } from "../lib/project-options.js";
 import { testCreateRepo } from "./test-lib.js";
+import defaultConfig from "../lib/gitgitgadget-config.js";
 
 jest.setTimeout(60000);
 const sourceFileName = fileURLToPath(import.meta.url);
@@ -102,7 +103,15 @@ class PatchSeriesTest extends PatchSeries {
             }
         }
 
-        const x = new PatchSeriesTest(new GitNotes(), {}, new ProjectOptionsTest(), prMeta, undefined, 1);
+        const x = new PatchSeriesTest(
+            defaultConfig,
+            new GitNotes(),
+            {},
+            new ProjectOptionsTest(),
+            prMeta,
+            undefined,
+            1,
+        );
 
         x.insertCcAndFromLines(mails, thisAuthor, senderName);
 

--- a/tests/project-options.test.ts
+++ b/tests/project-options.test.ts
@@ -6,6 +6,7 @@ import { getConfig } from "../lib/gitgitgadget-config.js";
 import { PatchSeries } from "../lib/patch-series.js";
 import { ProjectOptions } from "../lib/project-options.js";
 import { testCreateRepo } from "./test-lib.js";
+import defaultConfig from "../lib/gitgitgadget-config.js";
 
 // This test script might take quite a while to run
 jest.setTimeout(20000);
@@ -45,7 +46,7 @@ test("project options", async () => {
                 headLabel: options2.branchName,
                 iteration: 1,
             };
-            const x = new X(new GitNotes(repo.workDir), {}, options2, prMeta, undefined, 1);
+            const x = new X(defaultConfig, new GitNotes(repo.workDir), {}, options2, prMeta, undefined, 1);
             const mbox = await x.generateMBox();
             const needle = "=?UTF-8?Q?Nguy=E1=BB=85n_Th=C3=A1i_Ng=E1=BB=8Dc?= Duy";
             expect(mbox).toEqual(expect.stringContaining(needle));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,7 @@
     "types": [ "node" ],                      /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */
@@ -54,6 +54,13 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "plugins": [
+      {
+        "transform": "typia/lib/transform"
+      }
+    ],
+    "skipLibCheck": true,
+    "strictNullChecks": true
   },
   "include": [
     "lib/**/*.ts",

--- a/update-mail-to-commit-notes/action.yml
+++ b/update-mail-to-commit-notes/action.yml
@@ -2,6 +2,9 @@ name: 'Update the mail <-> commit notes'
 description: 'Updates the mapping between commits and patch emails, stored in the `mail-to-commit` and `commit-to-mail` Git notes refs.'
 author: 'Johannes Schindelin'
 inputs:
+  config:
+    description: 'The GitGitGadget configuration to use (see https://github.com/gitgitgadget/gitgitgadget/blob/HEAD/lib/project-config.ts)'
+    required: false # not just yet...
   pr-repo-token:
     description: 'The access token to work on the repository that holds PRs and state'
     required: true

--- a/update-prs/action.yml
+++ b/update-prs/action.yml
@@ -2,6 +2,9 @@ name: 'Update the Pull Requests'
 description: 'Updates the Pull Requests in response to upstream commits'
 author: 'Johannes Schindelin'
 inputs:
+  config:
+    description: 'The GitGitGadget configuration to use (see https://github.com/gitgitgadget/gitgitgadget/blob/HEAD/lib/project-config.ts)'
+    required: false # not just yet...
   pr-repo-token:
     description: 'The access token to work on the repository that holds PRs and state'
     required: true


### PR DESCRIPTION
GitGitGadget stores its state in three Git notes: `refs/notes/gitgitgadget`, `refs/notes/mail-to-commit`, and `refs/notes/commit-to-mail`. Before GitGitGadget can be used on a new project, these need to be initialized.

Add a GitHub Action to do precisely that.

This PR is stacked on top of #1991 