### PR TITLE
patch-series: handle markdown-formatted Cc: lines

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -230,8 +230,10 @@ export class PatchSeries {
                             }
                             basedOn = match2[2];
                             break;
-                        case "cc:":
-                            addressparser(match2[2], { flatten: true }).forEach((e: addressparser.Address) => {
+                        case "cc:": {
+                            // Convert markdown-formatted emails [email](mailto:email) to <email>
+                            const ccValue = match2[2].replace(/\[([^\]@]+@[^\]]+)\]\(mailto:\1\)/g, "<$1>");
+                            addressparser(ccValue, { flatten: true }).forEach((e: addressparser.Address) => {
                                 if (e.name) {
                                     cc.push(`${e.name} <${e.address}>`);
                                 } else {
@@ -239,6 +241,7 @@ export class PatchSeries {
                                 }
                             });
                             break;
+                        }
                         case "range-diff:":
                             if (rangeDiff) {
                                 throw new Error(`Duplicate Range-Diff`);

--- a/tests/patch-series.test.ts
+++ b/tests/patch-series.test.ts
@@ -495,6 +495,26 @@ Fetch-It-Via: git fetch ${repoUrl} my-series-v1
             expect(parsed.cc).toEqual([]);
 
             expect(parsed.coverLetter).toEqual(expectedCover1);
+
+            // Markdown-formatted Cc test (copy/pasted from GitHub)
+            prBody = [
+                "some description",
+                "",
+                "Cc: Junio C Hamano [gitster@pobox.com](mailto:gitster@pobox.com)",
+                "Cc: Another User [another@example.com](mailto:another@example.com), " +
+                    "Third Person [third@test.org](mailto:third@test.org)",
+                "Cc: Mixed Format <mixed@normal.com>, Markdown [md@format.com](mailto:md@format.com)",
+            ].join("\r\n");
+
+            parsed = await PatchSeries.parsePullRequest(repo.workDir, prTitle, prBody, 76, "");
+
+            expect(parsed.cc).toEqual([
+                "Junio C Hamano <gitster@pobox.com>",
+                "Another User <another@example.com>",
+                "Third Person <third@test.org>",
+                "Mixed Format <mixed@normal.com>",
+                "Markdown <md@format.com>",
+            ]);
         });
     }
 }


### PR DESCRIPTION
When users copy/paste Cc: lines from another GitHub PR, they arrive in markdown format like `[email](mailto:email)` instead of the expected `<email>` format. This causes addressparser to fail silently.

This change converts markdown-formatted email links to the standard angle bracket format before parsing, following Postel's law to be liberal in what we accept.

Fixes #1645