### PR TITLE
patch-series: publish a moving `-latest` branch on /submit

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -906,6 +906,11 @@ export class CIHelper {
 
                     const metadata = await gitGitGadget.submit(pr, userInfo);
                     const code = "\n```";
+                    const aliasSection = metadata?.latestBranch
+                        ? `\n\nTo always fetch the latest iteration into \`FETCH_HEAD\`:${
+                              code
+                          }\ngit fetch ${this.urlRepo} ${metadata.latestBranch}${code}`
+                        : "";
                     await addComment(
                         `Submitted as [${
                             metadata?.coverLetterMessageId
@@ -917,7 +922,9 @@ export class CIHelper {
                             code
                         }\n\nTo fetch this version to local tag \`${metadata?.latestTag}\`:${
                             code
-                        }\ngit fetch --no-tags ${this.urlRepo} tag ${metadata?.latestTag}${code}${extraComment}`,
+                        }\ngit fetch --no-tags ${this.urlRepo} tag ${metadata?.latestTag}${code}${
+                            aliasSection
+                        }${extraComment}`,
                     );
                 }
             } else if (command === "/preview") {

--- a/lib/patch-series-metadata.ts
+++ b/lib/patch-series-metadata.ts
@@ -7,6 +7,7 @@ export interface IPatchSeriesMetadata {
     iteration: number;
     coverLetterMessageId?: string;
     latestTag?: string;
+    latestBranch?: string;
     referencesMessageIds?: string[];
     tipCommitInGitGit?: string;
     branchNameInGitsterGit?: string;

--- a/lib/patch-series.ts
+++ b/lib/patch-series.ts
@@ -649,6 +649,7 @@ export class PatchSeries {
             this.metadata.referencesMessageIds,
         );
         let tagName: string | undefined;
+        let latestBranch: string | undefined;
         if (!this.metadata.pullRequestURL) {
             tagName = `${this.project.branchName}-v${this.metadata.iteration}`;
         } else {
@@ -656,9 +657,11 @@ export class PatchSeries {
             const branch = this.metadata.headLabel.replace(/:/g, "/");
             const tagPrefix = prKey.owner === this.config.repo.owner ? "pr-" : `pr-${prKey.owner}-`;
             tagName = `${tagPrefix}${prKey.pull_number}/${branch}-v${this.metadata.iteration}`;
+            latestBranch = `${tagPrefix}${prKey.pull_number}/${branch}-latest`;
         }
 
         this.metadata.latestTag = tagName;
+        this.metadata.latestBranch = latestBranch;
 
         if (this.project.publishToRemote) {
             const url = await gitConfig(`remote.${this.project.publishToRemote}.url`, this.project.workDir);
@@ -852,7 +855,11 @@ export class PatchSeries {
                 }
 
                 logger.log("Publishing tag");
-                await git([...auth, "push", publishTagsAndNotesToRemote, `refs/tags/${tagName}`], {
+                const refspecs = [`refs/tags/${tagName}`];
+                if (latestBranch) {
+                    refspecs.push(`+${this.metadata.headCommit}:refs/heads/${latestBranch}`);
+                }
+                await git([...auth, "push", publishTagsAndNotesToRemote, ...refspecs], {
                     workDir: this.notes.workDir,
                 });
             }

--- a/tests/gitgitgadget.test.ts
+++ b/tests/gitgitgadget.test.ts
@@ -292,6 +292,7 @@ to have included in git.git [https://github.com/git/git].`);
         headLabel: "somebody:master",
         iteration: 2,
         latestTag: "pr-1/somebody/master-v2",
+        latestBranch: "pr-1/somebody/master-latest",
         pullRequestURL,
         referencesMessageIds: [refMid],
     } as IPatchSeriesMetadata);


### PR DESCRIPTION
Alongside the immutable per-iteration tag, also publish a force-moved `-latest` branch pointing at the most recent submission, and add a fetch line for it in the `/submit` reply. Using a branch (rather than a tag) means consumers can refresh it with plain `git fetch`.

I often run something like `git diff pr-git-2281/HaraldNordgren/checkout-fetch-start-point-v1...` to write a good cover letter for the next version, and it's annoying to keep track of exactly which is the latest version.