### PR TITLE
ci-helper: only comment on first integration into a branch

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -662,19 +662,25 @@ export class CIHelper {
             if (!prMeta.mergedIntoUpstream) {
                 prMeta.mergedIntoUpstream = {};
             }
-            if (prMeta.mergedIntoUpstream[branch] !== mergeCommit) {
+            const previousMergeCommit = prMeta.mergedIntoUpstream[branch];
+            if (previousMergeCommit !== mergeCommit) {
                 prMeta.mergedIntoUpstream[branch] = mergeCommit;
                 notesUpdated = true;
 
                 // Add label on GitHub
                 prLabelsToAdd.push(branch);
 
-                // Add comment on GitHub
-                const comment = `This patch series was integrated into ${branch} via https://github.com/${
-                    this.config.repo.upstreamOwner
-                }/${this.config.repo.name}/commit/${mergeCommit}.`;
-                const url = await this.github.addPRComment(prKey, comment);
-                console.log(`Added comment ${url.id} about ${branch}: ${url.url}`);
+                // Only comment when the branch is newly integrated, i.e. when
+                // the label is not there yet. When the merge commit merely
+                // changes (e.g. due to a rebase), the label is already present,
+                // so we update the notes silently.
+                if (previousMergeCommit === undefined) {
+                    const comment = `This patch series was integrated into ${branch} via https://github.com/${
+                        this.config.repo.upstreamOwner
+                    }/${this.config.repo.name}/commit/${mergeCommit}.`;
+                    const url = await this.github.addPRComment(prKey, comment);
+                    console.log(`Added comment ${url.id} about ${branch}: ${url.url}`);
+                }
             }
         }
 

--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -649,9 +649,23 @@ export class CIHelper {
 
         let upstreamMergeCommit: string | undefined;
         const prLabelsToAdd: string[] = [];
+        const prLabelsToRemove: string[] = [];
         for (const branch of this.config.repo.trackingBranches) {
             const mergeCommit = await this.identifyMergeCommit(branch, tipCommitInGitGit);
+            const previousMergeCommit = prMeta.mergedIntoUpstream?.[branch];
             if (!mergeCommit) {
+                // The patch series used to be in this branch but no
+                // longer is (e.g., `seen` was rewound and ejected it):
+                // drop the label and inform the PR author.
+                if (previousMergeCommit !== undefined && prMeta.mergedIntoUpstream) {
+                    delete prMeta.mergedIntoUpstream[branch];
+                    notesUpdated = true;
+                    prLabelsToRemove.push(branch);
+
+                    const comment = `This patch series is no longer integrated into ${branch}.`;
+                    const url = await this.github.addPRComment(prKey, comment);
+                    console.log(`Added comment ${url.id} about ${branch} drop-out: ${url.url}`);
+                }
                 continue;
             }
 
@@ -662,7 +676,6 @@ export class CIHelper {
             if (!prMeta.mergedIntoUpstream) {
                 prMeta.mergedIntoUpstream = {};
             }
-            const previousMergeCommit = prMeta.mergedIntoUpstream[branch];
             if (previousMergeCommit !== mergeCommit) {
                 prMeta.mergedIntoUpstream[branch] = mergeCommit;
                 notesUpdated = true;
@@ -686,6 +699,9 @@ export class CIHelper {
 
         if (prLabelsToAdd.length) {
             await this.github.addPRLabels(prKey, prLabelsToAdd);
+        }
+        for (const label of prLabelsToRemove) {
+            await this.github.removePRLabel(prKey, label);
         }
 
         let optionsUpdated = false;

--- a/lib/github-glue.ts
+++ b/lib/github-glue.ts
@@ -1,5 +1,6 @@
 import addressparser from "nodemailer/lib/addressparser/index.js";
 import { Octokit } from "@octokit/rest";
+import { RequestError } from "@octokit/request-error";
 import { git, gitConfig } from "./git.js";
 import { getPullRequestKey, pullRequestKeyInfo, pullRequestKey } from "./pullRequestKey.js";
 export { RequestError } from "@octokit/request-error";
@@ -287,6 +288,25 @@ export class GitHubGlue {
             repo: prKey.repo,
         });
         return result.data.map((res: { id: number }) => `${res.id}`);
+    }
+
+    public async removePRLabel(pullRequest: pullRequestKeyInfo, label: string): Promise<void> {
+        const prKey = getPullRequestKey(pullRequest);
+
+        await this.ensureAuthenticated(prKey.owner);
+        try {
+            await this.client.rest.issues.removeLabel({
+                issue_number: prKey.pull_number,
+                name: label,
+                owner: prKey.owner,
+                repo: prKey.repo,
+            });
+        } catch (e) {
+            // Tolerate the label already being absent so that handlePR
+            // can still persist the updated notes on a retry.
+            if (e instanceof RequestError && e.status === 404) return;
+            throw e;
+        }
     }
 
     public async closePRAsMerged(pullRequest: pullRequestKeyInfo, mergeCommit: string): Promise<number> {

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -5,6 +5,7 @@ import { GitNotes } from "../lib/git-notes.js";
 import { getConfig } from "../lib/gitgitgadget-config.js";
 import { GitHubGlue, IGitHubUser, IPRComment, IPRCommit, IPullRequestInfo } from "../lib/github-glue.js";
 import { IMailMetadata } from "../lib/mail-metadata.js";
+import { IPatchSeriesMetadata } from "../lib/patch-series-metadata.js";
 import { testSmtpServer } from "test-smtp-server";
 import { testCreateRepo, TestRepo } from "./test-lib.js";
 
@@ -263,6 +264,55 @@ testQ("identify upstream commit", async () => {
     expect(bMetaNew?.originalCommit).toEqual(commitB);
     expect(bMetaNew?.commitInGitGit).toEqual(commitBNew);
 });
+
+testQ("handlePR comments when a branch first integrates a PR", async () => {
+    const { ci, pullRequestURL } = await mockHandlePR("-mi-new");
+    await ci.handlePR(pullRequestURL, { allowedUsers: [] });
+    expect(ci.addPRCommentCalls.some(([, body]) => /integrated into seen/.test(body))).toBe(true);
+});
+
+testQ("handlePR does not re-comment when an integration merge commit changes", async () => {
+    const { ci, pullRequestURL } = await mockHandlePR("-mi-old", { seen: "0".repeat(40) });
+    await ci.handlePR(pullRequestURL, { allowedUsers: [] });
+    expect(ci.addPRCommentCalls.some(([, body]) => /integrated into seen/.test(body))).toBe(false);
+});
+
+async function mockHandlePR(
+    suffix: string,
+    mergedIntoUpstream?: { [branch: string]: string },
+): Promise<{ ci: TestCIHelper; pullRequestURL: string }> {
+    const repo = await testCreateRepo(sourceFileName, suffix);
+    const remote = await testCreateRepo(sourceFileName, `${suffix}-rmt`);
+    await repo.git(["config", `url.${remote.workDir}.insteadOf`, "https://github.com/gitgitgadget/git"]);
+
+    const pullRequestURL = "https://github.com/gitgitgadget/git/pull/1";
+    const messageID = "msg@example.com";
+    const commitInGitGit = "cafef00d".repeat(5);
+
+    await new GitNotes(repo.workDir).set<IPatchSeriesMetadata>(pullRequestURL, {
+        pullRequestURL,
+        baseCommit: "0".repeat(40),
+        baseLabel: "x:master",
+        headCommit: "0".repeat(40),
+        headLabel: "y:branch",
+        iteration: 1,
+        coverLetterMessageId: messageID,
+        ...(mergedIntoUpstream ? { mergedIntoUpstream } : {}),
+    });
+
+    // skipUpdate=true skips all the git plumbing (notes fetch, branch
+    // fetch); stub the lookups that handlePR depends on so we only
+    // exercise the "previous integration" decision.
+    const ci = new TestCIHelper(repo.workDir, true);
+    /* eslint-disable @typescript-eslint/require-await */
+    ci.getMessageIdForOriginalCommit = async (): Promise<string> => messageID;
+    ci.getMailMetadata = async (): Promise<IMailMetadata> => ({ messageID, commitInGitGit });
+    ci.identifyMergeCommit = async (b: string): Promise<string | undefined> =>
+        b === "seen" ? "deadbeef".repeat(5) : undefined;
+    /* eslint-enable @typescript-eslint/require-await */
+
+    return { ci, pullRequestURL };
+}
 
 testQ("handle comment allow basic test", async () => {
     const { worktree, gggLocal } = await setupRepos("a1");

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -60,6 +60,7 @@ class TestCIHelper extends CIHelper {
     public addPRCommentCalls: string[][]; // reference mock.calls
     public updatePRCalls: string[][]; // reference mock.calls
     public addPRLabelsCalls: Array<[_: string, labels: string[]]>;
+    public removePRLabelCalls: Array<[_: string, label: string]>;
 
     public constructor(workDir: string, debug = false, gggDir = ".") {
         super(workDir, config, debug, gggDir);
@@ -81,6 +82,11 @@ class TestCIHelper extends CIHelper {
         const addPRLabels = jest.fn(async (_: string, labels: string[]): Promise<string[]> => labels);
         this.ghGlue.addPRLabels = addPRLabels;
         this.addPRLabelsCalls = addPRLabels.mock.calls;
+
+        // eslint-disable-next-line @typescript-eslint/require-await
+        const removePRLabel = jest.fn(async (_: string, _label: string): Promise<void> => undefined);
+        this.ghGlue.removePRLabel = removePRLabel;
+        this.removePRLabelCalls = removePRLabel.mock.calls;
 
         // need keys to authenticate
         // this.ghGlue.ensureAuthenticated = async (): Promise<void> => {};
@@ -275,6 +281,18 @@ testQ("handlePR does not re-comment when an integration merge commit changes", a
     const { ci, pullRequestURL } = await mockHandlePR("-mi-old", { seen: "0".repeat(40) });
     await ci.handlePR(pullRequestURL, { allowedUsers: [] });
     expect(ci.addPRCommentCalls.some(([, body]) => /integrated into seen/.test(body))).toBe(false);
+});
+
+testQ("handlePR comments and removes the label when a PR drops out of a branch", async () => {
+    const { ci, pullRequestURL } = await mockHandlePR("-mi-out", { seen: "0".repeat(40) });
+    // eslint-disable-next-line @typescript-eslint/require-await
+    ci.identifyMergeCommit = async (): Promise<string | undefined> => undefined;
+    await ci.handlePR(pullRequestURL, { allowedUsers: [] });
+    expect(ci.removePRLabelCalls.map(([, label]) => label)).toContain("seen");
+    expect(ci.addPRCommentCalls.some(([, body]) => /no longer integrated into seen/.test(body))).toBe(true);
+    // The branch entry must actually be dropped from the persisted notes,
+    // not just labelled/commented; otherwise we would re-comment forever.
+    expect((await ci.getPRMetadata(pullRequestURL))?.mergedIntoUpstream?.seen).toBeUndefined();
 });
 
 async function mockHandlePR(


### PR DESCRIPTION
Fixes https://github.com/gitgitgadget/gitgitgadget/issues/1646.

Only post the "integrated into" comment the first time a series enters a branch; when the merge commit merely changes (e.g. a rebase) the label is already present, so the notes are updated silently.