### PR TITLE
maint: updates to ncc with ts 7

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -110,7 +110,7 @@ jobs:
       working-directory: gitgitgadget
 
     - name: Run build
-      run: npm run build
+      run: npm run build:all
       working-directory: gitgitgadget
 
     - name: Run tests

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   "type": "module",
   "scripts": {
     "build": "npm run build:dev && npm run build:test",
+    "build:all": "npm run build:dev && npm run build:test && npm run build:dist",
     "build:dev": "ttsc",
+    "build:dist": "ncc build -s -m ./build/lib/ci-helper.js -o dist",
     "build:test": "ttsc --tsconfig tests/tsconfig.json",
-    "build-dist": "ncc build -s -m ./lib/ci-helper.ts -o dist",
+    "build-dist": "npm run build:dev && npm run build:dist",
     "cleanbranch": "node ./build/script/delete-test-branches.js",
     "lint": "eslint \"{lib,script,tests}/**/*.{ts,tsx,mjs,js}\" \"*/index.js\" --ignore-pattern \"dist/**/*\"",
     "start": "node server.js",

--- a/tests/ci-helper.test.ts
+++ b/tests/ci-helper.test.ts
@@ -1,3 +1,5 @@
+import { access } from "node:fs/promises";
+import path from "node:path";
 import { afterAll, beforeAll, expect, test, vi } from "vitest";
 import { fileURLToPath } from "url";
 import { CIHelper } from "../lib/ci-helper.js";
@@ -1377,4 +1379,42 @@ testQ("Handle comment cc", async () => {
 
     expect(ci.updatePRCalls[0][ci.updatePRCalls[0].length - 1]).toMatch(/S Body/);
     expect(ci.updatePRCalls).toHaveLength(1);
+});
+
+testQ("Test run the ncc compiled file", async () => {
+    const dirName = path.dirname(fileURLToPath(import.meta.url)); // set path to ncc generated index.js
+    const index = path.join(dirName, "..", "dist", "index.js");
+
+    let found = true;
+    try {
+        await access(index);
+    } catch {
+        console.log(`NCC build not found at ${index}`);
+        found = false;
+    }
+
+    if (found) {
+        process.env.LOCAL_GIT_DIRECTORY = "./node_modules/dugite/git";
+        const { worktree, gggLocal } = await setupRepos("action1");
+
+        /* eslint-disable-next-line @typescript-eslint/naming-convention,
+            @typescript-eslint/no-unsafe-assignment,
+            no-shadow
+        */
+        const { CIHelper } = await import(index);
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+        const ci = new CIHelper(gggLocal.workDir, config, false, worktree.workDir);
+
+        const gitConfigParameters = process.env.GIT_CONFIG_PARAMETERS;
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        await ci.setupGitHubAction();
+
+        if (gitConfigParameters === undefined) {
+            delete process.env.GIT_CONFIG_PARAMETERS;
+        } else {
+            process.env.GIT_CONFIG_PARAMETERS = gitConfigParameters;
+        }
+    }
 });


### PR DESCRIPTION
Add a test to load and run ncc generated code.  The test does no run if the index build was not done.

Change ncc to build from js code.  The ts-7 support is still in limbo.

Add build of ncc code to dev workflow. `build-dist` will build both dev (build) and dist code.