### PR TITLE
perf: use caching to improve build performance

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -105,6 +105,28 @@ jobs:
       run: npm ci
       working-directory: gitgitgadget
 
+    - name: Gen version string
+      uses: actions/github-script@v9
+      id: cache-id
+      with:
+        script: |
+            const packageJson = require('./gitgitgadget/package.json');
+            const tsc = packageJson.devDependencies["@typescript/native"];
+            const ttsc = packageJson.devDependencies["ttsc"];
+            const typia = packageJson.devDependencies["typia"];
+
+            return tsc + ttsc + typia;
+
+    # Restore and prepare ttsc cache
+    - uses: actions/cache@v4
+      with:
+        path: ./gitgitgadget/node_modules/.cache/ttsc
+        key: ${{ runner.os }}-${{ runner.arch }}-ttsc-${{steps.cache-id.outputs.result}}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-ttsc-
+    - run: npx ttsc prepare
+      working-directory: gitgitgadget
+
     - name: Run linter
       run: npm run lint
       working-directory: gitgitgadget


### PR DESCRIPTION
ttsc (needed for typia) builds a cache to improve go performance.  It takes some time. Reusing the cache will make the builds run faster.

The use of the versions in the key limits the number of cache blobs that will be created.  This is especially true with the current dependabot setup.

The key suffix can be changed to `-ttsc-${{ hashFiles('./gitgitgadget/package-lock.json') }}` if using the versions becomes an issue.

The ttsc doc describes this [here](https://ttsc.dev/docs/ttsc/cache/).  The use of `versions` in the key came from this [issue](https://github.com/samchon/ttsc/issues/1064).