### PR TITLE
range-diff: rebase old series onto new base to reduce upstream "noise"

### DIFF
--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -724,7 +724,7 @@ export class PatchSeries {
    )}
    git range-diff <options> ${getRange(this.rangeDiff.previousRange)} ${getRange(this.rangeDiff.currentRange)}`);
             } else {
-                const previousRange = await this.rebaseOldSeriesIfNeeded();
+                const previousRange = await this.rebaseOldSeriesIfNeeded(logger);
 
                 const rangeDiff = await git(
                     ["range-diff", "--no-color", "--creation-factor=95", previousRange, this.rangeDiff.currentRange],
@@ -866,7 +866,7 @@ export class PatchSeries {
         return this.metadata;
     }
 
-    protected async rebaseOldSeriesIfNeeded(): Promise<string> {
+    protected async rebaseOldSeriesIfNeeded(logger: ILogger): Promise<string> {
         if (!this.rangeDiff || this.rangeDiff.oldBaseCommit === this.rangeDiff.newBaseCommit) {
             return this.rangeDiff!.previousRange;
         }
@@ -885,6 +885,7 @@ export class PatchSeries {
                 { workDir },
             );
             const rebasedHead = (await git(["rev-parse", "HEAD"], { workDir })).trim();
+            logger.log("Rebased old series onto new base for range-diff");
             return `${this.rangeDiff.newBaseCommit}..${rebasedHead}`;
         } catch (_) {
             try {
@@ -892,6 +893,7 @@ export class PatchSeries {
             } catch (__) {
                 // Just ignore it
             }
+            logger.log("warning: could not rebase old series onto new base, falling back to cross-base range-diff");
             return this.rangeDiff.previousRange;
         } finally {
             await git(["checkout", origHead], { workDir });

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -51,8 +51,10 @@ const singletonHeaders: ISingletonHeader[] = [
 interface IRangeDiff {
     previousRange: string;
     currentRange: string;
-    baseCommit: string;
-    headCommit: string;
+    oldBaseCommit: string;
+    oldHeadCommit: string;
+    newBaseCommit: string;
+    newHeadCommit: string;
 }
 
 export class PatchSeries {
@@ -102,7 +104,14 @@ export class PatchSeries {
             }
 
             const previousRange = `${metadata.baseCommit}..${metadata.headCommit}`;
-            rangeDiffRanges = { previousRange, currentRange, baseCommit: metadata.baseCommit, headCommit };
+            rangeDiffRanges = {
+                previousRange,
+                currentRange,
+                oldBaseCommit: metadata.baseCommit,
+                oldHeadCommit: metadata.headCommit,
+                newBaseCommit: baseCommit,
+                newHeadCommit: headCommit,
+            };
 
             metadata.iteration++;
             metadata.baseCommit = baseCommit;
@@ -710,19 +719,15 @@ export class PatchSeries {
                 };
 
                 footers.push(`Contributor requested no range-diff. You can review it using these commands:
