### PR TITLE
ci-helper: decouple mail-note updates from open PRs

### DIFF
--- a/lib/ci-helper.ts
+++ b/lib/ci-helper.ts
@@ -87,6 +87,7 @@ export class CIHelper {
 
     public async setupGitHubAction(setupOptions?: {
         needsMailingListMirror?: boolean;
+        needsOpenPRHeads?: boolean;
         needsUpstreamBranches?: boolean;
         needsMailToCommitNotes?: boolean;
     }): Promise<void> {
@@ -189,6 +190,8 @@ export class CIHelper {
                 },
             );
             console.timeEnd("fetch upstream branches");
+        }
+        if (setupOptions?.needsOpenPRHeads) {
             console.time("get open PR head commits");
             const openPRCommits = (
                 await Promise.all(

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -168,6 +168,46 @@ async function setupRepos(instance: string): Promise<{ worktree: TestRepo; gggLo
     return { worktree, gggLocal, gggRemote };
 }
 
+testQ("setup GitHub Action only fetches open PR heads when requested", async () => {
+    const gitConfigParameters = process.env.GIT_CONFIG_PARAMETERS;
+    const withoutOpenPRHeads = await setupRepos("setup-no-pr-heads");
+    const withOpenPRHeads = await setupRepos("setup-pr-heads");
+    const ciWithoutOpenPRHeads = new TestCIHelper(
+        withoutOpenPRHeads.gggLocal.workDir,
+        false,
+        withoutOpenPRHeads.worktree.workDir,
+    );
+    const getOpenPRsWithoutOpenPRHeads = jest.fn((_repositoryOwner: string) => Promise.resolve<IPullRequestInfo[]>([]));
+    ciWithoutOpenPRHeads.ghGlue.getOpenPRs = getOpenPRsWithoutOpenPRHeads;
+
+    await ciWithoutOpenPRHeads.setupGitHubAction({ needsUpstreamBranches: true });
+
+    expect(getOpenPRsWithoutOpenPRHeads).not.toHaveBeenCalled();
+    expect(await withoutOpenPRHeads.gggLocal.revParse("refs/remotes/upstream/seen")).toEqual(
+        await withoutOpenPRHeads.gggRemote.revParse("seen"),
+    );
+
+    const ciWithOpenPRHeads = new TestCIHelper(
+        withOpenPRHeads.gggLocal.workDir,
+        false,
+        withOpenPRHeads.worktree.workDir,
+    );
+    const getOpenPRsWithOpenPRHeads = jest.fn((_repositoryOwner: string) => Promise.resolve<IPullRequestInfo[]>([]));
+    ciWithOpenPRHeads.ghGlue.getOpenPRs = getOpenPRsWithOpenPRHeads;
+
+    await ciWithOpenPRHeads.setupGitHubAction({
+        needsOpenPRHeads: true,
+        needsUpstreamBranches: true,
+    });
+
+    expect(getOpenPRsWithOpenPRHeads.mock.calls.map(([owner]) => owner)).toEqual(config.app.installedOn);
+    if (gitConfigParameters === undefined) {
+        delete process.env.GIT_CONFIG_PARAMETERS;
+    } else {
+        process.env.GIT_CONFIG_PARAMETERS = gitConfigParameters;
+    }
+});
+
 /**
  * Check the mail server for an email.
  *

--- a/update-prs/index.js
+++ b/update-prs/index.js
@@ -4,6 +4,7 @@ async function run() {
   const ci = new CIHelper()
 
   await ci.setupGitHubAction({
+    needsOpenPRHeads: true,
     needsUpstreamBranches: true,
   })
   await ci.updateOpenPrs()


### PR DESCRIPTION
The `update-mail-to-commit-notes` action needs the upstream branch `seen`, but does not use open pull request heads. Requesting upstream branches nevertheless queried every owner in `config.app.installedOn`.

Since https://github.com/gitgitgadget/gitgitgadget/pull/2218 made `getOpenPRs()` authenticate, the workflow's token for `gitgitgadget/git` is insufficient. Setup aborts with `Need a GitHub token for dscho` before updating notes, see e.g.
https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/actions/runs/29785245976/job/88495272227.

Treat these requirements independently. Mail-note updates can still fetch `upstream/seen` without querying open pull requests, while `update-prs` retains the head prefetch it needs.