### PR TITLE
fix: do not allow build of dist action to run concurrently

### DIFF
--- a/.github/workflows/push-github-actions.yml
+++ b/.github/workflows/push-github-actions.yml
@@ -12,6 +12,9 @@ on:
       - 'script/**/*'
       - '.github/workflows/push-github-actions.yml'
 
+concurrency:
+  group: ${{ github.workflow }}
+
 permissions:
   contents: write
 


### PR DESCRIPTION
When approving dependabot PRs, sometimes the action to build a new dist will fail due to the same version being used by two jobs.