-   git fetch https://github.com/gitgitgadget/git ${gitShortHash(this.rangeDiff.baseCommit)} ${gitShortHash(
-       this.rangeDiff.headCommit,
+   git fetch https://github.com/gitgitgadget/git ${gitShortHash(this.rangeDiff.oldBaseCommit)} ${gitShortHash(
+       this.rangeDiff.newHeadCommit,
    )}
    git range-diff <options> ${getRange(this.rangeDiff.previousRange)} ${getRange(this.rangeDiff.currentRange)}`);
             } else {
+                const previousRange = await this.rebaseOldSeriesIfNeeded();
+
                 const rangeDiff = await git(
-                    [
-                        "range-diff",
-                        "--no-color",
-                        "--creation-factor=95",
-                        this.rangeDiff.previousRange,
-                        this.rangeDiff.currentRange,
-                    ],
+                    ["range-diff", "--no-color", "--creation-factor=95", previousRange, this.rangeDiff.currentRange],
                     { workDir: this.project.workDir },
                 );
                 // split the range-diff and prefix with a space
@@ -859,6 +864,38 @@ export class PatchSeries {
         }
 
         return this.metadata;
+    }
+
+    protected async rebaseOldSeriesIfNeeded(): Promise<string> {
+        if (!this.rangeDiff || this.rangeDiff.oldBaseCommit === this.rangeDiff.newBaseCommit) {
+            return this.rangeDiff!.previousRange;
+        }
+
+        const workDir = this.project.workDir;
+        const origHead = (await git(["rev-parse", "HEAD"], { workDir })).trim();
+        try {
+            await git(
+                [
+                    "rebase",
+                    "--onto",
+                    this.rangeDiff.newBaseCommit,
+                    this.rangeDiff.oldBaseCommit,
+                    this.rangeDiff.oldHeadCommit,
+                ],
+                { workDir },
+            );
+            const rebasedHead = (await git(["rev-parse", "HEAD"], { workDir })).trim();
+            return `${this.rangeDiff.newBaseCommit}..${rebasedHead}`;
+        } catch (_) {
+            try {
+                await git(["rebase", "--abort"], { workDir });
+            } catch (__) {
+                // Just ignore it
+            }
+            return this.rangeDiff.previousRange;
+        } finally {
+            await git(["checkout", origHead], { workDir });
+        }
     }
 
     protected async generateMBox(): Promise<string> {

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -352,7 +352,12 @@ test("range-diff rebases old series onto new base", async () => {
     await git(["config", "user.name", "GitGitGadget"], repo.options);
     await git(["config", "user.email", "gitgitgadget@example.com"], repo.options);
 
-    const logger = { log: (): void => {} };
+    const logs: string[] = [];
+    const logger = {
+        log: (message: string): void => {
+            logs.push(message);
+        },
+    };
     const mails: string[] = [];
     // eslint-disable-next-line @typescript-eslint/require-await
     async function send(mail: string): Promise<string> {
@@ -401,11 +406,97 @@ test("range-diff rebases old series onto new base", async () => {
         undefined,
     );
     mails.splice(0);
+    logs.splice(0);
     await patches2.generateAndSend(logger, send, undefined, pullRequestURL);
 
     if (await gitCommandExists("range-diff", repo.workDir)) {
         expect(mails[0]).toMatch(/Range-diff vs v1:/);
         expect(mails[0]).not.toMatch(/upstream-change/);
+        expect(logs).toContain("Rebased old series onto new base for range-diff");
+        expect(logs).not.toContain(expect.stringMatching(/warning:/));
+    }
+});
+
+test("range-diff falls back when rebase conflicts", async () => {
+    const repo = await testCreateRepo(sourceFileName, "-range-diff-conflict");
+    const notes = new GitNotes(repo.workDir);
+    await notes.set("", { allowedUsers: ["somebody"] } as IGitGitGadgetOptions);
+
+    await repo.git(["config", "user.name", "Test H. Dev"]);
+    await repo.git(["config", "user.email", "dev@example.com"]);
+
+    expect(await repo.commit("initial", "shared.t", "original content")).not.toEqual("");
+    const baseCommit1 = await repo.revParse("HEAD");
+    expect(await repo.newBranch("test-branch")).toEqual("");
+    expect(await repo.commit("A", "shared.t", "v1 change")).not.toEqual("");
+    const headCommit1 = await repo.revParse("HEAD");
+
+    const pullRequestURL = "https://github.com/gitgitgadget/git/pull/3";
+    const pullRequestTitle = "Conflicting PR!";
+    const pullRequestBody = "A conflicting change.\n\nCc: Some Body <somebody@example.com>";
+
+    await git(["config", "user.name", "GitGitGadget"], repo.options);
+    await git(["config", "user.email", "gitgitgadget@example.com"], repo.options);
+
+    const logs: string[] = [];
+    const logger = {
+        log: (message: string): void => {
+            logs.push(message);
+        },
+    };
+    const mails: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async function send(mail: string): Promise<string> {
+        mails.push(mail);
+        return "Message-ID";
+    }
+
+    const patches1 = await PatchSeries.getFromNotes(
+        defaultConfig,
+        notes,
+        pullRequestURL,
+        pullRequestTitle,
+        pullRequestBody,
+        "gitgitgadget:next",
+        baseCommit1,
+        "somebody:test-branch",
+        headCommit1,
+        {},
+        "GitHub User",
+        undefined,
+    );
+    await patches1.generateAndSend(logger, send, undefined, pullRequestURL);
+
+    await repo.git(["checkout", baseCommit1]);
+    expect(await repo.commit("upstream-conflict", "shared.t", "conflicting upstream change")).not.toEqual("");
+    const baseCommit2 = await repo.revParse("HEAD");
+
+    expect(await repo.commit("A-v2", "shared.t", "v2 resolved change")).not.toEqual("");
+    const headCommit2 = await repo.revParse("HEAD");
+
+    const patches2 = await PatchSeries.getFromNotes(
+        defaultConfig,
+        notes,
+        pullRequestURL,
+        pullRequestTitle,
+        pullRequestBody,
+        "gitgitgadget:next",
+        baseCommit2,
+        "somebody:test-branch",
+        headCommit2,
+        {},
+        "GitHub User",
+        undefined,
+    );
+    mails.splice(0);
+    logs.splice(0);
+    await patches2.generateAndSend(logger, send, undefined, pullRequestURL);
+
+    if (await gitCommandExists("range-diff", repo.workDir)) {
+        expect(mails[0]).toMatch(/Range-diff vs v1:/);
+        expect(logs).toContain(
+            "warning: could not rebase old series onto new base, falling back to cross-base range-diff",
+        );
     }
 });
 

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -331,6 +331,84 @@ Submitted-As: https://dummy.com/?mid=${coverMid}
 In-Reply-To: https://dummy.com/?mid=${refMid}`);
 });
 
