### PR TITLE
github-glue: authenticate before all GitHub API calls

### DIFF
--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -315,9 +315,12 @@ export class GitHubGlue {
         return result.data.id;
     }
 
-    // The following public methods do not require authentication
+    // The following public methods do not require authentication, but we
+    // authenticate anyway to avoid the unauthenticated rate limit (60 req/hr
+    // per IP), which is easily exceeded on shared CI runners.
 
     public async getOpenPRs(repositoryOwner: string): Promise<IPullRequestInfo[]> {
+        await this.ensureAuthenticated(repositoryOwner);
         const result: IPullRequestInfo[] = [];
         const response = await this.client.rest.pulls.list({
             owner: repositoryOwner,
@@ -358,6 +361,7 @@ export class GitHubGlue {
      * @returns information about that Pull Request
      */
     public async getPRInfo(prKey: pullRequestKey): Promise<IPullRequestInfo> {
+        await this.ensureAuthenticated(prKey.owner);
         const response = await this.client.rest.pulls.get({ ...prKey });
 
         const pullRequest = response.data;
@@ -393,6 +397,7 @@ export class GitHubGlue {
      * @returns the text in the comment
      */
     public async getPRComment(repositoryOwner: string, commentID: number): Promise<IPRComment> {
+        await this.ensureAuthenticated(repositoryOwner);
         const response = await this.client.rest.issues.getComment({
             comment_id: commentID,
             owner: repositoryOwner,
@@ -422,6 +427,7 @@ export class GitHubGlue {
      * @returns the set of commits
      */
     public async getPRCommits(repositoryOwner: string, prNumber: number): Promise<IPRCommit[]> {
+        await this.ensureAuthenticated(repositoryOwner);
         const response = await this.client.rest.pulls.listCommits({
             owner: repositoryOwner,
             pull_number: prNumber,


### PR DESCRIPTION
The `GitHubGlue` class initializes `this.client` as an unauthenticated Octokit instance. Methods that mutate state correctly call `ensureAuthenticated()` before using the client, but four read-only methods (`getOpenPRs`, `getPRInfo`, `getPRComment`, `getPRCommits`) skipped that step, relying on a comment that they "do not require authentication".

While technically true (public repo data is readable without a token), this means those methods hit the unauthenticated rate limit of 60 requests per hour per IP. On shared GitHub Actions runners, that limit is easily exhausted by unrelated workflows sharing the same IP. The symptom is a 403 "API rate limit exceeded" error with the tell-tale "Authenticated requests get a higher rate limit" hint.

The specific failure was in `handleComment()`, where `getPRComment()` is the very first GitHub API call, so `this.client` was guaranteed to still be the unauthenticated default. See https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/actions/runs/24894748244/job/72896350283 for the failing run.

The fix adds `ensureAuthenticated()` calls to all four methods and updates the comment to explain why authentication is used even though it is not strictly required.