### PR TITLE
deps: group build tools and slow down lint updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,29 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      build-tools:
+        patterns:
+          - "ttsc"
+          - "@ttsc/*"
+          - "typia"
+          - "typescript"
+          - "@typescript/native"
+          - "@vercel/ncc"
+    ignore:
+      - dependency-name: "*eslint*"
+  - package-ecosystem: "npm"
+    allow:
+      - dependency-name: "*eslint*"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    target-branch: main
+    groups:
+      lint:
+        patterns:
+          - "*eslint*"
   # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#enabling-dependabot-version-updates-for-actions
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests


### PR DESCRIPTION
Add a group for the build tools to keep updates in synch.  Updates will be in a single PR.  Dependabot does not seem to fully support peer dependencies.

Separate lint related updates into a monthly scan to help reduce the PR frequency.

The ability to have two schedules was identified [in this issue](https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219) using `target-branch`.

If the monthly interval is too long, a `chron` style interval could be used.