+test("range-diff rebases old series onto new base", async () => {
+    const repo = await testCreateRepo(sourceFileName, "-range-diff-rebase");
+    const notes = new GitNotes(repo.workDir);
+    await notes.set("", { allowedUsers: ["somebody"] } as IGitGitGadgetOptions);
+
+    await repo.git(["config", "user.name", "Test H. Dev"]);
+    await repo.git(["config", "user.email", "dev@example.com"]);
+
+    expect(await repo.commit("initial")).not.toEqual("");
+    const baseCommit1 = await repo.revParse("HEAD");
+    expect(await repo.newBranch("test-branch")).toEqual("");
+    expect(await repo.commit("A")).not.toEqual("");
+    const headCommit1 = await repo.revParse("HEAD");
+
+    const pullRequestURL = "https://github.com/gitgitgadget/git/pull/2";
+    const pullRequestTitle = "Rebased PR!";
+    const pullRequestBody = "A simple change.\n\nCc: Some Body <somebody@example.com>";
+
+    await git(["config", "user.name", "GitGitGadget"], repo.options);
+    await git(["config", "user.email", "gitgitgadget@example.com"], repo.options);
+
+    const logger = { log: (): void => {} };
+    const mails: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async function send(mail: string): Promise<string> {
+        mails.push(mail);
+        return "Message-ID";
+    }
+
+    const patches1 = await PatchSeries.getFromNotes(
+        defaultConfig,
+        notes,
+        pullRequestURL,
+        pullRequestTitle,
+        pullRequestBody,
+        "gitgitgadget:next",
+        baseCommit1,
+        "somebody:test-branch",
+        headCommit1,
+        {},
+        "GitHub User",
+        undefined,
+    );
+    await patches1.generateAndSend(logger, send, undefined, pullRequestURL);
+
+    await repo.git(["checkout", baseCommit1]);
+    expect(await repo.commit("upstream-change")).not.toEqual("");
+    const baseCommit2 = await repo.revParse("HEAD");
+
+    await git(["cherry-pick", headCommit1], { workDir: repo.workDir });
+    expect(await repo.commit("A-v2", "A.t", "A modified")).not.toEqual("");
+    await git(["reset", "--soft", "HEAD~2"], { workDir: repo.workDir });
+    await git(["commit", "-m", "A"], { workDir: repo.workDir });
+    const headCommit2 = await repo.revParse("HEAD");
+
+    const patches2 = await PatchSeries.getFromNotes(
+        defaultConfig,
+        notes,
+        pullRequestURL,
+        pullRequestTitle,
+        pullRequestBody,
+        "gitgitgadget:next",
+        baseCommit2,
+        "somebody:test-branch",
+        headCommit2,
+        {},
+        "GitHub User",
+        undefined,
+    );
+    mails.splice(0);
+    await patches2.generateAndSend(logger, send, undefined, pullRequestURL);
+
+    if (await gitCommandExists("range-diff", repo.workDir)) {
+        expect(mails[0]).toMatch(/Range-diff vs v1:/);
+        expect(mails[0]).not.toMatch(/upstream-change/);
+    }
+});
+
 test("allow/disallow", async () => {
     const repo = await testCreateRepo(sourceFileName);
     const workDir = repo.workDir;


### PR DESCRIPTION
This is based on a discussion between me and JCH (https://lore.kernel.org/git/xmqqfr4xcz7s.fsf@gitster.g/), thought I could work on possibly making the range-diff more useful.

When the contributor rebases their patch series onto a newer upstream between iterations, the range-diff previously showed noise from upstream changes alongside the actual patch modifications. Now rebases the old series onto the new base before running `git range-diff`, so only the real differences between iterations are shown. Falls back to the original range-diff if the rebase fails (e.g. due to conflicts).