### PR TITLE
commit-lint: prefix error messages with bullet points

### DIFF
--- a/lib/commit-lint.ts
+++ b/lib/commit-lint.ts
@@ -68,18 +68,17 @@ export class LintCommit {
         }
 
         if (this.messages.length) {
-            this.messages.unshift(`\`${this.lines[0]}\``);
             return {
                 checkFailed: this.blocked,
                 message: `There ${this.messages.length > 1 ? "are issues" : "is an issue"} in commit ${
                     this.patch.commit
-                }:\n${this.messages.join("\n")}`,
+                }:\n\`${this.lines[0]}\``.concat(...this.messages),
             };
         }
     }
 
     private addMessage(message: string): void {
-        this.messages.push(message);
+        this.messages.push(`\n- ${message}`);
     }
 
     private block(message: string): void {

--- a/tests/commit-lint.test.ts
+++ b/tests/commit-lint.test.ts
@@ -289,3 +289,29 @@ test("lint options tests", () => {
         { maxColumns: 66 },
     );
 });
+
+test("lint message format uses bullet points", () => {
+    const commit = {
+        author: {
+            email: "ggg@example.com",
+            login: "ggg",
+            name: "e. e. cummings",
+        },
+        commit: "BAD1FEEDBEEF",
+        committer: {
+            email: "ggg@example.com",
+            login: "ggg",
+            name: "e. e. cummings",
+        },
+        message: "Short message",
+        parentCount: 1,
+    };
+
+    lintCheck(commit, (lintError) => {
+        const lines = lintError.message.split("\n");
+        expect(lines[0]).toBe("There are issues in commit BAD1FEEDBEEF:");
+        expect(lines[1]).toBe("`Short message`");
+        expect(lines[2]).toBe("- Commit checks stopped - the message is too short");
+        expect(lines[3]).toBe("- Commit not signed off");
+    });
+});


### PR DESCRIPTION
I used gitgitgadget today and it's a very nice tool, but I was a bit confused about the warning messages.

I figured bullet points could make it much clearer to other developers.